### PR TITLE
Milestone 2: Tool class architecture with dir/file/search tools

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,9 @@
         "commander": "^14.0.0",
         "gray-matter": "^4.0.3",
         "ink": "^6.0.0",
+        "istextorbinary": "^9.5.0",
         "react": "^19.1.0",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -60,6 +62,8 @@
 
     "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
 
+    "binaryextensions": ["binaryextensions@6.11.0", "", { "dependencies": { "editions": "^6.21.0" } }, "sha512-sXnYK/Ij80TO3lcqZVV2YgfKN5QjUWIRk/XSm2J/4bd/lPko3lvk0O4ZppH6m+6hB2/GTu+ptNwVFe1xh+QLQw=="],
+
     "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
@@ -77,6 +81,8 @@
     "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "editions": ["editions@6.22.0", "", { "dependencies": { "version-range": "^4.15.0" } }, "sha512-UgGlf8IW75je7HZjNDpJdCv4cGJWIi6yumFdZ0R7A8/CIhQiWUjyGLCxdHpd8bmyD1gnkfUNK0oeOXqUS2cpfQ=="],
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
@@ -103,6 +109,8 @@
     "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
     "is-in-ci": ["is-in-ci@2.0.0", "", { "bin": { "is-in-ci": "cli.js" } }, "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w=="],
+
+    "istextorbinary": ["istextorbinary@9.5.0", "", { "dependencies": { "binaryextensions": "^6.11.0", "editions": "^6.21.0", "textextensions": "^6.11.0" } }, "sha512-5mbUj3SiZXCuRf9fT3ibzbSSEWiy63gFfksmGfdOzujPjW3k+z8WvIBxcJHBoQNlaZaiyB25deviif2+osLmLw=="],
 
     "js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
@@ -144,11 +152,15 @@
 
     "terminal-size": ["terminal-size@4.0.1", "", {}, "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ=="],
 
+    "textextensions": ["textextensions@6.11.0", "", { "dependencies": { "editions": "^6.21.0" } }, "sha512-tXJwSr9355kFJI3lbCkPpUH5cP8/M0GGy2xLO34aZCjMXBaK3SoPnZwr/oWmo1FdCnELcs4npdCIOFtq9W3ruQ=="],
+
     "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 
     "type-fest": ["type-fest@5.5.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g=="],
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "version-range": ["version-range@4.15.0", "", {}, "sha512-Ck0EJbAGxHwprkzFO966t4/5QkRuzh+/I1RxhLgUKKwEn+Cd8NwM60mE3AqBZg5gYODoXW0EFsQvbZjRlvdqbg=="],
 
     "widest-line": ["widest-line@6.0.0", "", { "dependencies": { "string-width": "^8.1.0" } }, "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA=="],
 
@@ -157,6 +169,8 @@
     "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
     "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
+
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
   }

--- a/docs/plans/milestone-2-context-and-embeddings.md
+++ b/docs/plans/milestone-2-context-and-embeddings.md
@@ -4,36 +4,159 @@
 
 Build the knowledge management foundation — the ability to ingest, chunk, embed, and search content. This is Botholomew's core differentiator: a local hybrid search system that makes the agent's context rich and relevant.
 
+The agent interacts with context items through a **virtual filesystem abstraction** — `dir`, `file`, and `search` tools that map to the `context_items` and `embeddings` tables in DuckDB. The `context_path` column acts as the file path; `content` is the file body.
+
 ## What Gets Unblocked
 
 - The daemon can search relevant context when working tasks
 - The operator can feed the agent documents, URLs, and files
 - "Contextual" loading mode works (system prompt includes relevant context per-task)
+- A reusable **Tool class** pattern that all future tools follow
 
 ---
 
-## New Dependency
+## New Dependencies
 
-Add `@xenova/transformers` to `package.json` for local embedding generation using `Xenova/bge-small-en-v1.5` (384-dim vectors).
+- `@xenova/transformers` — local embedding generation using `Xenova/bge-small-en-v1.5` (384-dim vectors)
+- `zod` — input/output schema validation for tools
+- `zod-to-json-schema` — convert Zod schemas to JSON Schema for Anthropic API tool definitions
+
+---
+
+## Architecture: The Tool Class
+
+Every tool (task, dir, file, search) is an instance of a shared `Tool` base class:
+
+- **Name** and **description** — used for both LLM tool definitions and CLI help text
+- **Zod input schema** — per-field descriptions; validates args, generates JSON Schema for Anthropic API, generates Commander options
+- **Zod output schema** — strongly typed, guaranteed response format
+- **`execute()` method** — the actual implementation (DuckDB-backed)
+
+The same Tool definition serves two consumers with thin adapters:
+1. **Daemon agent** — Zod input → Anthropic `Tool` JSON Schema; `execute()` called from `executeToolCall()`
+2. **CLI** — Zod input → Commander arguments/options; `execute()` called from action handler
+
+### File Structure
+
+```
+src/tools/
+  tool.ts                 ← Tool base class, registry, adapter utilities
+  task/
+    complete.ts           ← complete_task tool
+    fail.ts               ← fail_task tool
+    wait.ts               ← wait_task tool
+    create.ts             ← create_task tool
+  dir/
+    create.ts             ← dir_create tool
+    list.ts               ← dir_list tool
+    tree.ts               ← dir_tree tool
+    size.ts               ← dir_size tool
+  file/
+    read.ts               ← file_read tool
+    write.ts              ← file_write tool
+    edit.ts               ← file_edit tool
+    delete.ts             ← file_delete tool
+    copy.ts               ← file_copy tool
+    move.ts               ← file_move tool
+    info.ts               ← file_info tool
+    exists.ts             ← file_exists tool
+    count-lines.ts        ← file_count_lines tool
+  search/
+    find.ts               ← search_find tool
+    grep.ts               ← search_grep tool
+    semantic.ts           ← search_semantic tool
+```
+
+Each file exports a single Tool instance and self-registers on import. One tool per file.
 
 ---
 
 ## Implementation
 
-### 1. Context CRUD (`src/db/context.ts`)
+### 1. Tool Base Class (`src/tools/tool.ts`)
+
+- `Tool<TInput, TOutput>` abstract class with `name`, `description`, `group`, `inputSchema`, `outputSchema`, `execute()`
+- `toAnthropicTool()` method — converts Zod input schema to Anthropic API JSON Schema via `zod-to-json-schema`
+- `ToolContext` interface — `{ conn: DuckDBConnection, projectDir: string, config: Required<BotholomewConfig> }`
+- Global registry: `registerTool()`, `getTool()`, `getAllTools()`, `getToolsByGroup()`
+- Adapter: `toAnthropicTools()` — returns full `Tool[]` array for the Anthropic API
+- Adapter: `registerToolsAsCLI(program)` — auto-generates Commander subcommands from the registry
+
+### 2. Task Tool Migration (`src/tools/task/`)
+
+Migrate the 4 existing hand-written daemon tools to the Tool class:
+
+- `complete_task` — `{ summary: string }` → marks task complete
+- `fail_task` — `{ reason: string }` → marks task failed
+- `wait_task` — `{ reason: string }` → marks task waiting
+- `create_task` — `{ name, description?, priority?, blocked_by? }` → creates subtask
+
+These tools have a `terminal` flag on the class to signal the agent loop should stop.
+
+### 3. Context CRUD (`src/db/context.ts`)
 
 Replace the stub with full implementation:
 
 - `createContextItem(conn, { title, content?, contentBlob?, mimeType, sourcePath, contextPath })` — insert a context item
 - `getContextItem(conn, id)` — fetch by ID
+- `getContextItemByPath(conn, contextPath)` — fetch by virtual path
 - `listContextItems(conn, { contextPath?, mimeType?, limit? })` — list with filters
+- `listContextItemsByPrefix(conn, prefix, { recursive?, limit? })` — list items under a path prefix
+- `contextPathExists(conn, contextPath)` — check if a path exists
+- `getDistinctDirectories(conn, prefix?)` — unique parent paths (for dir listing)
 - `updateContextItem(conn, id, updates)` — update fields
+- `updateContextItemContent(conn, contextPath, content)` — overwrite content by path
+- `applyPatchesToContextItem(conn, contextPath, patches)` — git-style line-range patches
+- `copyContextItem(conn, srcPath, dstPath)` — duplicate with new path
+- `moveContextItem(conn, oldPath, newPath)` — rename path
 - `deleteContextItem(conn, id)` — delete item and its embeddings
+- `deleteContextItemByPath(conn, contextPath)` — delete by virtual path
+- `deleteContextItemsByPrefix(conn, prefix)` — recursive delete
 - `searchContextByKeyword(conn, query, limit?)` — full-text search on title + content
 
-### 2. Embedding Pipeline (`src/context/`)
+### 4. Directory Tools (`src/tools/dir/`)
 
-New module at `src/context/` for the ingestion pipeline:
+| Tool | Input | Output | DB operation |
+|------|-------|--------|-------------|
+| `dir_create` | `{ path, parents? }` | `{ created: boolean }` | Insert placeholder with `mime_type: "inode/directory"` |
+| `dir_list` | `{ path?, recursive? }` | `{ entries: {name, type, size}[] }` | `listContextItemsByPrefix` + `getDistinctDirectories` |
+| `dir_tree` | `{ path?, max_items? }` | `{ tree: string }` | `listContextItemsByPrefix(recursive: true)` → render markdown tree |
+| `dir_size` | `{ path?, recursive? }` | `{ bytes: number, formatted: string }` | `SUM(length(content))` for items under prefix |
+
+### 5. File Tools (`src/tools/file/`)
+
+| Tool | Input | Output | DB operation |
+|------|-------|--------|-------------|
+| `file_read` | `{ path, offset?, limit? }` | `{ content: string }` | `getContextItemByPath` → slice lines |
+| `file_write` | `{ path, content, title?, description? }` | `{ id, path }` | Upsert via `getContextItemByPath` → create or update |
+| `file_edit` | `{ path, patches: Patch[] }` | `{ applied: number, content: string }` | `applyPatchesToContextItem` |
+| `file_delete` | `{ path, recursive?, force? }` | `{ deleted: number }` | `deleteContextItemByPath` or `deleteContextItemsByPrefix` |
+| `file_copy` | `{ src, dst, overwrite? }` | `{ id, path }` | `copyContextItem` |
+| `file_move` | `{ src, dst, overwrite? }` | `{ path }` | `moveContextItem` |
+| `file_info` | `{ path }` | `{ id, title, mime_type, is_textual, size, lines, ... }` | `getContextItemByPath` |
+| `file_exists` | `{ path }` | `{ exists: boolean }` | `contextPathExists` |
+| `file_count_lines` | `{ path }` | `{ lines: number }` | `getContextItemByPath` → count `\n` |
+
+#### Patch Format (`file_edit`)
+
+```typescript
+{ start_line: number, end_line: number, content: string }
+```
+
+- `start_line` / `end_line`: 1-based inclusive line range
+- `end_line: 0` means insert without replacing
+- `content: ""` means delete the line range
+- Patches applied bottom-up (descending `start_line`) so line numbers stay stable
+
+### 6. Search Tools (`src/tools/search/`)
+
+| Tool | Input | Output | DB operation |
+|------|-------|--------|-------------|
+| `search_find` | `{ pattern, path?, max_results? }` | `{ matches: string[] }` | `context_path` glob match via DuckDB `glob()` |
+| `search_grep` | `{ pattern, path?, glob?, ignore_case?, context?, max_results? }` | `{ matches: {path, line, content, context_lines}[] }` | `regexp_matches()` on `content` |
+| `search_semantic` | `{ query, top_k?, threshold? }` | `{ results: {path, title, score, snippet}[] }` | `embed([query])` → `hybridSearch()` |
+
+### 7. Embedding Pipeline (`src/context/`)
 
 **`src/context/embedder.ts`**
 - Load `Xenova/bge-small-en-v1.5` via `@xenova/transformers` pipeline
@@ -53,9 +176,8 @@ New module at `src/context/` for the ingestion pipeline:
   4. Embed each chunk via `embedder.ts`
   5. Store embeddings in DB
   6. Update `indexed_at` on context item
-- Handle both text and binary (for binary: extract text first or store description-only embedding)
 
-### 3. Embeddings CRUD (`src/db/embeddings.ts`)
+### 8. Embeddings CRUD (`src/db/embeddings.ts`)
 
 Replace the stub with full implementation:
 
@@ -64,32 +186,48 @@ Replace the stub with full implementation:
 - `searchEmbeddings(conn, queryEmbedding, limit?)` — vector similarity search via DuckDB VSS
 - `hybridSearch(conn, query, queryEmbedding, limit?)` — combine keyword search on chunk_content/title with vector similarity, merge and re-rank results
 
-### 4. VSS Extension Management
+### 9. VSS Extension Management
 
 In `src/db/schema.ts`, improve `installVss()`:
 - Try to install/load the vss extension
 - If available, create the HNSW index
 - Track in `daemon_state` whether VSS is available
-- `searchEmbeddings` falls back to brute-force cosine similarity in SQL if VSS unavailable:
-  ```sql
-  SELECT *, list_cosine_similarity(embedding, $query) AS score
-  FROM embeddings ORDER BY score DESC LIMIT $limit
-  ```
+- `searchEmbeddings` falls back to brute-force cosine similarity in SQL if VSS unavailable
 
-### 5. Context CLI Commands (`src/commands/context.ts`)
+### 10. Embeddings Cascade on Mutations
 
-Replace stubs:
+When content is modified via `file_write`, `file_edit`, `file_move`, or `file_delete`:
+- Delete old embeddings for the affected context item
+- For write/edit: re-run the ingestion pipeline to re-chunk and re-embed
+- For move: update `source_path` on embeddings rows
+- For delete: cascade delete embeddings
 
-- `botholomew context list [--path <prefix>]` — list all context items, filterable by virtual path
-- `botholomew context add <path>` — ingest a file or directory recursively
+### 11. Context CLI Commands (`src/commands/context.ts`)
+
+Replace stubs (these are in addition to the auto-generated tool CLI commands):
+
+- `botholomew context add <path>` — ingest a file or directory from the real filesystem
   - Detect mime type from extension
   - For directories, walk and ingest each file
   - Show progress with spinner
-- `botholomew context search <query>` — hybrid search: embed the query, search both keyword and vector, display ranked results with snippets
 - `botholomew context view <id>` — show context item details and its chunks
 - `botholomew context remove <id>` — delete a context item and its embeddings
 
-### 6. Contextual Loading in System Prompt (`src/daemon/prompt.ts`)
+### 12. Daemon Integration (`src/daemon/llm.ts`)
+
+Replace hand-written `DAEMON_TOOLS` and `executeToolCall`:
+- `DAEMON_TOOLS` becomes `toAnthropicTools()` — auto-generated from registry
+- `executeToolCall` dispatches via `getTool(name)` → validate input → `tool.execute()`
+- Terminal tools (complete/fail/wait) detected via a `terminal` flag on the Tool class
+
+### 13. CLI Integration (`src/commands/tools.ts`)
+
+- `registerToolCommands(program)` — auto-generates Commander subcommands from tool registry
+- Groups tools by `group` field → `dir`, `file`, `search` subcommand groups
+- Derives positional args and `--options` from Zod schema shape
+- Registered in `src/cli.ts`
+
+### 14. Contextual Loading in System Prompt (`src/daemon/prompt.ts`)
 
 Extend `buildSystemPrompt()`:
 - Still load all `loading: always` markdown files
@@ -99,42 +237,52 @@ Extend `buildSystemPrompt()`:
   3. Include top-N results as additional context in the system prompt
 - Also load `loading: contextual` markdown files if their content is keyword-relevant to the task
 
-### 7. Daemon Agent Context Tools
-
-Add to `DAEMON_TOOLS` in `src/daemon/llm.ts`:
-
-- `search_context` — search the context database (hybrid search)
-- `save_context` — store a piece of content the agent generated (e.g., a summary it produced)
-- `list_context` — browse the context virtual filesystem
-
 ---
 
 ## Files Modified
 
 | File | Change |
 |------|--------|
-| `package.json` | Add `@xenova/transformers` |
-| `src/db/context.ts` | Full CRUD implementation |
+| `package.json` | Add `@xenova/transformers`, `zod`, `zod-to-json-schema` |
+| `src/tools/tool.ts` | **New** — Tool base class, registry, adapters |
+| `src/tools/task/*.ts` | **New** — 4 task tools (migrated from hand-written) |
+| `src/tools/dir/*.ts` | **New** — 4 directory tools |
+| `src/tools/file/*.ts` | **New** — 9 file tools |
+| `src/tools/search/*.ts` | **New** — 3 search tools |
+| `src/db/context.ts` | Full CRUD + filesystem query helpers |
 | `src/db/embeddings.ts` | Full CRUD + search implementation |
 | `src/db/schema.ts` | Improve `installVss()` fallback |
 | `src/context/embedder.ts` | **New** — local embedding via transformers |
 | `src/context/chunker.ts` | **New** — LLM-driven chunking |
 | `src/context/ingest.ts` | **New** — full ingestion pipeline |
-| `src/commands/context.ts` | Full CLI implementation |
+| `src/commands/context.ts` | CLI for ingest/view/remove |
+| `src/commands/tools.ts` | **New** — auto-generate CLI from tool registry |
+| `src/cli.ts` | Register tool commands |
 | `src/daemon/prompt.ts` | Contextual loading for tasks |
-| `src/daemon/llm.ts` | Add context tools to daemon |
+| `src/daemon/llm.ts` | Replace hand-written tools with registry |
 
 ## Tests
 
-- `test/db/context.test.ts` — context CRUD
+- `test/tools/tool.test.ts` — base class, adapters
+- `test/tools/dir/*.test.ts` — 1 test per tool
+- `test/tools/file/*.test.ts` — 1 test per tool
+- `test/tools/search/*.test.ts` — 1 test per tool
+- `test/db/context.test.ts` — context CRUD + filesystem queries
 - `test/db/embeddings.test.ts` — embedding CRUD, vector search
 - `test/context/chunker.test.ts` — chunking strategies
 - `test/context/ingest.test.ts` — full pipeline (mock LLM)
 
 ## Verification
 
-1. `botholomew context add ./some-folder` — ingests files, shows progress
-2. `botholomew context search "quarterly revenue"` — returns ranked results with snippets
-3. `botholomew context list` — shows all items with paths
-4. Daemon tick with a task referencing a topic — system prompt includes relevant context from the DB
-5. Daemon agent uses `search_context` tool during task execution
+1. `bun test` — all tests pass
+2. Existing task tools still work after migration to Tool class
+3. `botholomew file write /notes/meeting.md "# Meeting Notes"` — creates context item
+4. `botholomew file read /notes/meeting.md` — prints content
+5. `botholomew dir list /notes` — shows entries
+6. `botholomew dir tree /` — shows virtual filesystem tree
+7. `botholomew search grep "Meeting" --path /notes` — finds matches
+8. `botholomew file edit /notes/meeting.md --patches '[{"start_line":1,"end_line":1,"content":"# Updated"}]'`
+9. `botholomew context add ./some-folder` — ingests files, shows progress
+10. `botholomew context search "quarterly revenue"` — returns ranked results with snippets
+11. Daemon agent loop uses registered tools — no hand-written schemas
+12. Daemon tick with a task — system prompt includes relevant context from DB

--- a/package.json
+++ b/package.json
@@ -14,11 +14,13 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.88.0",
     "@duckdb/node-api": "1.5.1-r.2",
+    "ansis": "^4.2.0",
     "commander": "^14.0.0",
     "gray-matter": "^4.0.3",
-    "ansis": "^4.2.0",
     "ink": "^6.0.0",
-    "react": "^19.1.0"
+    "istextorbinary": "^9.5.0",
+    "react": "^19.1.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import { registerTaskCommand } from "./commands/task.ts";
 import { registerChatCommand } from "./commands/chat.ts";
 import { registerContextCommand } from "./commands/context.ts";
 import { registerMcpxCommand } from "./commands/mcpx.ts";
+import { registerToolCommands } from "./commands/tools.ts";
 
 const pkg = await Bun.file(new URL("../package.json", import.meta.url)).json();
 
@@ -22,5 +23,6 @@ registerTaskCommand(program);
 registerChatCommand(program);
 registerContextCommand(program);
 registerMcpxCommand(program);
+registerToolCommands(program);
 
 program.parse();

--- a/src/commands/tools.ts
+++ b/src/commands/tools.ts
@@ -1,0 +1,251 @@
+import type { Command } from "commander";
+import { z } from "zod";
+import { getDbPath } from "../constants.ts";
+import { getConnection } from "../db/connection.ts";
+import { migrate } from "../db/schema.ts";
+import {
+  getToolsByGroup,
+  type ToolDefinition,
+  type ToolContext,
+} from "../tools/tool.ts";
+import type { BotholomewConfig } from "../config/schemas.ts";
+import { DEFAULT_CONFIG } from "../config/schemas.ts";
+import { logger } from "../utils/logger.ts";
+import { registerAllTools } from "../tools/registry.ts";
+
+registerAllTools();
+
+const GROUP_DESCRIPTIONS: Record<string, string> = {
+  dir: "Directory operations on the virtual filesystem",
+  file: "File operations on the virtual filesystem",
+  search: "Search the virtual filesystem",
+};
+
+export function registerToolCommands(program: Command) {
+  for (const group of ["dir", "file", "search"]) {
+    const groupCmd = program
+      .command(group)
+      .description(GROUP_DESCRIPTIONS[group] ?? `${group} tools`);
+
+    for (const tool of getToolsByGroup(group)) {
+      registerToolAsCLI(groupCmd, tool, program);
+    }
+  }
+}
+
+function registerToolAsCLI(
+  parent: Command,
+  tool: ToolDefinition<any, any>,
+  program: Command,
+) {
+  // Derive subcommand name: "file_read" → "read", "file_count_lines" → "count-lines"
+  const subName = tool.name.replace(/^[^_]+_/, "").replace(/_/g, "-");
+
+  // Inspect zod schema to determine positional args and options
+  const shape = tool.inputSchema.shape as Record<string, z.ZodType>;
+  const positionals: string[] = [];
+  const options: { key: string; flag: string; description: string; isArray: boolean }[] = [];
+
+  for (const [key, schema] of Object.entries(shape)) {
+    const desc = schema.description ?? key;
+    const isOptional = schema.isOptional();
+    const unwrapped = unwrapOptional(schema);
+
+    if (isPositionalArg(key, tool.name)) {
+      positionals.push(isOptional ? `[${key}]` : `<${key}>`);
+    } else if (unwrapped instanceof z.ZodBoolean) {
+      options.push({
+        key,
+        flag: `--${key.replace(/_/g, "-")}`,
+        description: desc,
+        isArray: false,
+      });
+    } else if (unwrapped instanceof z.ZodArray) {
+      options.push({
+        key,
+        flag: `--${key.replace(/_/g, "-")} <json>`,
+        description: desc,
+        isArray: true,
+      });
+    } else {
+      options.push({
+        key,
+        flag: `--${key.replace(/_/g, "-")} <value>`,
+        description: desc,
+        isArray: false,
+      });
+    }
+  }
+
+  const cmd = parent
+    .command(`${subName} ${positionals.join(" ")}`.trim())
+    .description(tool.description);
+
+  for (const opt of options) {
+    if (opt.isArray) {
+      cmd.option(opt.flag, opt.description);
+    } else {
+      cmd.option(opt.flag, opt.description);
+    }
+  }
+
+  cmd.action(async (...args: unknown[]) => {
+    const dir = program.opts().dir;
+    const conn = await getConnection(getDbPath(dir));
+    await migrate(conn);
+
+    try {
+      const input = buildInput(
+        tool,
+        positionals,
+        options,
+        shape,
+        args,
+      );
+
+      const ctx: ToolContext = {
+        conn,
+        projectDir: dir,
+        config: DEFAULT_CONFIG as Required<BotholomewConfig>,
+      };
+
+      const result = await tool.execute(input, ctx);
+      formatOutput(result, tool.name);
+    } catch (err) {
+      logger.error(String(err));
+      process.exit(1);
+    } finally {
+      conn.closeSync();
+    }
+  });
+}
+
+function buildInput(
+  tool: ToolDefinition<any, any>,
+  positionals: string[],
+  options: { key: string; flag: string; description: string; isArray: boolean }[],
+  shape: Record<string, z.ZodType>,
+  args: unknown[],
+): Record<string, unknown> {
+  const input: Record<string, unknown> = {};
+
+  // Positional args come first in Commander's action callback
+  for (let i = 0; i < positionals.length; i++) {
+    const key = positionals[i]!.replace(/[<>\[\]]/g, "");
+    const value = args[i];
+    if (value !== undefined) input[key] = value;
+  }
+
+  // Options object is the last argument before the Command object
+  const optsObj = (args[positionals.length] ?? {}) as Record<string, unknown>;
+
+  for (const opt of options) {
+    const cliKey = opt.key.replace(/_/g, "-");
+    // Commander converts --foo-bar to fooBar
+    const camelKey = cliKey.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+    let value = optsObj[camelKey] ?? optsObj[opt.key];
+
+    if (value === undefined) continue;
+
+    const unwrapped = unwrapOptional(shape[opt.key]!);
+
+    // Parse JSON for array types
+    if (opt.isArray && typeof value === "string") {
+      value = JSON.parse(value);
+    }
+    // Parse numbers
+    else if (unwrapped instanceof z.ZodNumber && typeof value === "string") {
+      value = Number(value);
+    }
+
+    input[opt.key] = value;
+  }
+
+  // Validate with zod
+  const parsed = tool.inputSchema.safeParse(input);
+  if (!parsed.success) {
+    throw new Error(`Invalid arguments: ${JSON.stringify(parsed.error)}`);
+  }
+
+  return parsed.data;
+}
+
+function formatOutput(result: unknown, toolName: string) {
+  if (result == null) return;
+
+  if (typeof result === "object") {
+    const obj = result as Record<string, unknown>;
+
+    // Special formatting for known output shapes
+    if ("tree" in obj && typeof obj.tree === "string") {
+      console.log(obj.tree);
+      return;
+    }
+
+    if ("content" in obj && typeof obj.content === "string") {
+      console.log(obj.content);
+      return;
+    }
+
+    if ("exists" in obj && typeof obj.exists === "boolean") {
+      if (!obj.exists) process.exit(1);
+      return;
+    }
+
+    if ("entries" in obj && Array.isArray(obj.entries)) {
+      for (const entry of obj.entries) {
+        const e = entry as { name: string; type: string; size: number };
+        const suffix = e.type === "directory" ? "/" : "";
+        console.log(`  ${e.name}${suffix}`);
+      }
+      return;
+    }
+
+    if ("matches" in obj && Array.isArray(obj.matches)) {
+      for (const match of obj.matches) {
+        if (typeof match === "string") {
+          console.log(match);
+        } else {
+          const m = match as { path: string; line: number; content: string };
+          console.log(`${m.path}:${m.line}: ${m.content}`);
+        }
+      }
+      return;
+    }
+
+    // Default: print as JSON
+    console.log(JSON.stringify(obj, null, 2));
+  } else {
+    console.log(result);
+  }
+}
+
+function isPositionalArg(key: string, toolName: string): boolean {
+  // These keys are treated as positional arguments
+  const positionalKeys: Record<string, string[]> = {
+    dir_create: ["path"],
+    dir_list: ["path"],
+    dir_tree: ["path"],
+    dir_size: ["path"],
+    file_read: ["path"],
+    file_write: ["path"],
+    file_edit: ["path"],
+    file_delete: ["path"],
+    file_copy: ["src", "dst"],
+    file_move: ["src", "dst"],
+    file_info: ["path"],
+    file_exists: ["path"],
+    file_count_lines: ["path"],
+    search_find: ["pattern"],
+    search_grep: ["pattern"],
+    search_semantic: ["query"],
+  };
+  return positionalKeys[toolName]?.includes(key) ?? false;
+}
+
+function unwrapOptional(schema: z.ZodType): z.ZodType {
+  if (schema instanceof z.ZodOptional) {
+    return schema.unwrap();
+  }
+  return schema;
+}

--- a/src/daemon/llm.ts
+++ b/src/daemon/llm.ts
@@ -1,84 +1,33 @@
 import Anthropic from "@anthropic-ai/sdk";
 import type {
   MessageParam,
-  Tool,
   ToolUseBlock,
   ToolResultBlockParam,
 } from "@anthropic-ai/sdk/resources/messages";
 import type { DuckDBConnection } from "../db/connection.ts";
 import type { BotholomewConfig } from "../config/schemas.ts";
 import type { Task } from "../db/tasks.ts";
-import { createTask } from "../db/tasks.ts";
 import { logInteraction } from "../db/threads.ts";
 import { logger } from "../utils/logger.ts";
+import {
+  getTool,
+  toAnthropicTools,
+  type ToolContext,
+} from "../tools/tool.ts";
+import { registerAllTools } from "../tools/registry.ts";
 
-const DAEMON_TOOLS: Tool[] = [
-  {
-    name: "complete_task",
-    description:
-      "Mark the current task as complete with a summary of what was accomplished.",
-    input_schema: {
-      type: "object" as const,
-      properties: {
-        summary: { type: "string", description: "Summary of work done" },
-      },
-      required: ["summary"],
-    },
-  },
-  {
-    name: "fail_task",
-    description: "Mark the current task as failed with a reason.",
-    input_schema: {
-      type: "object" as const,
-      properties: {
-        reason: { type: "string", description: "Why the task failed" },
-      },
-      required: ["reason"],
-    },
-  },
-  {
-    name: "wait_task",
-    description:
-      "Put the task in waiting status (e.g., needs human input, rate limited).",
-    input_schema: {
-      type: "object" as const,
-      properties: {
-        reason: {
-          type: "string",
-          description: "Why the task is waiting",
-        },
-      },
-      required: ["reason"],
-    },
-  },
-  {
-    name: "create_task",
-    description: "Create a new task to be worked on later.",
-    input_schema: {
-      type: "object" as const,
-      properties: {
-        name: { type: "string", description: "Task name" },
-        description: { type: "string", description: "Task description" },
-        priority: {
-          type: "string",
-          enum: ["low", "medium", "high"],
-          description: "Task priority",
-        },
-        blocked_by: {
-          type: "array",
-          items: { type: "string" },
-          description: "IDs of tasks that must complete first",
-        },
-      },
-      required: ["name"],
-    },
-  },
-];
+registerAllTools();
 
 export interface AgentLoopResult {
   status: "complete" | "failed" | "waiting";
   reason?: string;
 }
+
+const STATUS_MAP: Record<string, AgentLoopResult["status"]> = {
+  complete_task: "complete",
+  fail_task: "failed",
+  wait_task: "waiting",
+};
 
 export async function runAgentLoop(input: {
   systemPrompt: string;
@@ -86,12 +35,15 @@ export async function runAgentLoop(input: {
   config: Required<BotholomewConfig>;
   conn: DuckDBConnection;
   threadId: string;
+  projectDir: string;
 }): Promise<AgentLoopResult> {
-  const { systemPrompt, task, config, conn, threadId } = input;
+  const { systemPrompt, task, config, conn, threadId, projectDir } = input;
 
   const client = new Anthropic({
     apiKey: config.anthropic_api_key || undefined,
   });
+
+  const toolCtx: ToolContext = { conn, projectDir, config };
 
   const userMessage = `Please work on this task:\n\nName: ${task.name}\nDescription: ${task.description}\nPriority: ${task.priority}\n\nUse the available tools to complete this task, then call complete_task, fail_task, or wait_task to indicate the outcome.`;
 
@@ -104,6 +56,8 @@ export async function runAgentLoop(input: {
     content: userMessage,
   });
 
+  const daemonTools = toAnthropicTools();
+
   const maxTurns = 10;
   for (let turn = 0; turn < maxTurns; turn++) {
     const startTime = Date.now();
@@ -112,7 +66,7 @@ export async function runAgentLoop(input: {
       max_tokens: 4096,
       system: systemPrompt,
       messages,
-      tools: DAEMON_TOOLS,
+      tools: daemonTools,
     });
     const durationMs = Date.now() - startTime;
     const tokenCount =
@@ -162,7 +116,7 @@ export async function runAgentLoop(input: {
       });
 
       const toolStart = Date.now();
-      const result = await executeToolCall(toolUse, conn);
+      const result = await executeToolCall(toolUse, toolCtx);
       const toolDuration = Date.now() - toolStart;
 
       // Log tool result
@@ -199,59 +153,39 @@ interface ToolCallResult {
 
 async function executeToolCall(
   toolUse: ToolUseBlock,
-  conn: DuckDBConnection,
+  ctx: ToolContext,
 ): Promise<ToolCallResult> {
-  const input = toolUse.input as Record<string, unknown>;
+  const tool = getTool(toolUse.name);
+  if (!tool) {
+    return { output: `Unknown tool: ${toolUse.name}`, terminal: false };
+  }
 
-  switch (toolUse.name) {
-    case "complete_task":
+  const parsed = tool.inputSchema.safeParse(toolUse.input);
+  if (!parsed.success) {
+    return {
+      output: `Invalid input: ${JSON.stringify(parsed.error)}`,
+      terminal: false,
+    };
+  }
+
+  const result = await tool.execute(parsed.data, ctx);
+  const output = typeof result === "string" ? result : JSON.stringify(result);
+
+  // Check if this is a terminal tool (complete/fail/wait)
+  if (tool.terminal) {
+    const status = STATUS_MAP[tool.name];
+    if (status) {
+      const reason =
+        (parsed.data as Record<string, unknown>).summary ??
+        (parsed.data as Record<string, unknown>).reason ??
+        "";
       return {
-        output: `Task completed: ${input.summary}`,
+        output,
         terminal: true,
-        agentResult: {
-          status: "complete",
-          reason: String(input.summary ?? ""),
-        },
-      };
-
-    case "fail_task":
-      return {
-        output: `Task failed: ${input.reason}`,
-        terminal: true,
-        agentResult: {
-          status: "failed",
-          reason: String(input.reason ?? ""),
-        },
-      };
-
-    case "wait_task":
-      return {
-        output: `Task waiting: ${input.reason}`,
-        terminal: true,
-        agentResult: {
-          status: "waiting",
-          reason: String(input.reason ?? ""),
-        },
-      };
-
-    case "create_task": {
-      const newTask = await createTask(conn, {
-        name: String(input.name),
-        description: input.description ? String(input.description) : undefined,
-        priority: input.priority as Task["priority"] | undefined,
-        blocked_by: input.blocked_by as string[] | undefined,
-      });
-      logger.info(`Created subtask: ${newTask.name} (${newTask.id})`);
-      return {
-        output: `Created task "${newTask.name}" with ID ${newTask.id}`,
-        terminal: false,
+        agentResult: { status, reason: String(reason) },
       };
     }
-
-    default:
-      return {
-        output: `Unknown tool: ${toolUse.name}`,
-        terminal: false,
-      };
   }
+
+  return { output, terminal: false };
 }

--- a/src/daemon/tick.ts
+++ b/src/daemon/tick.ts
@@ -40,6 +40,7 @@ export async function tick(
       config,
       conn,
       threadId,
+      projectDir,
     });
 
     // Update task status

--- a/src/db/context.ts
+++ b/src/db/context.ts
@@ -14,9 +14,354 @@ export interface ContextItem {
   updated_at: Date;
 }
 
-// Stub — full implementation in a later milestone
+export interface Patch {
+  start_line: number;
+  end_line: number;
+  content: string;
+}
+
+function rowToContextItem(row: unknown[]): ContextItem {
+  return {
+    id: String(row[0]),
+    title: String(row[1]),
+    description: String(row[2]),
+    content: row[3] != null ? String(row[3]) : null,
+    // skip content_blob (row[4])
+    mime_type: String(row[5]),
+    is_textual: Boolean(row[6]),
+    source_path: row[7] != null ? String(row[7]) : null,
+    context_path: String(row[8]),
+    indexed_at: row[9] != null ? new Date(String(row[9])) : null,
+    created_at: new Date(String(row[10])),
+    updated_at: new Date(String(row[11])),
+  };
+}
+
+function escape(str: string): string {
+  return str.replace(/'/g, "''");
+}
+
+// --- Basic CRUD ---
+
+export async function createContextItem(
+  conn: DuckDBConnection,
+  params: {
+    title: string;
+    content?: string;
+    mimeType?: string;
+    sourcePath?: string;
+    contextPath: string;
+    description?: string;
+    isTextual?: boolean;
+  },
+): Promise<ContextItem> {
+  const result = await conn.runAndReadAll(`
+    INSERT INTO context_items (title, description, content, mime_type, is_textual, source_path, context_path)
+    VALUES (
+      '${escape(params.title)}',
+      '${escape(params.description ?? "")}',
+      ${params.content != null ? `'${escape(params.content)}'` : "NULL"},
+      '${escape(params.mimeType ?? "text/plain")}',
+      ${params.isTextual !== false},
+      ${params.sourcePath != null ? `'${escape(params.sourcePath)}'` : "NULL"},
+      '${escape(params.contextPath)}'
+    )
+    RETURNING *
+  `);
+  return rowToContextItem(result.getRows()[0]!);
+}
+
+export async function getContextItem(
+  conn: DuckDBConnection,
+  id: string,
+): Promise<ContextItem | null> {
+  const result = await conn.runAndReadAll(
+    `SELECT * FROM context_items WHERE id = '${escape(id)}'`,
+  );
+  const rows = result.getRows();
+  return rows.length > 0 ? rowToContextItem(rows[0]!) : null;
+}
+
+export async function getContextItemByPath(
+  conn: DuckDBConnection,
+  contextPath: string,
+): Promise<ContextItem | null> {
+  const result = await conn.runAndReadAll(
+    `SELECT * FROM context_items WHERE context_path = '${escape(contextPath)}'`,
+  );
+  const rows = result.getRows();
+  return rows.length > 0 ? rowToContextItem(rows[0]!) : null;
+}
+
 export async function listContextItems(
-  _conn: DuckDBConnection,
+  conn: DuckDBConnection,
+  filters?: {
+    contextPath?: string;
+    mimeType?: string;
+    limit?: number;
+  },
 ): Promise<ContextItem[]> {
-  return [];
+  const conditions: string[] = [];
+  if (filters?.contextPath)
+    conditions.push(`context_path = '${escape(filters.contextPath)}'`);
+  if (filters?.mimeType)
+    conditions.push(`mime_type = '${escape(filters.mimeType)}'`);
+
+  const where =
+    conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+  const limit = filters?.limit ? `LIMIT ${filters.limit}` : "";
+
+  const result = await conn.runAndReadAll(
+    `SELECT * FROM context_items ${where} ORDER BY context_path ASC ${limit}`,
+  );
+  return result.getRows().map(rowToContextItem);
+}
+
+export async function listContextItemsByPrefix(
+  conn: DuckDBConnection,
+  prefix: string,
+  opts?: { recursive?: boolean; limit?: number },
+): Promise<ContextItem[]> {
+  const normalizedPrefix = prefix.endsWith("/") ? prefix : `${prefix}/`;
+
+  let where: string;
+  if (opts?.recursive) {
+    // All items under this prefix at any depth
+    where = `WHERE context_path LIKE '${escape(normalizedPrefix)}%'`;
+  } else {
+    // Only immediate children: match prefix but no further slashes
+    where = `WHERE context_path LIKE '${escape(normalizedPrefix)}%'
+      AND context_path NOT LIKE '${escape(normalizedPrefix)}%/%'`;
+  }
+
+  const limit = opts?.limit ? `LIMIT ${opts.limit}` : "";
+
+  const result = await conn.runAndReadAll(
+    `SELECT * FROM context_items ${where} ORDER BY context_path ASC ${limit}`,
+  );
+  return result.getRows().map(rowToContextItem);
+}
+
+export async function contextPathExists(
+  conn: DuckDBConnection,
+  contextPath: string,
+): Promise<boolean> {
+  const result = await conn.runAndReadAll(
+    `SELECT 1 FROM context_items WHERE context_path = '${escape(contextPath)}' LIMIT 1`,
+  );
+  return result.getRows().length > 0;
+}
+
+export async function getDistinctDirectories(
+  conn: DuckDBConnection,
+  prefix?: string,
+): Promise<string[]> {
+  const normalizedPrefix = prefix
+    ? prefix.endsWith("/")
+      ? prefix
+      : `${prefix}/`
+    : "/";
+
+  // Extract the directory portion after the prefix, taking only the first path segment
+  const where = prefix
+    ? `WHERE context_path LIKE '${escape(normalizedPrefix)}%/%'`
+    : `WHERE context_path LIKE '%/%'`;
+
+  const result = await conn.runAndReadAll(`
+    SELECT DISTINCT
+      '${escape(normalizedPrefix)}' || split_part(
+        substr(context_path, length('${escape(normalizedPrefix)}') + 1),
+        '/',
+        1
+      ) AS dir
+    FROM context_items
+    ${where}
+    ORDER BY dir ASC
+  `);
+
+  return result.getRows().map((row) => String(row[0]));
+}
+
+// --- Mutations ---
+
+export async function updateContextItem(
+  conn: DuckDBConnection,
+  id: string,
+  updates: Partial<
+    Pick<ContextItem, "title" | "description" | "content" | "mime_type">
+  >,
+): Promise<ContextItem | null> {
+  const setClauses: string[] = ["updated_at = current_timestamp"];
+  if (updates.title !== undefined)
+    setClauses.push(`title = '${escape(updates.title)}'`);
+  if (updates.description !== undefined)
+    setClauses.push(`description = '${escape(updates.description)}'`);
+  if (updates.content !== undefined)
+    setClauses.push(`content = '${escape(updates.content)}'`);
+  if (updates.mime_type !== undefined)
+    setClauses.push(`mime_type = '${escape(updates.mime_type)}'`);
+
+  const result = await conn.runAndReadAll(`
+    UPDATE context_items
+    SET ${setClauses.join(", ")}
+    WHERE id = '${escape(id)}'
+    RETURNING *
+  `);
+  const rows = result.getRows();
+  return rows.length > 0 ? rowToContextItem(rows[0]!) : null;
+}
+
+export async function updateContextItemContent(
+  conn: DuckDBConnection,
+  contextPath: string,
+  content: string,
+): Promise<ContextItem | null> {
+  const result = await conn.runAndReadAll(`
+    UPDATE context_items
+    SET content = '${escape(content)}', updated_at = current_timestamp
+    WHERE context_path = '${escape(contextPath)}'
+    RETURNING *
+  `);
+  const rows = result.getRows();
+  return rows.length > 0 ? rowToContextItem(rows[0]!) : null;
+}
+
+export async function applyPatchesToContextItem(
+  conn: DuckDBConnection,
+  contextPath: string,
+  patches: Patch[],
+): Promise<{ item: ContextItem; applied: number }> {
+  const item = await getContextItemByPath(conn, contextPath);
+  if (!item) throw new Error(`Not found: ${contextPath}`);
+  if (item.content == null) throw new Error(`No text content: ${contextPath}`);
+
+  const lines = item.content.split("\n");
+
+  // Sort patches by start_line descending so we apply bottom-up
+  const sorted = [...patches].sort((a, b) => b.start_line - a.start_line);
+
+  for (const patch of sorted) {
+    if (patch.end_line === 0) {
+      // Insert at start_line without replacing
+      const insertLines =
+        patch.content === "" ? [] : patch.content.split("\n");
+      lines.splice(patch.start_line - 1, 0, ...insertLines);
+    } else {
+      // Replace lines [start_line, end_line] inclusive (1-based)
+      const deleteCount = patch.end_line - patch.start_line + 1;
+      const insertLines =
+        patch.content === "" ? [] : patch.content.split("\n");
+      lines.splice(patch.start_line - 1, deleteCount, ...insertLines);
+    }
+  }
+
+  const newContent = lines.join("\n");
+  const updated = await updateContextItemContent(conn, contextPath, newContent);
+  if (!updated) throw new Error(`Failed to update: ${contextPath}`);
+  return { item: updated, applied: patches.length };
+}
+
+export async function copyContextItem(
+  conn: DuckDBConnection,
+  srcPath: string,
+  dstPath: string,
+): Promise<ContextItem> {
+  const src = await getContextItemByPath(conn, srcPath);
+  if (!src) throw new Error(`Not found: ${srcPath}`);
+
+  return createContextItem(conn, {
+    title: src.title,
+    description: src.description,
+    content: src.content ?? undefined,
+    mimeType: src.mime_type,
+    sourcePath: src.source_path ?? undefined,
+    contextPath: dstPath,
+    isTextual: src.is_textual,
+  });
+}
+
+export async function moveContextItem(
+  conn: DuckDBConnection,
+  oldPath: string,
+  newPath: string,
+): Promise<void> {
+  const result = await conn.runAndReadAll(`
+    UPDATE context_items
+    SET context_path = '${escape(newPath)}', updated_at = current_timestamp
+    WHERE context_path = '${escape(oldPath)}'
+    RETURNING id
+  `);
+  if (result.getRows().length === 0) {
+    throw new Error(`Not found: ${oldPath}`);
+  }
+}
+
+// --- Deletion ---
+
+export async function deleteContextItem(
+  conn: DuckDBConnection,
+  id: string,
+): Promise<boolean> {
+  // Delete embeddings first (foreign key)
+  await conn.run(
+    `DELETE FROM embeddings WHERE context_item_id = '${escape(id)}'`,
+  );
+  const result = await conn.runAndReadAll(
+    `DELETE FROM context_items WHERE id = '${escape(id)}' RETURNING id`,
+  );
+  return result.getRows().length > 0;
+}
+
+export async function deleteContextItemByPath(
+  conn: DuckDBConnection,
+  contextPath: string,
+): Promise<boolean> {
+  // Get ID first so we can cascade embeddings
+  const item = await getContextItemByPath(conn, contextPath);
+  if (!item) return false;
+  return deleteContextItem(conn, item.id);
+}
+
+export async function deleteContextItemsByPrefix(
+  conn: DuckDBConnection,
+  prefix: string,
+): Promise<number> {
+  const normalizedPrefix = prefix.endsWith("/") ? prefix : `${prefix}/`;
+
+  // Delete embeddings for all matching items
+  await conn.run(`
+    DELETE FROM embeddings
+    WHERE context_item_id IN (
+      SELECT id FROM context_items
+      WHERE context_path LIKE '${escape(normalizedPrefix)}%'
+    )
+  `);
+
+  const result = await conn.runAndReadAll(`
+    DELETE FROM context_items
+    WHERE context_path LIKE '${escape(normalizedPrefix)}%'
+    RETURNING id
+  `);
+  return result.getRows().length;
+}
+
+// --- Search ---
+
+export async function searchContextByKeyword(
+  conn: DuckDBConnection,
+  query: string,
+  limit = 20,
+): Promise<ContextItem[]> {
+  const escaped = escape(query);
+  const result = await conn.runAndReadAll(`
+    SELECT * FROM context_items
+    WHERE content IS NOT NULL
+      AND (
+        lower(content) LIKE lower('%${escaped}%')
+        OR lower(title) LIKE lower('%${escaped}%')
+      )
+    ORDER BY updated_at DESC
+    LIMIT ${limit}
+  `);
+  return result.getRows().map(rowToContextItem);
 }

--- a/src/db/tasks.ts
+++ b/src/db/tasks.ts
@@ -1,11 +1,14 @@
 import type { DuckDBConnection } from "./connection.ts";
 
+export const TASK_PRIORITIES = ["low", "medium", "high"] as const;
+export const TASK_STATUSES = ["pending", "in_progress", "failed", "complete", "waiting"] as const;
+
 export interface Task {
   id: string;
   name: string;
   description: string;
-  priority: "low" | "medium" | "high";
-  status: "pending" | "in_progress" | "failed" | "complete" | "waiting";
+  priority: (typeof TASK_PRIORITIES)[number];
+  status: (typeof TASK_STATUSES)[number];
   waiting_reason: string | null;
   claimed_by: string | null;
   claimed_at: Date | null;

--- a/src/tools/dir/create.ts
+++ b/src/tools/dir/create.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+import type { ToolDefinition } from "../tool.ts";
+import { createContextItem, contextPathExists } from "../../db/context.ts";
+
+export const dirCreateTool: ToolDefinition<any, any> = {
+  name: "dir_create",
+  description: "Create a directory in the virtual filesystem.",
+  group: "dir",
+  inputSchema: z.object({
+    path: z.string().describe("Directory path to create"),
+    parents: z
+      .boolean()
+      .optional()
+      .describe("Create parent directories as needed"),
+  }),
+  outputSchema: z.object({
+    created: z.boolean(),
+    path: z.string(),
+  }),
+  execute: async (input, ctx) => {
+    const exists = await contextPathExists(ctx.conn, input.path);
+    if (exists) {
+      return { created: false, path: input.path };
+    }
+
+    await createContextItem(ctx.conn, {
+      title: input.path.split("/").filter(Boolean).pop() ?? input.path,
+      contextPath: input.path,
+      mimeType: "inode/directory",
+      isTextual: false,
+    });
+
+    return { created: true, path: input.path };
+  },
+};

--- a/src/tools/dir/list.ts
+++ b/src/tools/dir/list.ts
@@ -1,0 +1,83 @@
+import { z } from "zod";
+import type { ToolDefinition } from "../tool.ts";
+import {
+  listContextItemsByPrefix,
+  getDistinctDirectories,
+} from "../../db/context.ts";
+
+const DirEntrySchema = z.object({
+  name: z.string(),
+  type: z.enum(["file", "directory"]),
+  size: z.number(),
+});
+
+export const dirListTool: ToolDefinition<any, any> = {
+  name: "dir_list",
+  description: "List directory contents in the virtual filesystem.",
+  group: "dir",
+  inputSchema: z.object({
+    path: z.string().optional().describe("Directory path (defaults to /)"),
+    recursive: z
+      .boolean()
+      .optional()
+      .default(true)
+      .describe("Include contents of subdirectories (defaults to true)"),
+    limit: z
+      .number()
+      .optional()
+      .default(100)
+      .describe("Maximum number of entries to return (defaults to 100)"),
+    offset: z
+      .number()
+      .optional()
+      .default(0)
+      .describe("Number of entries to skip (defaults to 0)"),
+  }),
+  outputSchema: z.object({
+    entries: z.array(DirEntrySchema),
+    total: z.number(),
+  }),
+  execute: async (input, ctx) => {
+    const path = input.path ?? "/";
+    const recursive = input.recursive ?? true;
+    const limit = input.limit ?? 100;
+    const offset = input.offset ?? 0;
+    const normalizedPath = path.endsWith("/") ? path : `${path}/`;
+
+    const allItems = await listContextItemsByPrefix(ctx.conn, path, {
+      recursive,
+    });
+
+    const entries: z.infer<typeof DirEntrySchema>[] = allItems.map((item) => ({
+      name: recursive
+        ? item.context_path
+        : item.context_path.slice(normalizedPath.length),
+      type:
+        item.mime_type === "inode/directory"
+          ? ("directory" as const)
+          : ("file" as const),
+      size: item.content?.length ?? 0,
+    }));
+
+    // Add subdirectories (if not recursive, show immediate child dirs)
+    if (!recursive) {
+      const dirs = await getDistinctDirectories(ctx.conn, path);
+      for (const dir of dirs) {
+        const name = dir.slice(normalizedPath.length);
+        if (!entries.some((e) => e.name === name)) {
+          entries.push({ name, type: "directory", size: 0 });
+        }
+      }
+    }
+
+    entries.sort((a, b) => {
+      if (a.type !== b.type) return a.type === "directory" ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    });
+
+    const total = entries.length;
+    const paginated = entries.slice(offset, offset + limit);
+
+    return { entries: paginated, total };
+  },
+};

--- a/src/tools/dir/size.ts
+++ b/src/tools/dir/size.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+import type { ToolDefinition } from "../tool.ts";
+import { listContextItemsByPrefix } from "../../db/context.ts";
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(1024));
+  const value = bytes / Math.pow(1024, i);
+  return `${value.toFixed(i > 0 ? 1 : 0)} ${units[i]}`;
+}
+
+export const dirSizeTool: ToolDefinition<any, any> = {
+  name: "dir_size",
+  description: "Get the total size of files in a directory.",
+  group: "dir",
+  inputSchema: z.object({
+    path: z.string().optional().describe("Directory path (defaults to /)"),
+    recursive: z
+      .boolean()
+      .optional()
+      .describe("Include subdirectories (defaults to true)"),
+  }),
+  outputSchema: z.object({
+    bytes: z.number(),
+    formatted: z.string(),
+  }),
+  execute: async (input, ctx) => {
+    const path = input.path ?? "/";
+    const items = await listContextItemsByPrefix(ctx.conn, path, {
+      recursive: input.recursive !== false,
+    });
+
+    let bytes = 0;
+    for (const item of items) {
+      if (item.content != null) bytes += item.content.length;
+    }
+
+    return { bytes, formatted: formatBytes(bytes) };
+  },
+};

--- a/src/tools/dir/tree.ts
+++ b/src/tools/dir/tree.ts
@@ -1,0 +1,84 @@
+import { z } from "zod";
+import type { ToolDefinition } from "../tool.ts";
+import { listContextItemsByPrefix } from "../../db/context.ts";
+
+const DEFAULT_MAX_ITEMS = 200;
+
+export const dirTreeTool: ToolDefinition<any, any> = {
+  name: "dir_tree",
+  description:
+    "Render a directory as a markdown-style tree in the virtual filesystem.",
+  group: "dir",
+  inputSchema: z.object({
+    path: z
+      .string()
+      .optional()
+      .describe("Root path for the tree (defaults to /)"),
+    max_items: z
+      .number()
+      .optional()
+      .default(DEFAULT_MAX_ITEMS)
+      .describe(`Maximum number of items to include (defaults to ${DEFAULT_MAX_ITEMS})`),
+  }),
+  outputSchema: z.object({
+    tree: z.string(),
+  }),
+  execute: async (input, ctx) => {
+    const path = input.path ?? "/";
+    const maxItems = input.max_items ?? DEFAULT_MAX_ITEMS;
+    const items = await listContextItemsByPrefix(ctx.conn, path, {
+      recursive: true,
+      limit: maxItems,
+    });
+
+    if (items.length === 0) {
+      return { tree: `${path}\n  (empty)` };
+    }
+
+    const normalizedPath = path.endsWith("/") ? path : `${path}/`;
+
+    // Build tree structure
+    const lines: string[] = [path];
+
+    // Collect all paths and sort
+    const paths = items.map((i) => i.context_path).sort();
+
+    // Collect all directory prefixes
+    const dirSet = new Set<string>();
+    for (const p of paths) {
+      const relative = p.slice(normalizedPath.length);
+      const parts = relative.split("/");
+      for (let i = 1; i < parts.length; i++) {
+        dirSet.add(parts.slice(0, i).join("/"));
+      }
+    }
+
+    // Merge dirs and files, sort
+    const allEntries = [
+      ...Array.from(dirSet).map((d) => ({ path: d, isDir: true })),
+      ...paths.map((p) => ({
+        path: p.slice(normalizedPath.length),
+        isDir: false,
+      })),
+    ].sort((a, b) => a.path.localeCompare(b.path));
+
+    for (let i = 0; i < allEntries.length; i++) {
+      const entry = allEntries[i]!;
+      const depth = entry.path.split("/").length - 1;
+      const isLast =
+        i === allEntries.length - 1 ||
+        allEntries[i + 1]!.path.split("/").length - 1 <= depth;
+      const prefix = isLast ? "└── " : "├── ";
+      const indent = "│   ".repeat(depth);
+      const name = entry.path.split("/").pop()!;
+      const suffix = entry.isDir ? "/" : "";
+      lines.push(`${indent}${prefix}${name}${suffix}`);
+    }
+
+    if (items.length >= maxItems) {
+      lines.push(`... (truncated at ${maxItems} items)`);
+    }
+
+    return { tree: lines.join("\n") };
+  },
+};

--- a/src/tools/file/copy.ts
+++ b/src/tools/file/copy.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import type { ToolDefinition } from "../tool.ts";
+import { contextPathExists, copyContextItem } from "../../db/context.ts";
+
+export const fileCopyTool: ToolDefinition<any, any> = {
+  name: "file_copy",
+  description: "Copy a file in the virtual filesystem.",
+  group: "file",
+  inputSchema: z.object({
+    src: z.string().describe("Source file path"),
+    dst: z.string().describe("Destination file path"),
+    overwrite: z
+      .boolean()
+      .optional()
+      .describe("Overwrite if destination exists"),
+  }),
+  outputSchema: z.object({
+    id: z.string(),
+    path: z.string(),
+  }),
+  execute: async (input, ctx) => {
+    if (!input.overwrite && (await contextPathExists(ctx.conn, input.dst))) {
+      throw new Error(`Destination already exists: ${input.dst}`);
+    }
+
+    const item = await copyContextItem(ctx.conn, input.src, input.dst);
+    return { id: item.id, path: item.context_path };
+  },
+};

--- a/src/tools/file/count-lines.ts
+++ b/src/tools/file/count-lines.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+import type { ToolDefinition } from "../tool.ts";
+import { getContextItemByPath } from "../../db/context.ts";
+
+export const fileCountLinesTool: ToolDefinition<any, any> = {
+  name: "file_count_lines",
+  description: "Count the number of lines in a text file.",
+  group: "file",
+  inputSchema: z.object({
+    path: z.string().describe("File path"),
+  }),
+  outputSchema: z.object({
+    lines: z.number(),
+  }),
+  execute: async (input, ctx) => {
+    const item = await getContextItemByPath(ctx.conn, input.path);
+    if (!item) throw new Error(`Not found: ${input.path}`);
+    if (item.content == null) throw new Error(`No text content: ${input.path}`);
+
+    return { lines: item.content.split("\n").length };
+  },
+};

--- a/src/tools/file/delete.ts
+++ b/src/tools/file/delete.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+import type { ToolDefinition } from "../tool.ts";
+import {
+  deleteContextItemByPath,
+  deleteContextItemsByPrefix,
+} from "../../db/context.ts";
+
+export const fileDeleteTool: ToolDefinition<any, any> = {
+  name: "file_delete",
+  description: "Delete a file or directory from the virtual filesystem.",
+  group: "file",
+  inputSchema: z.object({
+    path: z.string().describe("Path to delete"),
+    recursive: z
+      .boolean()
+      .optional()
+      .describe("Delete all items under this path prefix"),
+    force: z
+      .boolean()
+      .optional()
+      .describe("Do not error if the path does not exist"),
+  }),
+  outputSchema: z.object({
+    deleted: z.number(),
+  }),
+  execute: async (input, ctx) => {
+    if (input.recursive) {
+      const count = await deleteContextItemsByPrefix(ctx.conn, input.path);
+      const exact = await deleteContextItemByPath(ctx.conn, input.path);
+      return { deleted: count + (exact ? 1 : 0) };
+    }
+
+    const deleted = await deleteContextItemByPath(ctx.conn, input.path);
+    if (!deleted && !input.force) {
+      throw new Error(`Not found: ${input.path}`);
+    }
+    return { deleted: deleted ? 1 : 0 };
+  },
+};

--- a/src/tools/file/edit.ts
+++ b/src/tools/file/edit.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+import type { ToolDefinition } from "../tool.ts";
+import { applyPatchesToContextItem } from "../../db/context.ts";
+
+const PatchSchema = z.object({
+  start_line: z.number().describe("1-based inclusive start line"),
+  end_line: z
+    .number()
+    .describe("1-based inclusive end line (0 to insert without replacing)"),
+  content: z
+    .string()
+    .describe("Replacement text (empty string to delete lines)"),
+});
+
+export const fileEditTool: ToolDefinition<any, any> = {
+  name: "file_edit",
+  description:
+    "Apply git-style patches to a file. Each patch specifies a line range to replace.",
+  group: "file",
+  inputSchema: z.object({
+    path: z.string().describe("File path to edit"),
+    patches: z.array(PatchSchema).describe("Patches to apply"),
+  }),
+  outputSchema: z.object({
+    applied: z.number(),
+    content: z.string(),
+  }),
+  execute: async (input, ctx) => {
+    const { item, applied } = await applyPatchesToContextItem(
+      ctx.conn,
+      input.path,
+      input.patches,
+    );
+    return { applied, content: item.content ?? "" };
+  },
+};

--- a/src/tools/file/exists.ts
+++ b/src/tools/file/exists.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+import type { ToolDefinition } from "../tool.ts";
+import { contextPathExists } from "../../db/context.ts";
+
+export const fileExistsTool: ToolDefinition<any, any> = {
+  name: "file_exists",
+  description: "Check if a file exists in the virtual filesystem.",
+  group: "file",
+  inputSchema: z.object({
+    path: z.string().describe("File path to check"),
+  }),
+  outputSchema: z.object({
+    exists: z.boolean(),
+  }),
+  execute: async (input, ctx) => {
+    const exists = await contextPathExists(ctx.conn, input.path);
+    return { exists };
+  },
+};

--- a/src/tools/file/info.ts
+++ b/src/tools/file/info.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+import type { ToolDefinition } from "../tool.ts";
+import { getContextItemByPath } from "../../db/context.ts";
+
+export const fileInfoTool: ToolDefinition<any, any> = {
+  name: "file_info",
+  description: "Show file metadata (size, MIME type, line count, etc.).",
+  group: "file",
+  inputSchema: z.object({
+    path: z.string().describe("File path"),
+  }),
+  outputSchema: z.object({
+    id: z.string(),
+    title: z.string(),
+    description: z.string(),
+    mime_type: z.string(),
+    is_textual: z.boolean(),
+    size: z.number(),
+    lines: z.number(),
+    source_path: z.string().nullable(),
+    context_path: z.string(),
+    indexed_at: z.string().nullable(),
+    created_at: z.string(),
+    updated_at: z.string(),
+  }),
+  execute: async (input, ctx) => {
+    const item = await getContextItemByPath(ctx.conn, input.path);
+    if (!item) throw new Error(`Not found: ${input.path}`);
+
+    const content = item.content ?? "";
+    return {
+      id: item.id,
+      title: item.title,
+      description: item.description,
+      mime_type: item.mime_type,
+      is_textual: item.is_textual,
+      size: content.length,
+      lines: content ? content.split("\n").length : 0,
+      source_path: item.source_path,
+      context_path: item.context_path,
+      indexed_at: item.indexed_at?.toISOString() ?? null,
+      created_at: item.created_at.toISOString(),
+      updated_at: item.updated_at.toISOString(),
+    };
+  },
+};

--- a/src/tools/file/move.ts
+++ b/src/tools/file/move.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+import type { ToolDefinition } from "../tool.ts";
+import { contextPathExists, moveContextItem } from "../../db/context.ts";
+
+export const fileMoveTool: ToolDefinition<any, any> = {
+  name: "file_move",
+  description: "Move or rename a file in the virtual filesystem.",
+  group: "file",
+  inputSchema: z.object({
+    src: z.string().describe("Source file path"),
+    dst: z.string().describe("Destination file path"),
+    overwrite: z
+      .boolean()
+      .optional()
+      .describe("Overwrite if destination exists"),
+  }),
+  outputSchema: z.object({
+    path: z.string(),
+  }),
+  execute: async (input, ctx) => {
+    if (!input.overwrite && (await contextPathExists(ctx.conn, input.dst))) {
+      throw new Error(`Destination already exists: ${input.dst}`);
+    }
+
+    await moveContextItem(ctx.conn, input.src, input.dst);
+    return { path: input.dst };
+  },
+};

--- a/src/tools/file/read.ts
+++ b/src/tools/file/read.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+import type { ToolDefinition } from "../tool.ts";
+import { getContextItemByPath } from "../../db/context.ts";
+
+export const fileReadTool: ToolDefinition<any, any> = {
+  name: "file_read",
+  description: "Read a file's contents from the virtual filesystem.",
+  group: "file",
+  inputSchema: z.object({
+    path: z.string().describe("File path to read"),
+    offset: z
+      .number()
+      .optional()
+      .describe("Line number to start reading from (1-based)"),
+    limit: z.number().optional().describe("Maximum number of lines to return"),
+  }),
+  outputSchema: z.object({
+    content: z.string(),
+  }),
+  execute: async (input, ctx) => {
+    const item = await getContextItemByPath(ctx.conn, input.path);
+    if (!item) throw new Error(`Not found: ${input.path}`);
+    if (item.content == null) throw new Error(`No text content: ${input.path}`);
+
+    let content = item.content;
+
+    if (input.offset || input.limit) {
+      const lines = content.split("\n");
+      const start = (input.offset ?? 1) - 1;
+      const end = input.limit ? start + input.limit : lines.length;
+      content = lines.slice(start, end).join("\n");
+    }
+
+    return { content };
+  },
+};

--- a/src/tools/file/write.ts
+++ b/src/tools/file/write.ts
@@ -1,0 +1,88 @@
+import { z } from "zod";
+import { isText } from "istextorbinary";
+import type { ToolDefinition } from "../tool.ts";
+import {
+  createContextItem,
+  getContextItemByPath,
+  updateContextItemContent,
+  updateContextItem,
+} from "../../db/context.ts";
+
+function mimeFromPath(path: string): string {
+  return Bun.file(path).type.split(";")[0]!;
+}
+
+function isTextualPath(path: string): boolean {
+  const filename = path.split("/").pop() ?? path;
+  const result = isText(filename);
+  // isText returns null if it can't determine from filename alone — default to true
+  return result !== false;
+}
+
+export const fileWriteTool: ToolDefinition<any, any> = {
+  name: "file_write",
+  description:
+    "Write content to a file in the virtual filesystem. Creates the file if it doesn't exist, or overwrites if it does.",
+  group: "file",
+  inputSchema: z.object({
+    path: z.string().describe("File path to write"),
+    content: z.string().describe("Text content to write"),
+    content_base64: z
+      .string()
+      .optional()
+      .describe("Base64-encoded binary content (used instead of content for binary files)"),
+    title: z
+      .string()
+      .optional()
+      .describe("Title for the file (defaults to filename)"),
+    description: z
+      .string()
+      .optional()
+      .describe("Description of the file"),
+  }),
+  outputSchema: z.object({
+    id: z.string(),
+    path: z.string(),
+  }),
+  execute: async (input, ctx) => {
+    const mimeType = mimeFromPath(input.path);
+    const isTextual = isTextualPath(input.path);
+    const existing = await getContextItemByPath(ctx.conn, input.path);
+
+    if (existing) {
+      if (input.content_base64) {
+        // Binary update — store as content for now (DB blob support can be added later)
+        await updateContextItemContent(
+          ctx.conn,
+          input.path,
+          input.content_base64,
+        );
+      } else {
+        await updateContextItemContent(ctx.conn, input.path, input.content);
+      }
+      if (input.title || input.description) {
+        await updateContextItem(ctx.conn, existing.id, {
+          title: input.title,
+          description: input.description,
+        });
+      }
+      return { id: existing.id, path: input.path };
+    }
+
+    const title =
+      input.title ??
+      input.path.split("/").filter(Boolean).pop() ??
+      input.path;
+
+    const item = await createContextItem(ctx.conn, {
+      title,
+      description: input.description,
+      content: input.content_base64 ?? input.content,
+      contextPath: input.path,
+      mimeType,
+      isTextual,
+    });
+
+    return { id: item.id, path: item.context_path };
+  },
+};

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -1,0 +1,59 @@
+import { registerTools } from "./tool.ts";
+
+// Task tools
+import { completeTaskTool } from "./task/complete.ts";
+import { failTaskTool } from "./task/fail.ts";
+import { waitTaskTool } from "./task/wait.ts";
+import { createTaskTool } from "./task/create.ts";
+
+// Directory tools
+import { dirCreateTool } from "./dir/create.ts";
+import { dirListTool } from "./dir/list.ts";
+import { dirTreeTool } from "./dir/tree.ts";
+import { dirSizeTool } from "./dir/size.ts";
+
+// File tools
+import { fileReadTool } from "./file/read.ts";
+import { fileWriteTool } from "./file/write.ts";
+import { fileEditTool } from "./file/edit.ts";
+import { fileDeleteTool } from "./file/delete.ts";
+import { fileCopyTool } from "./file/copy.ts";
+import { fileMoveTool } from "./file/move.ts";
+import { fileInfoTool } from "./file/info.ts";
+import { fileExistsTool } from "./file/exists.ts";
+import { fileCountLinesTool } from "./file/count-lines.ts";
+
+// Search tools
+import { searchGrepTool } from "./search/grep.ts";
+import { searchSemanticTool } from "./search/semantic.ts";
+
+export function registerAllTools(): void {
+  registerTools([
+    // Task
+    completeTaskTool,
+    failTaskTool,
+    waitTaskTool,
+    createTaskTool,
+
+    // Directory
+    dirCreateTool,
+    dirListTool,
+    dirTreeTool,
+    dirSizeTool,
+
+    // File
+    fileReadTool,
+    fileWriteTool,
+    fileEditTool,
+    fileDeleteTool,
+    fileCopyTool,
+    fileMoveTool,
+    fileInfoTool,
+    fileExistsTool,
+    fileCountLinesTool,
+
+    // Search
+    searchGrepTool,
+    searchSemanticTool,
+  ]);
+}

--- a/src/tools/search/grep.ts
+++ b/src/tools/search/grep.ts
@@ -1,0 +1,89 @@
+import { z } from "zod";
+import type { ToolDefinition } from "../tool.ts";
+import { listContextItemsByPrefix } from "../../db/context.ts";
+
+const GrepMatchSchema = z.object({
+  path: z.string(),
+  line: z.number(),
+  content: z.string(),
+  context_lines: z.array(z.string()),
+});
+
+export const searchGrepTool: ToolDefinition<any, any> = {
+  name: "search_grep",
+  description:
+    "Search file contents by regex pattern in the virtual filesystem.",
+  group: "search",
+  inputSchema: z.object({
+    pattern: z.string().describe("Regex pattern to search for"),
+    path: z
+      .string()
+      .optional()
+      .describe("Directory to search in (defaults to /)"),
+    glob: z
+      .string()
+      .optional()
+      .describe("Only search files matching this glob pattern"),
+    ignore_case: z.boolean().optional().describe("Case-insensitive search"),
+    context: z
+      .number()
+      .optional()
+      .describe("Number of context lines before and after each match"),
+    max_results: z
+      .number()
+      .optional()
+      .describe("Maximum number of matches to return"),
+  }),
+  outputSchema: z.object({
+    matches: z.array(GrepMatchSchema),
+  }),
+  execute: async (input, ctx) => {
+    const searchPath = input.path ?? "/";
+    const items = await listContextItemsByPrefix(ctx.conn, searchPath, {
+      recursive: true,
+    });
+
+    const flags = input.ignore_case ? "gi" : "g";
+    const regex = new RegExp(input.pattern, flags);
+    const globRegex = input.glob ? globToRegex(input.glob) : null;
+    const contextLines = input.context ?? 0;
+    const maxResults = input.max_results ?? 100;
+
+    const matches: z.infer<typeof GrepMatchSchema>[] = [];
+
+    for (const item of items) {
+      if (item.content == null) continue;
+
+      if (globRegex) {
+        const filename = item.context_path.split("/").pop() ?? "";
+        if (!globRegex.test(filename)) continue;
+      }
+
+      const lines = item.content.split("\n");
+      for (let i = 0; i < lines.length; i++) {
+        regex.lastIndex = 0;
+        if (regex.test(lines[i]!)) {
+          const start = Math.max(0, i - contextLines);
+          const end = Math.min(lines.length, i + contextLines + 1);
+          matches.push({
+            path: item.context_path,
+            line: i + 1,
+            content: lines[i]!,
+            context_lines: lines.slice(start, end),
+          });
+          if (matches.length >= maxResults) return { matches };
+        }
+      }
+    }
+
+    return { matches };
+  },
+};
+
+function globToRegex(glob: string): RegExp {
+  const escaped = glob
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*/g, ".*")
+    .replace(/\?/g, ".");
+  return new RegExp(`^${escaped}$`, "i");
+}

--- a/src/tools/search/semantic.ts
+++ b/src/tools/search/semantic.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+import type { ToolDefinition } from "../tool.ts";
+
+export const searchSemanticTool: ToolDefinition<any, any> = {
+  name: "search_semantic",
+  description:
+    "Semantic search over indexed files using vector embeddings. Finds conceptually related content, not just keyword matches.",
+  group: "search",
+  inputSchema: z.object({
+    query: z.string().describe("Natural language search query"),
+    top_k: z
+      .number()
+      .optional()
+      .default(10)
+      .describe("Maximum number of results to return (defaults to 10)"),
+    threshold: z
+      .number()
+      .optional()
+      .describe("Minimum similarity score (0-1) to include in results"),
+  }),
+  outputSchema: z.object({
+    results: z.array(
+      z.object({
+        path: z.string(),
+        title: z.string(),
+        score: z.number(),
+        snippet: z.string(),
+      }),
+    ),
+  }),
+  execute: async () => {
+    throw new Error(
+      "Semantic search is not yet available — requires the embeddings pipeline (M2)",
+    );
+  },
+};

--- a/src/tools/task/complete.ts
+++ b/src/tools/task/complete.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+import type { ToolDefinition } from "../tool.ts";
+
+export const completeTaskTool: ToolDefinition<any, any> = {
+  name: "complete_task",
+  description:
+    "Mark the current task as complete with a summary of what was accomplished.",
+  group: "task",
+  terminal: true,
+  inputSchema: z.object({
+    summary: z.string().describe("Summary of work done"),
+  }),
+  outputSchema: z.object({
+    message: z.string(),
+  }),
+  execute: async (input) => ({
+    message: `Task completed: ${input.summary}`,
+  }),
+};

--- a/src/tools/task/create.ts
+++ b/src/tools/task/create.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+import type { ToolDefinition } from "../tool.ts";
+import type { Task } from "../../db/tasks.ts";
+import { createTask, TASK_PRIORITIES } from "../../db/tasks.ts";
+import { logger } from "../../utils/logger.ts";
+
+export const createTaskTool: ToolDefinition<any, any> = {
+  name: "create_task",
+  description: "Create a new task to be worked on later.",
+  group: "task",
+  inputSchema: z.object({
+    name: z.string().describe("Task name"),
+    description: z.string().optional().describe("Task description"),
+    priority: z
+      .enum(TASK_PRIORITIES)
+      .optional()
+      .describe("Task priority"),
+    blocked_by: z
+      .array(z.string())
+      .optional()
+      .describe("IDs of tasks that must complete first"),
+  }),
+  outputSchema: z.object({
+    id: z.string(),
+    name: z.string(),
+    message: z.string(),
+  }),
+  execute: async (input, ctx) => {
+    const newTask = await createTask(ctx.conn, {
+      name: input.name,
+      description: input.description,
+      priority: input.priority,
+      blocked_by: input.blocked_by,
+    });
+    logger.info(`Created subtask: ${newTask.name} (${newTask.id})`);
+    return {
+      id: newTask.id,
+      name: newTask.name,
+      message: `Created task "${newTask.name}" with ID ${newTask.id}`,
+    };
+  },
+};

--- a/src/tools/task/fail.ts
+++ b/src/tools/task/fail.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+import type { ToolDefinition } from "../tool.ts";
+
+export const failTaskTool: ToolDefinition<any, any> = {
+  name: "fail_task",
+  description: "Mark the current task as failed with a reason.",
+  group: "task",
+  terminal: true,
+  inputSchema: z.object({
+    reason: z.string().describe("Why the task failed"),
+  }),
+  outputSchema: z.object({
+    message: z.string(),
+  }),
+  execute: async (input) => ({
+    message: `Task failed: ${input.reason}`,
+  }),
+};

--- a/src/tools/task/wait.ts
+++ b/src/tools/task/wait.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+import type { ToolDefinition } from "../tool.ts";
+
+export const waitTaskTool: ToolDefinition<any, any> = {
+  name: "wait_task",
+  description:
+    "Put the task in waiting status (e.g., needs human input, rate limited).",
+  group: "task",
+  terminal: true,
+  inputSchema: z.object({
+    reason: z.string().describe("Why the task is waiting"),
+  }),
+  outputSchema: z.object({
+    message: z.string(),
+  }),
+  execute: async (input) => ({
+    message: `Task waiting: ${input.reason}`,
+  }),
+};

--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -1,0 +1,73 @@
+import { z } from "zod";
+import type { Tool as AnthropicTool } from "@anthropic-ai/sdk/resources/messages";
+import type { DuckDBConnection } from "../db/connection.ts";
+import type { BotholomewConfig } from "../config/schemas.ts";
+
+export interface ToolContext {
+  conn: DuckDBConnection;
+  projectDir: string;
+  config: Required<BotholomewConfig>;
+}
+
+export interface ToolDefinition<
+  TInput extends z.ZodObject,
+  TOutput extends z.ZodType,
+> {
+  name: string;
+  description: string;
+  group: string;
+  terminal?: boolean;
+  inputSchema: TInput;
+  outputSchema: TOutput;
+  execute: (
+    input: z.infer<TInput>,
+    ctx: ToolContext,
+  ) => Promise<z.infer<TOutput>>;
+}
+
+// --- Registry ---
+
+const tools = new Map<string, ToolDefinition<any, any>>();
+
+export function registerTool(tool: ToolDefinition<any, any>): void {
+  tools.set(tool.name, tool);
+}
+
+export function registerTools(toolList: ToolDefinition<any, any>[]): void {
+  for (const tool of toolList) {
+    registerTool(tool);
+  }
+}
+
+export function getTool(name: string): ToolDefinition<any, any> | undefined {
+  return tools.get(name);
+}
+
+export function getAllTools(): ToolDefinition<any, any>[] {
+  return Array.from(tools.values());
+}
+
+export function getToolsByGroup(group: string): ToolDefinition<any, any>[] {
+  return getAllTools().filter((t) => t.group === group);
+}
+
+// --- Anthropic adapter ---
+
+export function toAnthropicTool(
+  tool: ToolDefinition<any, any>,
+): AnthropicTool {
+  const jsonSchema = z.toJSONSchema(tool.inputSchema);
+  return {
+    name: tool.name,
+    description: tool.description,
+    input_schema: {
+      type: "object" as const,
+      properties: jsonSchema.properties ?? {},
+      required: jsonSchema.required as string[] | undefined,
+    },
+  };
+}
+
+export function toAnthropicTools(): AnthropicTool[] {
+  return getAllTools().map(toAnthropicTool);
+}

--- a/test/db/context.test.ts
+++ b/test/db/context.test.ts
@@ -1,0 +1,354 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import {
+  getMemoryConnection,
+  type DuckDBConnection,
+} from "../../src/db/connection.ts";
+import { migrate } from "../../src/db/schema.ts";
+import {
+  createContextItem,
+  getContextItem,
+  getContextItemByPath,
+  listContextItems,
+  listContextItemsByPrefix,
+  contextPathExists,
+  getDistinctDirectories,
+  updateContextItem,
+  updateContextItemContent,
+  applyPatchesToContextItem,
+  copyContextItem,
+  moveContextItem,
+  deleteContextItem,
+  deleteContextItemByPath,
+  deleteContextItemsByPrefix,
+  searchContextByKeyword,
+} from "../../src/db/context.ts";
+
+let conn: DuckDBConnection;
+
+beforeEach(async () => {
+  conn = await getMemoryConnection();
+  await migrate(conn);
+});
+
+describe("context CRUD", () => {
+  test("create and get by id", async () => {
+    const item = await createContextItem(conn, {
+      title: "Test",
+      content: "Hello world",
+      contextPath: "/docs/test.md",
+    });
+    expect(item.id).toBeTruthy();
+    expect(item.title).toBe("Test");
+    expect(item.content).toBe("Hello world");
+    expect(item.context_path).toBe("/docs/test.md");
+    expect(item.mime_type).toBe("text/plain");
+
+    const fetched = await getContextItem(conn, item.id);
+    expect(fetched).not.toBeNull();
+    expect(fetched!.title).toBe("Test");
+  });
+
+  test("get by path", async () => {
+    await createContextItem(conn, {
+      title: "Notes",
+      content: "Some notes",
+      contextPath: "/notes/meeting.md",
+    });
+
+    const item = await getContextItemByPath(conn, "/notes/meeting.md");
+    expect(item).not.toBeNull();
+    expect(item!.title).toBe("Notes");
+
+    const missing = await getContextItemByPath(conn, "/nonexistent");
+    expect(missing).toBeNull();
+  });
+
+  test("list with filters", async () => {
+    await createContextItem(conn, {
+      title: "A",
+      contextPath: "/a.md",
+      content: "a",
+    });
+    await createContextItem(conn, {
+      title: "B",
+      contextPath: "/b.json",
+      content: "b",
+      mimeType: "application/json",
+    });
+
+    const all = await listContextItems(conn);
+    expect(all.length).toBe(2);
+
+    const jsonOnly = await listContextItems(conn, {
+      mimeType: "application/json",
+    });
+    expect(jsonOnly.length).toBe(1);
+    expect(jsonOnly[0]!.title).toBe("B");
+  });
+});
+
+describe("filesystem queries", () => {
+  beforeEach(async () => {
+    await createContextItem(conn, {
+      title: "Root",
+      contextPath: "/readme.md",
+      content: "root",
+    });
+    await createContextItem(conn, {
+      title: "Notes 1",
+      contextPath: "/notes/meeting.md",
+      content: "meeting notes",
+    });
+    await createContextItem(conn, {
+      title: "Notes 2",
+      contextPath: "/notes/ideas.md",
+      content: "ideas",
+    });
+    await createContextItem(conn, {
+      title: "Deep",
+      contextPath: "/notes/archive/old.md",
+      content: "old stuff",
+    });
+  });
+
+  test("listByPrefix non-recursive", async () => {
+    const items = await listContextItemsByPrefix(conn, "/notes");
+    expect(items.length).toBe(2);
+    expect(items.map((i) => i.context_path).sort()).toEqual([
+      "/notes/ideas.md",
+      "/notes/meeting.md",
+    ]);
+  });
+
+  test("listByPrefix recursive", async () => {
+    const items = await listContextItemsByPrefix(conn, "/notes", {
+      recursive: true,
+    });
+    expect(items.length).toBe(3);
+  });
+
+  test("contextPathExists", async () => {
+    expect(await contextPathExists(conn, "/notes/meeting.md")).toBe(true);
+    expect(await contextPathExists(conn, "/nonexistent")).toBe(false);
+  });
+
+  test("getDistinctDirectories", async () => {
+    const dirs = await getDistinctDirectories(conn, "/notes");
+    expect(dirs).toEqual(["/notes/archive"]);
+  });
+});
+
+describe("mutations", () => {
+  test("updateContextItem", async () => {
+    const item = await createContextItem(conn, {
+      title: "Old",
+      contextPath: "/test.md",
+      content: "old content",
+    });
+
+    const updated = await updateContextItem(conn, item.id, {
+      title: "New",
+      content: "new content",
+    });
+    expect(updated).not.toBeNull();
+    expect(updated!.title).toBe("New");
+    expect(updated!.content).toBe("new content");
+  });
+
+  test("updateContextItemContent", async () => {
+    await createContextItem(conn, {
+      title: "Test",
+      contextPath: "/test.md",
+      content: "original",
+    });
+
+    const updated = await updateContextItemContent(
+      conn,
+      "/test.md",
+      "replaced",
+    );
+    expect(updated).not.toBeNull();
+    expect(updated!.content).toBe("replaced");
+  });
+
+  test("applyPatches — replace lines", async () => {
+    await createContextItem(conn, {
+      title: "Test",
+      contextPath: "/test.md",
+      content: "line1\nline2\nline3\nline4",
+    });
+
+    const { item, applied } = await applyPatchesToContextItem(
+      conn,
+      "/test.md",
+      [{ start_line: 2, end_line: 3, content: "replaced" }],
+    );
+
+    expect(applied).toBe(1);
+    expect(item.content).toBe("line1\nreplaced\nline4");
+  });
+
+  test("applyPatches — delete lines", async () => {
+    await createContextItem(conn, {
+      title: "Test",
+      contextPath: "/test.md",
+      content: "line1\nline2\nline3",
+    });
+
+    const { item } = await applyPatchesToContextItem(conn, "/test.md", [
+      { start_line: 2, end_line: 2, content: "" },
+    ]);
+
+    expect(item.content).toBe("line1\nline3");
+  });
+
+  test("applyPatches — insert lines", async () => {
+    await createContextItem(conn, {
+      title: "Test",
+      contextPath: "/test.md",
+      content: "line1\nline2",
+    });
+
+    const { item } = await applyPatchesToContextItem(conn, "/test.md", [
+      { start_line: 2, end_line: 0, content: "inserted" },
+    ]);
+
+    expect(item.content).toBe("line1\ninserted\nline2");
+  });
+
+  test("applyPatches — multiple patches applied bottom-up", async () => {
+    await createContextItem(conn, {
+      title: "Test",
+      contextPath: "/test.md",
+      content: "a\nb\nc\nd\ne",
+    });
+
+    const { item } = await applyPatchesToContextItem(conn, "/test.md", [
+      { start_line: 2, end_line: 2, content: "B" },
+      { start_line: 4, end_line: 4, content: "D" },
+    ]);
+
+    expect(item.content).toBe("a\nB\nc\nD\ne");
+  });
+
+  test("copyContextItem", async () => {
+    await createContextItem(conn, {
+      title: "Original",
+      contextPath: "/src.md",
+      content: "content",
+    });
+
+    const copy = await copyContextItem(conn, "/src.md", "/dst.md");
+    expect(copy.context_path).toBe("/dst.md");
+    expect(copy.content).toBe("content");
+    expect(copy.title).toBe("Original");
+
+    // Original still exists
+    const original = await getContextItemByPath(conn, "/src.md");
+    expect(original).not.toBeNull();
+  });
+
+  test("moveContextItem", async () => {
+    await createContextItem(conn, {
+      title: "Moving",
+      contextPath: "/old.md",
+      content: "content",
+    });
+
+    await moveContextItem(conn, "/old.md", "/new.md");
+
+    expect(await getContextItemByPath(conn, "/old.md")).toBeNull();
+    const moved = await getContextItemByPath(conn, "/new.md");
+    expect(moved).not.toBeNull();
+    expect(moved!.content).toBe("content");
+  });
+});
+
+describe("deletion", () => {
+  test("deleteContextItem by id", async () => {
+    const item = await createContextItem(conn, {
+      title: "Test",
+      contextPath: "/test.md",
+      content: "x",
+    });
+
+    const deleted = await deleteContextItem(conn, item.id);
+    expect(deleted).toBe(true);
+    expect(await getContextItem(conn, item.id)).toBeNull();
+  });
+
+  test("deleteContextItemByPath", async () => {
+    await createContextItem(conn, {
+      title: "Test",
+      contextPath: "/test.md",
+      content: "x",
+    });
+
+    const deleted = await deleteContextItemByPath(conn, "/test.md");
+    expect(deleted).toBe(true);
+    expect(await getContextItemByPath(conn, "/test.md")).toBeNull();
+  });
+
+  test("deleteContextItemsByPrefix", async () => {
+    await createContextItem(conn, {
+      title: "A",
+      contextPath: "/dir/a.md",
+      content: "a",
+    });
+    await createContextItem(conn, {
+      title: "B",
+      contextPath: "/dir/b.md",
+      content: "b",
+    });
+    await createContextItem(conn, {
+      title: "Outside",
+      contextPath: "/other.md",
+      content: "c",
+    });
+
+    const count = await deleteContextItemsByPrefix(conn, "/dir");
+    expect(count).toBe(2);
+    expect(await contextPathExists(conn, "/other.md")).toBe(true);
+  });
+});
+
+describe("search", () => {
+  test("searchContextByKeyword finds by content", async () => {
+    await createContextItem(conn, {
+      title: "Meeting",
+      contextPath: "/notes/meeting.md",
+      content: "Discussed quarterly revenue targets",
+    });
+    await createContextItem(conn, {
+      title: "Ideas",
+      contextPath: "/notes/ideas.md",
+      content: "Random brainstorm",
+    });
+
+    const results = await searchContextByKeyword(conn, "revenue");
+    expect(results.length).toBe(1);
+    expect(results[0]!.title).toBe("Meeting");
+  });
+
+  test("searchContextByKeyword finds by title", async () => {
+    await createContextItem(conn, {
+      title: "Budget Report",
+      contextPath: "/reports/budget.md",
+      content: "Numbers here",
+    });
+
+    const results = await searchContextByKeyword(conn, "budget");
+    expect(results.length).toBe(1);
+  });
+
+  test("searchContextByKeyword is case-insensitive", async () => {
+    await createContextItem(conn, {
+      title: "Test",
+      contextPath: "/test.md",
+      content: "Hello World",
+    });
+
+    const results = await searchContextByKeyword(conn, "hello world");
+    expect(results.length).toBe(1);
+  });
+});

--- a/test/tools/tool.test.ts
+++ b/test/tools/tool.test.ts
@@ -1,0 +1,142 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { z } from "zod";
+
+// Fresh-import the module each test to reset the registry
+let registerTool: typeof import("../../src/tools/tool.ts").registerTool;
+let getTool: typeof import("../../src/tools/tool.ts").getTool;
+let getAllTools: typeof import("../../src/tools/tool.ts").getAllTools;
+let getToolsByGroup: typeof import("../../src/tools/tool.ts").getToolsByGroup;
+let toAnthropicTool: typeof import("../../src/tools/tool.ts").toAnthropicTool;
+let toAnthropicTools: typeof import("../../src/tools/tool.ts").toAnthropicTools;
+
+// Since the registry is module-level state, we import once and test with unique names
+beforeEach(async () => {
+  const mod = await import("../../src/tools/tool.ts");
+  registerTool = mod.registerTool;
+  getTool = mod.getTool;
+  getAllTools = mod.getAllTools;
+  getToolsByGroup = mod.getToolsByGroup;
+  toAnthropicTool = mod.toAnthropicTool;
+  toAnthropicTools = mod.toAnthropicTools;
+});
+
+function makeTool(overrides: Partial<Parameters<typeof registerTool>[0]> = {}) {
+  return {
+    name: `test_${Date.now()}_${Math.random()}`,
+    description: "A test tool",
+    group: "test",
+    inputSchema: z.object({
+      path: z.string().describe("A file path"),
+    }),
+    outputSchema: z.object({
+      content: z.string(),
+    }),
+    execute: async () => ({ content: "ok" }),
+    ...overrides,
+  };
+}
+
+describe("Tool registry", () => {
+  test("registerTool adds tool to registry", () => {
+    const tool = makeTool();
+    registerTool(tool);
+    expect(getTool(tool.name)).toBe(tool);
+  });
+
+  test("getTool returns undefined for unknown tool", () => {
+    expect(getTool("nonexistent_tool_xyz")).toBeUndefined();
+  });
+
+  test("getAllTools includes registered tools", () => {
+    const tool = makeTool();
+    registerTool(tool);
+    const all = getAllTools();
+    expect(all.some((t) => t.name === tool.name)).toBe(true);
+  });
+
+  test("getToolsByGroup filters by group", () => {
+    const toolA = makeTool({ group: "alpha" });
+    const toolB = makeTool({ group: "beta" });
+    registerTool(toolA);
+    registerTool(toolB);
+
+    const alphaTools = getToolsByGroup("alpha");
+    expect(alphaTools.some((t) => t.name === toolA.name)).toBe(true);
+    expect(alphaTools.some((t) => t.name === toolB.name)).toBe(false);
+  });
+});
+
+describe("Anthropic adapter", () => {
+  test("toAnthropicTool produces valid tool definition", () => {
+    const tool = makeTool({
+      name: "anthro_test",
+      description: "Test description",
+      inputSchema: z.object({
+        path: z.string().describe("Virtual path"),
+        limit: z.number().optional().describe("Max results"),
+      }),
+    });
+
+    const result = toAnthropicTool(tool);
+
+    expect(result.name).toBe("anthro_test");
+    expect(result.description).toBe("Test description");
+    expect(result.input_schema.type).toBe("object");
+    expect(result.input_schema.properties).toEqual({
+      path: { type: "string", description: "Virtual path" },
+      limit: { type: "number", description: "Max results" },
+    });
+    expect(result.input_schema.required).toEqual(["path"]);
+  });
+
+  test("toAnthropicTools converts all registered tools", () => {
+    const tool = makeTool();
+    registerTool(tool);
+    const all = toAnthropicTools();
+    expect(all.some((t) => t.name === tool.name)).toBe(true);
+    expect(all.every((t) => t.input_schema.type === "object")).toBe(true);
+  });
+});
+
+describe("Tool execution", () => {
+  test("execute receives validated input and returns typed output", async () => {
+    const tool = makeTool({
+      inputSchema: z.object({
+        path: z.string(),
+        offset: z.number().optional(),
+      }),
+      outputSchema: z.object({
+        content: z.string(),
+        lines: z.number(),
+      }),
+      execute: async (input) => ({
+        content: `read: ${input.path}`,
+        lines: input.offset ?? 0,
+      }),
+    });
+
+    const result = await tool.execute(
+      { path: "/test.md" },
+      {} as any, // ctx not needed for this test
+    );
+    expect(result.content).toBe("read: /test.md");
+    expect(result.lines).toBe(0);
+  });
+
+  test("inputSchema validates input", () => {
+    const tool = makeTool({
+      inputSchema: z.object({
+        path: z.string(),
+      }),
+    });
+
+    const good = tool.inputSchema.safeParse({ path: "/test" });
+    expect(good.success).toBe(true);
+
+    const bad = tool.inputSchema.safeParse({ path: 123 });
+    expect(bad.success).toBe(false);
+
+    const missing = tool.inputSchema.safeParse({});
+    expect(missing.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Introduces a `Tool` base class (`src/tools/tool.ts`) with Zod-validated input/output schemas that auto-generate both Anthropic API tool definitions and Commander CLI subcommands from a single definition
- Implements 19 tools across 4 groups: task (4, migrated from hand-written), dir (4), file (9), and search (2 + semantic stub) — all backed by a virtual filesystem over the `context_items` table in DuckDB
- Expands `src/db/context.ts` from a stub to full CRUD with filesystem-oriented queries (list by prefix, path exists, patches, copy, move, recursive delete, keyword search)
- Refactors the daemon agent loop to use the tool registry instead of hand-written tool schemas and switch/case dispatch
- Adds `zod` and `istextorbinary` dependencies; removes `zod-to-json-schema` in favor of Zod v4's built-in `z.toJSONSchema()`

## Test plan

- [x] `bun test` — 62 tests pass (21 new context DB tests, 8 new tool registry tests)
- [x] End-to-end CLI: `file write`, `file read`, `dir list`, `dir tree`, `search grep`, `file edit`, `file exists`
- [x] Daemon tick test still passes with refactored tool dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)