### PR TITLE
Extract migration SQL into numbered .sql files

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,3 +1,5 @@
+import { readdirSync, readFileSync } from "fs";
+import { join } from "path";
 import type { DuckDBConnection } from "./connection.ts";
 
 interface Migration {
@@ -6,122 +8,23 @@ interface Migration {
   sql: string;
 }
 
-const migrations: Migration[] = [
-  {
-    id: 1,
-    name: "create_core_tables",
-    sql: `
-      CREATE TYPE task_priority AS ENUM ('low', 'medium', 'high');
-      CREATE TYPE task_status AS ENUM ('pending', 'in_progress', 'failed', 'complete', 'waiting');
+const sqlDir = join(import.meta.dir, "sql");
 
-      CREATE TABLE tasks (
-        id VARCHAR PRIMARY KEY DEFAULT gen_random_uuid()::VARCHAR,
-        name VARCHAR NOT NULL,
-        description TEXT NOT NULL DEFAULT '',
-        priority task_priority NOT NULL DEFAULT 'medium',
-        status task_status NOT NULL DEFAULT 'pending',
-        waiting_reason TEXT,
-        claimed_by VARCHAR,
-        claimed_at TIMESTAMP,
-        blocked_by VARCHAR[],
-        context_ids VARCHAR[],
-        created_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
-        updated_at TIMESTAMP NOT NULL DEFAULT current_timestamp
-      );
+function loadMigrations(): Migration[] {
+  const files = readdirSync(sqlDir)
+    .filter((f) => f.endsWith(".sql"))
+    .sort();
 
-      CREATE TABLE schedules (
-        id VARCHAR PRIMARY KEY DEFAULT gen_random_uuid()::VARCHAR,
-        name VARCHAR NOT NULL,
-        description TEXT NOT NULL DEFAULT '',
-        frequency VARCHAR NOT NULL,
-        last_run_at TIMESTAMP,
-        enabled BOOLEAN NOT NULL DEFAULT true,
-        created_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
-        updated_at TIMESTAMP NOT NULL DEFAULT current_timestamp
-      );
-
-      CREATE TABLE context_items (
-        id VARCHAR PRIMARY KEY DEFAULT gen_random_uuid()::VARCHAR,
-        title VARCHAR NOT NULL,
-        description TEXT NOT NULL DEFAULT '',
-        content TEXT,
-        content_blob BLOB,
-        mime_type VARCHAR NOT NULL DEFAULT 'text/plain',
-        is_textual BOOLEAN NOT NULL DEFAULT true,
-        source_path VARCHAR,
-        context_path VARCHAR NOT NULL,
-        indexed_at TIMESTAMP,
-        created_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
-        updated_at TIMESTAMP NOT NULL DEFAULT current_timestamp
-      );
-
-      CREATE TABLE embeddings (
-        id VARCHAR PRIMARY KEY DEFAULT gen_random_uuid()::VARCHAR,
-        context_item_id VARCHAR NOT NULL REFERENCES context_items(id),
-        chunk_index INTEGER NOT NULL,
-        chunk_content TEXT,
-        title VARCHAR NOT NULL,
-        description TEXT NOT NULL DEFAULT '',
-        source_path VARCHAR,
-        embedding FLOAT[384],
-        created_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
-        UNIQUE(context_item_id, chunk_index)
-      );
-    `,
-  },
-  {
-    id: 2,
-    name: "create_logging_tables",
-    sql: `
-      CREATE TYPE thread_type AS ENUM ('daemon_tick', 'chat_session');
-      CREATE TYPE interaction_role AS ENUM ('user', 'assistant', 'system', 'tool');
-      CREATE TYPE interaction_kind AS ENUM (
-        'message',
-        'thinking',
-        'tool_use',
-        'tool_result',
-        'context_update',
-        'status_change'
-      );
-
-      CREATE TABLE threads (
-        id VARCHAR PRIMARY KEY DEFAULT gen_random_uuid()::VARCHAR,
-        type thread_type NOT NULL,
-        task_id VARCHAR,
-        title VARCHAR NOT NULL DEFAULT '',
-        started_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
-        ended_at TIMESTAMP,
-        metadata TEXT
-      );
-
-      CREATE TABLE interactions (
-        id VARCHAR PRIMARY KEY DEFAULT gen_random_uuid()::VARCHAR,
-        thread_id VARCHAR NOT NULL REFERENCES threads(id),
-        sequence INTEGER NOT NULL,
-        role interaction_role NOT NULL,
-        kind interaction_kind NOT NULL,
-        content TEXT NOT NULL,
-        tool_name VARCHAR,
-        tool_input TEXT,
-        duration_ms INTEGER,
-        token_count INTEGER,
-        created_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
-        UNIQUE(thread_id, sequence)
-      );
-    `,
-  },
-  {
-    id: 3,
-    name: "create_daemon_state",
-    sql: `
-      CREATE TABLE daemon_state (
-        key VARCHAR PRIMARY KEY,
-        value TEXT NOT NULL,
-        updated_at TIMESTAMP NOT NULL DEFAULT current_timestamp
-      );
-    `,
-  },
-];
+  return files.map((file) => {
+    const match = file.match(/^(\d+)-(.+)\.sql$/);
+    if (!match) throw new Error(`Invalid migration filename: ${file}`);
+    return {
+      id: parseInt(match[1], 10),
+      name: match[2],
+      sql: readFileSync(join(sqlDir, file), "utf-8"),
+    };
+  });
+}
 
 export async function migrate(conn: DuckDBConnection): Promise<void> {
   // Create migrations tracking table
@@ -138,7 +41,7 @@ export async function migrate(conn: DuckDBConnection): Promise<void> {
   const applied = new Set(result.getRows().map((row) => Number(row[0])));
 
   // Run pending migrations in order
-  for (const migration of migrations) {
+  for (const migration of loadMigrations()) {
     if (applied.has(migration.id)) continue;
 
     // Split on semicolons and run each statement individually

--- a/src/db/sql/1-core_tables.sql
+++ b/src/db/sql/1-core_tables.sql
@@ -1,0 +1,56 @@
+CREATE TYPE task_priority AS ENUM ('low', 'medium', 'high');
+CREATE TYPE task_status AS ENUM ('pending', 'in_progress', 'failed', 'complete', 'waiting');
+
+CREATE TABLE tasks (
+  id VARCHAR PRIMARY KEY DEFAULT gen_random_uuid()::VARCHAR,
+  name VARCHAR NOT NULL,
+  description TEXT NOT NULL DEFAULT '',
+  priority task_priority NOT NULL DEFAULT 'medium',
+  status task_status NOT NULL DEFAULT 'pending',
+  waiting_reason TEXT,
+  claimed_by VARCHAR,
+  claimed_at TIMESTAMP,
+  blocked_by VARCHAR[],
+  context_ids VARCHAR[],
+  created_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
+  updated_at TIMESTAMP NOT NULL DEFAULT current_timestamp
+);
+
+CREATE TABLE schedules (
+  id VARCHAR PRIMARY KEY DEFAULT gen_random_uuid()::VARCHAR,
+  name VARCHAR NOT NULL,
+  description TEXT NOT NULL DEFAULT '',
+  frequency VARCHAR NOT NULL,
+  last_run_at TIMESTAMP,
+  enabled BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
+  updated_at TIMESTAMP NOT NULL DEFAULT current_timestamp
+);
+
+CREATE TABLE context_items (
+  id VARCHAR PRIMARY KEY DEFAULT gen_random_uuid()::VARCHAR,
+  title VARCHAR NOT NULL,
+  description TEXT NOT NULL DEFAULT '',
+  content TEXT,
+  content_blob BLOB,
+  mime_type VARCHAR NOT NULL DEFAULT 'text/plain',
+  is_textual BOOLEAN NOT NULL DEFAULT true,
+  source_path VARCHAR,
+  context_path VARCHAR NOT NULL,
+  indexed_at TIMESTAMP,
+  created_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
+  updated_at TIMESTAMP NOT NULL DEFAULT current_timestamp
+);
+
+CREATE TABLE embeddings (
+  id VARCHAR PRIMARY KEY DEFAULT gen_random_uuid()::VARCHAR,
+  context_item_id VARCHAR NOT NULL REFERENCES context_items(id),
+  chunk_index INTEGER NOT NULL,
+  chunk_content TEXT,
+  title VARCHAR NOT NULL,
+  description TEXT NOT NULL DEFAULT '',
+  source_path VARCHAR,
+  embedding FLOAT[384],
+  created_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
+  UNIQUE(context_item_id, chunk_index)
+);

--- a/src/db/sql/2-logging_tables.sql
+++ b/src/db/sql/2-logging_tables.sql
@@ -1,0 +1,35 @@
+CREATE TYPE thread_type AS ENUM ('daemon_tick', 'chat_session');
+CREATE TYPE interaction_role AS ENUM ('user', 'assistant', 'system', 'tool');
+CREATE TYPE interaction_kind AS ENUM (
+  'message',
+  'thinking',
+  'tool_use',
+  'tool_result',
+  'context_update',
+  'status_change'
+);
+
+CREATE TABLE threads (
+  id VARCHAR PRIMARY KEY DEFAULT gen_random_uuid()::VARCHAR,
+  type thread_type NOT NULL,
+  task_id VARCHAR,
+  title VARCHAR NOT NULL DEFAULT '',
+  started_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
+  ended_at TIMESTAMP,
+  metadata TEXT
+);
+
+CREATE TABLE interactions (
+  id VARCHAR PRIMARY KEY DEFAULT gen_random_uuid()::VARCHAR,
+  thread_id VARCHAR NOT NULL REFERENCES threads(id),
+  sequence INTEGER NOT NULL,
+  role interaction_role NOT NULL,
+  kind interaction_kind NOT NULL,
+  content TEXT NOT NULL,
+  tool_name VARCHAR,
+  tool_input TEXT,
+  duration_ms INTEGER,
+  token_count INTEGER,
+  created_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
+  UNIQUE(thread_id, sequence)
+);

--- a/src/db/sql/3-daemon_state.sql
+++ b/src/db/sql/3-daemon_state.sql
@@ -1,0 +1,5 @@
+CREATE TABLE daemon_state (
+  key VARCHAR PRIMARY KEY,
+  value TEXT NOT NULL,
+  updated_at TIMESTAMP NOT NULL DEFAULT current_timestamp
+);


### PR DESCRIPTION
## Summary
- Moves inline migration SQL out of `src/db/schema.ts` into individual numbered files under `src/db/sql/` (e.g. `1-core_tables.sql`, `2-logging_tables.sql`, `3-daemon_state.sql`)
- The `migrate()` function now reads and sorts `.sql` files from disk at runtime, parsing the id and name from filenames
- Public API unchanged — all existing callers and tests pass without modification

## Test plan
- [x] `bun test` — all 33 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)