### PR TITLE
Add Conductor worktree setup and simplify .botholomew gitignore

### DIFF
--- a/.conductor/setup.sh
+++ b/.conductor/setup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+bun install
+
+MAIN=$(git worktree list --porcelain | head -1 | sed 's/worktree //')
+if [ -d "$MAIN/.botholomew" ]; then
+  cp -r "$MAIN/.botholomew" .botholomew
+  echo "Copied .botholomew from $MAIN"
+else
+  echo "Warning: No .botholomew directory found in main worktree ($MAIN)"
+  echo "Run 'bun dev init' in the main worktree first"
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,4 @@ dist/
 *.tsbuildinfo
 
 # Botholomew project data (contains API keys and DB)
-.botholomew/config.json
-.botholomew/data.duckdb
-.botholomew/data.duckdb.wal
-.botholomew/daemon.pid
-.botholomew/daemon.log
+.botholomew/

--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,5 @@
+{
+  "scripts": {
+    "setup": "bash .conductor/setup.sh"
+  }
+}

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -76,17 +76,9 @@ async function updateGitignore(projectDir: string): Promise<void> {
     content = await file.text();
   }
 
-  const entries = [
-    ".botholomew/config.json",
-    ".botholomew/data.duckdb",
-    ".botholomew/data.duckdb.wal",
-    ".botholomew/daemon.pid",
-    ".botholomew/daemon.log",
-  ];
+  const entry = ".botholomew/";
+  if (content.includes(entry)) return;
 
-  const linesToAdd = entries.filter((entry) => !content.includes(entry));
-  if (linesToAdd.length === 0) return;
-
-  const section = "\n# Botholomew (auto-generated)\n" + linesToAdd.join("\n") + "\n";
+  const section = "\n# Botholomew (auto-generated)\n" + entry + "\n";
   await Bun.write(gitignorePath, content.trimEnd() + "\n" + section);
 }

--- a/test/init/index.test.ts
+++ b/test/init/index.test.ts
@@ -81,8 +81,6 @@ describe("initProject", () => {
     await initProject(tempDir);
 
     const gitignore = await Bun.file(join(tempDir, ".gitignore")).text();
-    expect(gitignore).toContain(".botholomew/config.json");
-    expect(gitignore).toContain(".botholomew/data.duckdb");
-    expect(gitignore).toContain(".botholomew/daemon.pid");
+    expect(gitignore).toContain(".botholomew/");
   });
 });


### PR DESCRIPTION
## Summary
- Adds `conductor.json` and `.conductor/setup.sh` so Conductor worktrees automatically run `bun install` and copy `.botholomew/` from the main worktree
- Simplifies `.gitignore` to ignore the entire `.botholomew/` directory instead of listing individual files
- Updates `initProject()` and its test to match the new gitignore approach

## Test plan
- [x] `bun test` — all 33 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)