### PR TITLE
Add Conductor archive script to refresh parent worktree

### DIFF
--- a/.conductor/archive.sh
+++ b/.conductor/archive.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+MAIN=$(git worktree list --porcelain | head -1 | sed 's/worktree //')
+MAIN_BRANCH=$(git -C "$MAIN" rev-parse --abbrev-ref HEAD)
+
+if [ "$MAIN_BRANCH" = "main" ]; then
+  echo "Main worktree is on main — pulling latest"
+  git -C "$MAIN" pull
+else
+  echo "Main worktree is on $MAIN_BRANCH — fetching"
+  git -C "$MAIN" fetch
+fi

--- a/conductor.json
+++ b/conductor.json
@@ -1,5 +1,6 @@
 {
   "scripts": {
-    "setup": "bash .conductor/setup.sh"
+    "setup": "bash .conductor/setup.sh",
+    "archive": "bash .conductor/archive.sh"
   }
 }


### PR DESCRIPTION
## Summary
- Adds `.conductor/archive.sh` — a teardown script that runs when a Conductor workspace is archived
- The script finds the parent (non-worktree) repo and runs `git pull` if it's on `main`, or `git fetch` otherwise, keeping the main workspace fresh
- Registers the script in `conductor.json` under `scripts.archive`

## Test plan
- [ ] Archive a workspace and verify the parent repo gets updated
- [ ] Test with parent on `main` branch (should pull)
- [ ] Test with parent on a feature branch (should fetch only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)