### PR TITLE
Eliminate all explicit any types and fix all lint warnings

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
   "files": {
     "includes": ["src/**", "test/**"]
   },

--- a/src/commands/tools.ts
+++ b/src/commands/tools.ts
@@ -7,9 +7,9 @@ import { getConnection } from "../db/connection.ts";
 import { migrate } from "../db/schema.ts";
 import { registerAllTools } from "../tools/registry.ts";
 import {
+  type AnyToolDefinition,
   getToolsByGroup,
   type ToolContext,
-  type ToolDefinition,
 } from "../tools/tool.ts";
 import { logger } from "../utils/logger.ts";
 
@@ -35,7 +35,7 @@ export function registerToolCommands(program: Command) {
 
 function registerToolAsCLI(
   parent: Command,
-  tool: ToolDefinition<any, any>,
+  tool: AnyToolDefinition,
   program: Command,
 ) {
   // Derive subcommand name: "file_read" → "read", "file_count_lines" → "count-lines"
@@ -120,7 +120,7 @@ function registerToolAsCLI(
 }
 
 function buildInput(
-  tool: ToolDefinition<any, any>,
+  tool: AnyToolDefinition,
   positionals: string[],
   options: {
     key: string;
@@ -135,9 +135,9 @@ function buildInput(
 
   // Positional args come first in Commander's action callback
   for (let i = 0; i < positionals.length; i++) {
-    const key = positionals[i]!.replace(/[<>[\]]/g, "");
+    const key = positionals[i]?.replace(/[<>[\]]/g, "");
     const value = args[i];
-    if (value !== undefined) input[key] = value;
+    if (key !== undefined && value !== undefined) input[key] = value;
   }
 
   // Options object is the last argument before the Command object
@@ -151,7 +151,9 @@ function buildInput(
 
     if (value === undefined) continue;
 
-    const unwrapped = unwrapOptional(shape[opt.key]!);
+    const schemaForKey = shape[opt.key];
+    if (!schemaForKey) continue;
+    const unwrapped = unwrapOptional(schemaForKey);
 
     // Parse JSON for array types
     if (opt.isArray && typeof value === "string") {
@@ -174,7 +176,7 @@ function buildInput(
   return parsed.data;
 }
 
-function formatOutput(result: unknown, toolName: string) {
+function formatOutput(result: unknown, _toolName: string) {
   if (result == null) return;
 
   if (typeof result === "object") {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -27,5 +27,5 @@ export async function saveConfig(
   config: Partial<BotholomewConfig>,
 ): Promise<void> {
   const configPath = getConfigPath(projectDir);
-  await Bun.write(configPath, JSON.stringify(config, null, 2) + "\n");
+  await Bun.write(configPath, `${JSON.stringify(config, null, 2)}\n`);
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-import { join } from "path";
+import { join } from "node:path";
 
 export const BOTHOLOMEW_DIR = ".botholomew";
 export const DB_FILENAME = "data.duckdb";

--- a/src/daemon/llm.ts
+++ b/src/daemon/llm.ts
@@ -1,7 +1,6 @@
 import Anthropic from "@anthropic-ai/sdk";
 import type {
   MessageParam,
-  Tool,
   ToolResultBlockParam,
   ToolUseBlock,
 } from "@anthropic-ai/sdk/resources/messages";
@@ -11,7 +10,6 @@ import type { Task } from "../db/tasks.ts";
 import { logInteraction } from "../db/threads.ts";
 import { registerAllTools } from "../tools/registry.ts";
 import { getTool, type ToolContext, toAnthropicTools } from "../tools/tool.ts";
-import { logger } from "../utils/logger.ts";
 
 registerAllTools();
 
@@ -125,8 +123,8 @@ export async function runAgentLoop(input: {
         durationMs: toolDuration,
       });
 
-      if (result.terminal) {
-        return result.agentResult!;
+      if (result.terminal && result.agentResult) {
+        return result.agentResult;
       }
 
       toolResults.push({

--- a/src/daemon/prompt.ts
+++ b/src/daemon/prompt.ts
@@ -1,5 +1,5 @@
-import { readdir } from "fs/promises";
-import { join } from "path";
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
 import { getBotholomewDir } from "../constants.ts";
 import { parseContextFile } from "../utils/frontmatter.ts";
 

--- a/src/daemon/spawn.ts
+++ b/src/daemon/spawn.ts
@@ -1,4 +1,4 @@
-import { join } from "path";
+import { join } from "node:path";
 import { getBotholomewDir, getLogPath } from "../constants.ts";
 import { logger } from "../utils/logger.ts";
 import { isProcessAlive, readPidFile } from "../utils/pid.ts";

--- a/src/db/context.ts
+++ b/src/db/context.ts
@@ -68,7 +68,9 @@ export async function createContextItem(
     )
     RETURNING *
   `);
-  return rowToContextItem(result.getRows()[0]!);
+  const row = result.getRows()[0];
+  if (!row) throw new Error("INSERT did not return a row");
+  return rowToContextItem(row);
 }
 
 export async function getContextItem(
@@ -79,7 +81,7 @@ export async function getContextItem(
     `SELECT * FROM context_items WHERE id = '${escapeSql(id)}'`,
   );
   const rows = result.getRows();
-  return rows.length > 0 ? rowToContextItem(rows[0]!) : null;
+  return rows[0] ? rowToContextItem(rows[0]) : null;
 }
 
 export async function getContextItemByPath(
@@ -90,7 +92,7 @@ export async function getContextItemByPath(
     `SELECT * FROM context_items WHERE context_path = '${escapeSql(contextPath)}'`,
   );
   const rows = result.getRows();
-  return rows.length > 0 ? rowToContextItem(rows[0]!) : null;
+  return rows[0] ? rowToContextItem(rows[0]) : null;
 }
 
 export async function listContextItems(
@@ -212,7 +214,7 @@ export async function updateContextItem(
     RETURNING *
   `);
   const rows = result.getRows();
-  return rows.length > 0 ? rowToContextItem(rows[0]!) : null;
+  return rows[0] ? rowToContextItem(rows[0]) : null;
 }
 
 export async function updateContextItemContent(
@@ -227,7 +229,7 @@ export async function updateContextItemContent(
     RETURNING *
   `);
   const rows = result.getRows();
-  return rows.length > 0 ? rowToContextItem(rows[0]!) : null;
+  return rows[0] ? rowToContextItem(rows[0]) : null;
 }
 
 export async function applyPatchesToContextItem(

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,5 +1,5 @@
-import { readdirSync, readFileSync } from "fs";
-import { join } from "path";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import type { DuckDBConnection } from "./connection.ts";
 
 interface Migration {
@@ -18,9 +18,12 @@ function loadMigrations(): Migration[] {
   return files.map((file) => {
     const match = file.match(/^(\d+)-(.+)\.sql$/);
     if (!match) throw new Error(`Invalid migration filename: ${file}`);
+    const id = match[1];
+    const name = match[2];
+    if (!id || !name) throw new Error(`Invalid migration filename: ${file}`);
     return {
-      id: parseInt(match[1]!, 10),
-      name: match[2]!,
+      id: parseInt(id, 10),
+      name,
       sql: readFileSync(join(sqlDir, file), "utf-8"),
     };
   });

--- a/src/db/tasks.ts
+++ b/src/db/tasks.ts
@@ -63,7 +63,9 @@ export async function createTask(
     VALUES ('${escapeSql(params.name)}', '${escapeSql(params.description ?? "")}', '${params.priority ?? "medium"}', ${blockedBy}, ${contextIds})
     RETURNING *
   `);
-  return rowToTask(result.getRows()[0]!);
+  const row = result.getRows()[0];
+  if (!row) throw new Error("INSERT did not return a row");
+  return rowToTask(row);
 }
 
 export async function getTask(
@@ -74,7 +76,7 @@ export async function getTask(
     `SELECT * FROM tasks WHERE id = '${escapeSql(id)}'`,
   );
   const rows = result.getRows();
-  return rows.length > 0 ? rowToTask(rows[0]!) : null;
+  return rows[0] ? rowToTask(rows[0]) : null;
 }
 
 export async function listTasks(
@@ -145,7 +147,9 @@ export async function claimNextTask(
   const rows = result.getRows();
   if (rows.length === 0) return null;
 
-  const task = rowToTask(rows[0]!);
+  const firstRow = rows[0];
+  if (!firstRow) return null;
+  const task = rowToTask(firstRow);
 
   // Claim it atomically
   await conn.run(`

--- a/src/db/threads.ts
+++ b/src/db/threads.ts
@@ -72,7 +72,7 @@ export async function createThread(
     VALUES ('${type}', ${taskIdVal}, ${titleVal})
     RETURNING id
   `);
-  return String(result.getRows()[0]![0]);
+  return String(result.getRows()[0]?.[0]);
 }
 
 export async function logInteraction(
@@ -92,7 +92,7 @@ export async function logInteraction(
   const seqResult = await conn.runAndReadAll(`
     SELECT COALESCE(MAX(sequence), 0) + 1 FROM interactions WHERE thread_id = '${escapeSql(threadId)}'
   `);
-  const sequence = Number(seqResult.getRows()[0]![0]);
+  const sequence = Number(seqResult.getRows()[0]?.[0]);
 
   const toolName = params.toolName ? `'${escapeSql(params.toolName)}'` : "NULL";
   const toolInput = params.toolInput
@@ -106,7 +106,7 @@ export async function logInteraction(
     VALUES ('${escapeSql(threadId)}', ${sequence}, '${params.role}', '${params.kind}', '${escapeSql(params.content)}', ${toolName}, ${toolInput}, ${durationMs}, ${tokenCount})
     RETURNING id
   `);
-  return String(result.getRows()[0]![0]);
+  return String(result.getRows()[0]?.[0]);
 }
 
 export async function endThread(
@@ -126,14 +126,15 @@ export async function getThread(
     `SELECT * FROM threads WHERE id = '${escapeSql(threadId)}'`,
   );
   const threadRows = threadResult.getRows();
-  if (threadRows.length === 0) return null;
+  const firstRow = threadRows[0];
+  if (!firstRow) return null;
 
   const interactionsResult = await conn.runAndReadAll(`
     SELECT * FROM interactions WHERE thread_id = '${escapeSql(threadId)}' ORDER BY sequence ASC
   `);
 
   return {
-    thread: rowToThread(threadRows[0]!),
+    thread: rowToThread(firstRow),
     interactions: interactionsResult.getRows().map(rowToInteraction),
   };
 }

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -1,5 +1,5 @@
-import { mkdir } from "fs/promises";
-import { join } from "path";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
 import { getBotholomewDir, getDbPath, getMcpxDir } from "../constants.ts";
 import { getConnection } from "../db/connection.ts";
 import { migrate } from "../db/schema.ts";
@@ -39,13 +39,13 @@ export async function initProject(
   // Write config (without API key)
   await Bun.write(
     join(dotDir, "config.json"),
-    JSON.stringify(DEFAULT_CONFIG, null, 2) + "\n",
+    `${JSON.stringify(DEFAULT_CONFIG, null, 2)}\n`,
   );
 
   // Write mcpx servers config
   await Bun.write(
     join(mcpxDir, "servers.json"),
-    JSON.stringify(DEFAULT_MCPX_SERVERS, null, 2) + "\n",
+    `${JSON.stringify(DEFAULT_MCPX_SERVERS, null, 2)}\n`,
   );
 
   // Initialize database
@@ -79,6 +79,6 @@ async function updateGitignore(projectDir: string): Promise<void> {
   const entry = ".botholomew/";
   if (content.includes(entry)) return;
 
-  const section = "\n# Botholomew (auto-generated)\n" + entry + "\n";
-  await Bun.write(gitignorePath, content.trimEnd() + "\n" + section);
+  const section = `\n# Botholomew (auto-generated)\n${entry}\n`;
+  await Bun.write(gitignorePath, `${content.trimEnd()}\n${section}`);
 }

--- a/src/tools/dir/create.ts
+++ b/src/tools/dir/create.ts
@@ -2,21 +2,25 @@ import { z } from "zod";
 import { contextPathExists, createContextItem } from "../../db/context.ts";
 import type { ToolDefinition } from "../tool.ts";
 
-export const dirCreateTool: ToolDefinition<any, any> = {
+const inputSchema = z.object({
+  path: z.string().describe("Directory path to create"),
+  parents: z
+    .boolean()
+    .optional()
+    .describe("Create parent directories as needed"),
+});
+
+const outputSchema = z.object({
+  created: z.boolean(),
+  path: z.string(),
+});
+
+export const dirCreateTool = {
   name: "dir_create",
   description: "Create a directory in the virtual filesystem.",
   group: "dir",
-  inputSchema: z.object({
-    path: z.string().describe("Directory path to create"),
-    parents: z
-      .boolean()
-      .optional()
-      .describe("Create parent directories as needed"),
-  }),
-  outputSchema: z.object({
-    created: z.boolean(),
-    path: z.string(),
-  }),
+  inputSchema,
+  outputSchema,
   execute: async (input, ctx) => {
     const exists = await contextPathExists(ctx.conn, input.path);
     if (exists) {
@@ -32,4 +36,4 @@ export const dirCreateTool: ToolDefinition<any, any> = {
 
     return { created: true, path: input.path };
   },
-};
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/dir/list.ts
+++ b/src/tools/dir/list.ts
@@ -11,32 +11,36 @@ const DirEntrySchema = z.object({
   size: z.number(),
 });
 
-export const dirListTool: ToolDefinition<any, any> = {
+const inputSchema = z.object({
+  path: z.string().optional().describe("Directory path (defaults to /)"),
+  recursive: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe("Include contents of subdirectories (defaults to true)"),
+  limit: z
+    .number()
+    .optional()
+    .default(100)
+    .describe("Maximum number of entries to return (defaults to 100)"),
+  offset: z
+    .number()
+    .optional()
+    .default(0)
+    .describe("Number of entries to skip (defaults to 0)"),
+});
+
+const outputSchema = z.object({
+  entries: z.array(DirEntrySchema),
+  total: z.number(),
+});
+
+export const dirListTool = {
   name: "dir_list",
   description: "List directory contents in the virtual filesystem.",
   group: "dir",
-  inputSchema: z.object({
-    path: z.string().optional().describe("Directory path (defaults to /)"),
-    recursive: z
-      .boolean()
-      .optional()
-      .default(true)
-      .describe("Include contents of subdirectories (defaults to true)"),
-    limit: z
-      .number()
-      .optional()
-      .default(100)
-      .describe("Maximum number of entries to return (defaults to 100)"),
-    offset: z
-      .number()
-      .optional()
-      .default(0)
-      .describe("Number of entries to skip (defaults to 0)"),
-  }),
-  outputSchema: z.object({
-    entries: z.array(DirEntrySchema),
-    total: z.number(),
-  }),
+  inputSchema,
+  outputSchema,
   execute: async (input, ctx) => {
     const path = input.path ?? "/";
     const recursive = input.recursive ?? true;
@@ -80,4 +84,4 @@ export const dirListTool: ToolDefinition<any, any> = {
 
     return { entries: paginated, total };
   },
-};
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/dir/size.ts
+++ b/src/tools/dir/size.ts
@@ -10,21 +10,25 @@ function formatBytes(bytes: number): string {
   return `${value.toFixed(i > 0 ? 1 : 0)} ${units[i]}`;
 }
 
-export const dirSizeTool: ToolDefinition<any, any> = {
+const inputSchema = z.object({
+  path: z.string().optional().describe("Directory path (defaults to /)"),
+  recursive: z
+    .boolean()
+    .optional()
+    .describe("Include subdirectories (defaults to true)"),
+});
+
+const outputSchema = z.object({
+  bytes: z.number(),
+  formatted: z.string(),
+});
+
+export const dirSizeTool = {
   name: "dir_size",
   description: "Get the total size of files in a directory.",
   group: "dir",
-  inputSchema: z.object({
-    path: z.string().optional().describe("Directory path (defaults to /)"),
-    recursive: z
-      .boolean()
-      .optional()
-      .describe("Include subdirectories (defaults to true)"),
-  }),
-  outputSchema: z.object({
-    bytes: z.number(),
-    formatted: z.string(),
-  }),
+  inputSchema,
+  outputSchema,
   execute: async (input, ctx) => {
     const path = input.path ?? "/";
     const items = await listContextItemsByPrefix(ctx.conn, path, {
@@ -38,4 +42,4 @@ export const dirSizeTool: ToolDefinition<any, any> = {
 
     return { bytes, formatted: formatBytes(bytes) };
   },
-};
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/dir/tree.ts
+++ b/src/tools/dir/tree.ts
@@ -4,27 +4,31 @@ import type { ToolDefinition } from "../tool.ts";
 
 const DEFAULT_MAX_ITEMS = 200;
 
-export const dirTreeTool: ToolDefinition<any, any> = {
+const inputSchema = z.object({
+  path: z
+    .string()
+    .optional()
+    .describe("Root path for the tree (defaults to /)"),
+  max_items: z
+    .number()
+    .optional()
+    .default(DEFAULT_MAX_ITEMS)
+    .describe(
+      `Maximum number of items to include (defaults to ${DEFAULT_MAX_ITEMS})`,
+    ),
+});
+
+const outputSchema = z.object({
+  tree: z.string(),
+});
+
+export const dirTreeTool = {
   name: "dir_tree",
   description:
     "Render a directory as a markdown-style tree in the virtual filesystem.",
   group: "dir",
-  inputSchema: z.object({
-    path: z
-      .string()
-      .optional()
-      .describe("Root path for the tree (defaults to /)"),
-    max_items: z
-      .number()
-      .optional()
-      .default(DEFAULT_MAX_ITEMS)
-      .describe(
-        `Maximum number of items to include (defaults to ${DEFAULT_MAX_ITEMS})`,
-      ),
-  }),
-  outputSchema: z.object({
-    tree: z.string(),
-  }),
+  inputSchema,
+  outputSchema,
   execute: async (input, ctx) => {
     const path = input.path ?? "/";
     const maxItems = input.max_items ?? DEFAULT_MAX_ITEMS;
@@ -65,14 +69,15 @@ export const dirTreeTool: ToolDefinition<any, any> = {
     ].sort((a, b) => a.path.localeCompare(b.path));
 
     for (let i = 0; i < allEntries.length; i++) {
-      const entry = allEntries[i]!;
+      const entry = allEntries[i];
+      if (!entry) continue;
       const depth = entry.path.split("/").length - 1;
       const isLast =
         i === allEntries.length - 1 ||
-        allEntries[i + 1]!.path.split("/").length - 1 <= depth;
+        (allEntries[i + 1]?.path.split("/").length ?? 0) - 1 <= depth;
       const prefix = isLast ? "└── " : "├── ";
       const indent = "│   ".repeat(depth);
-      const name = entry.path.split("/").pop()!;
+      const name = entry.path.split("/").pop() ?? "";
       const suffix = entry.isDir ? "/" : "";
       lines.push(`${indent}${prefix}${name}${suffix}`);
     }
@@ -83,4 +88,4 @@ export const dirTreeTool: ToolDefinition<any, any> = {
 
     return { tree: lines.join("\n") };
   },
-};
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/file/copy.ts
+++ b/src/tools/file/copy.ts
@@ -2,22 +2,23 @@ import { z } from "zod";
 import { contextPathExists, copyContextItem } from "../../db/context.ts";
 import type { ToolDefinition } from "../tool.ts";
 
-export const fileCopyTool: ToolDefinition<any, any> = {
+const inputSchema = z.object({
+  src: z.string().describe("Source file path"),
+  dst: z.string().describe("Destination file path"),
+  overwrite: z.boolean().optional().describe("Overwrite if destination exists"),
+});
+
+const outputSchema = z.object({
+  id: z.string(),
+  path: z.string(),
+});
+
+export const fileCopyTool = {
   name: "file_copy",
   description: "Copy a file in the virtual filesystem.",
   group: "file",
-  inputSchema: z.object({
-    src: z.string().describe("Source file path"),
-    dst: z.string().describe("Destination file path"),
-    overwrite: z
-      .boolean()
-      .optional()
-      .describe("Overwrite if destination exists"),
-  }),
-  outputSchema: z.object({
-    id: z.string(),
-    path: z.string(),
-  }),
+  inputSchema,
+  outputSchema,
   execute: async (input, ctx) => {
     if (!input.overwrite && (await contextPathExists(ctx.conn, input.dst))) {
       throw new Error(`Destination already exists: ${input.dst}`);
@@ -26,4 +27,4 @@ export const fileCopyTool: ToolDefinition<any, any> = {
     const item = await copyContextItem(ctx.conn, input.src, input.dst);
     return { id: item.id, path: item.context_path };
   },
-};
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/file/count-lines.ts
+++ b/src/tools/file/count-lines.ts
@@ -2,16 +2,20 @@ import { z } from "zod";
 import { getContextItemByPath } from "../../db/context.ts";
 import type { ToolDefinition } from "../tool.ts";
 
-export const fileCountLinesTool: ToolDefinition<any, any> = {
+const inputSchema = z.object({
+  path: z.string().describe("File path"),
+});
+
+const outputSchema = z.object({
+  lines: z.number(),
+});
+
+export const fileCountLinesTool = {
   name: "file_count_lines",
   description: "Count the number of lines in a text file.",
   group: "file",
-  inputSchema: z.object({
-    path: z.string().describe("File path"),
-  }),
-  outputSchema: z.object({
-    lines: z.number(),
-  }),
+  inputSchema,
+  outputSchema,
   execute: async (input, ctx) => {
     const item = await getContextItemByPath(ctx.conn, input.path);
     if (!item) throw new Error(`Not found: ${input.path}`);
@@ -19,4 +23,4 @@ export const fileCountLinesTool: ToolDefinition<any, any> = {
 
     return { lines: item.content.split("\n").length };
   },
-};
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/file/delete.ts
+++ b/src/tools/file/delete.ts
@@ -5,24 +5,28 @@ import {
 } from "../../db/context.ts";
 import type { ToolDefinition } from "../tool.ts";
 
-export const fileDeleteTool: ToolDefinition<any, any> = {
+const inputSchema = z.object({
+  path: z.string().describe("Path to delete"),
+  recursive: z
+    .boolean()
+    .optional()
+    .describe("Delete all items under this path prefix"),
+  force: z
+    .boolean()
+    .optional()
+    .describe("Do not error if the path does not exist"),
+});
+
+const outputSchema = z.object({
+  deleted: z.number(),
+});
+
+export const fileDeleteTool = {
   name: "file_delete",
   description: "Delete a file or directory from the virtual filesystem.",
   group: "file",
-  inputSchema: z.object({
-    path: z.string().describe("Path to delete"),
-    recursive: z
-      .boolean()
-      .optional()
-      .describe("Delete all items under this path prefix"),
-    force: z
-      .boolean()
-      .optional()
-      .describe("Do not error if the path does not exist"),
-  }),
-  outputSchema: z.object({
-    deleted: z.number(),
-  }),
+  inputSchema,
+  outputSchema,
   execute: async (input, ctx) => {
     if (input.recursive) {
       const count = await deleteContextItemsByPrefix(ctx.conn, input.path);
@@ -36,4 +40,4 @@ export const fileDeleteTool: ToolDefinition<any, any> = {
     }
     return { deleted: deleted ? 1 : 0 };
   },
-};
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/file/edit.ts
+++ b/src/tools/file/edit.ts
@@ -12,19 +12,23 @@ const PatchSchema = z.object({
     .describe("Replacement text (empty string to delete lines)"),
 });
 
-export const fileEditTool: ToolDefinition<any, any> = {
+const inputSchema = z.object({
+  path: z.string().describe("File path to edit"),
+  patches: z.array(PatchSchema).describe("Patches to apply"),
+});
+
+const outputSchema = z.object({
+  applied: z.number(),
+  content: z.string(),
+});
+
+export const fileEditTool = {
   name: "file_edit",
   description:
     "Apply git-style patches to a file. Each patch specifies a line range to replace.",
   group: "file",
-  inputSchema: z.object({
-    path: z.string().describe("File path to edit"),
-    patches: z.array(PatchSchema).describe("Patches to apply"),
-  }),
-  outputSchema: z.object({
-    applied: z.number(),
-    content: z.string(),
-  }),
+  inputSchema,
+  outputSchema,
   execute: async (input, ctx) => {
     const { item, applied } = await applyPatchesToContextItem(
       ctx.conn,
@@ -33,4 +37,4 @@ export const fileEditTool: ToolDefinition<any, any> = {
     );
     return { applied, content: item.content ?? "" };
   },
-};
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/file/exists.ts
+++ b/src/tools/file/exists.ts
@@ -2,18 +2,22 @@ import { z } from "zod";
 import { contextPathExists } from "../../db/context.ts";
 import type { ToolDefinition } from "../tool.ts";
 
-export const fileExistsTool: ToolDefinition<any, any> = {
+const inputSchema = z.object({
+  path: z.string().describe("File path to check"),
+});
+
+const outputSchema = z.object({
+  exists: z.boolean(),
+});
+
+export const fileExistsTool = {
   name: "file_exists",
   description: "Check if a file exists in the virtual filesystem.",
   group: "file",
-  inputSchema: z.object({
-    path: z.string().describe("File path to check"),
-  }),
-  outputSchema: z.object({
-    exists: z.boolean(),
-  }),
+  inputSchema,
+  outputSchema,
   execute: async (input, ctx) => {
     const exists = await contextPathExists(ctx.conn, input.path);
     return { exists };
   },
-};
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/file/info.ts
+++ b/src/tools/file/info.ts
@@ -2,27 +2,31 @@ import { z } from "zod";
 import { getContextItemByPath } from "../../db/context.ts";
 import type { ToolDefinition } from "../tool.ts";
 
-export const fileInfoTool: ToolDefinition<any, any> = {
+const inputSchema = z.object({
+  path: z.string().describe("File path"),
+});
+
+const outputSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  description: z.string(),
+  mime_type: z.string(),
+  is_textual: z.boolean(),
+  size: z.number(),
+  lines: z.number(),
+  source_path: z.string().nullable(),
+  context_path: z.string(),
+  indexed_at: z.string().nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+
+export const fileInfoTool = {
   name: "file_info",
   description: "Show file metadata (size, MIME type, line count, etc.).",
   group: "file",
-  inputSchema: z.object({
-    path: z.string().describe("File path"),
-  }),
-  outputSchema: z.object({
-    id: z.string(),
-    title: z.string(),
-    description: z.string(),
-    mime_type: z.string(),
-    is_textual: z.boolean(),
-    size: z.number(),
-    lines: z.number(),
-    source_path: z.string().nullable(),
-    context_path: z.string(),
-    indexed_at: z.string().nullable(),
-    created_at: z.string(),
-    updated_at: z.string(),
-  }),
+  inputSchema,
+  outputSchema,
   execute: async (input, ctx) => {
     const item = await getContextItemByPath(ctx.conn, input.path);
     if (!item) throw new Error(`Not found: ${input.path}`);
@@ -43,4 +47,4 @@ export const fileInfoTool: ToolDefinition<any, any> = {
       updated_at: item.updated_at.toISOString(),
     };
   },
-};
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/file/move.ts
+++ b/src/tools/file/move.ts
@@ -2,21 +2,22 @@ import { z } from "zod";
 import { contextPathExists, moveContextItem } from "../../db/context.ts";
 import type { ToolDefinition } from "../tool.ts";
 
-export const fileMoveTool: ToolDefinition<any, any> = {
+const inputSchema = z.object({
+  src: z.string().describe("Source file path"),
+  dst: z.string().describe("Destination file path"),
+  overwrite: z.boolean().optional().describe("Overwrite if destination exists"),
+});
+
+const outputSchema = z.object({
+  path: z.string(),
+});
+
+export const fileMoveTool = {
   name: "file_move",
   description: "Move or rename a file in the virtual filesystem.",
   group: "file",
-  inputSchema: z.object({
-    src: z.string().describe("Source file path"),
-    dst: z.string().describe("Destination file path"),
-    overwrite: z
-      .boolean()
-      .optional()
-      .describe("Overwrite if destination exists"),
-  }),
-  outputSchema: z.object({
-    path: z.string(),
-  }),
+  inputSchema,
+  outputSchema,
   execute: async (input, ctx) => {
     if (!input.overwrite && (await contextPathExists(ctx.conn, input.dst))) {
       throw new Error(`Destination already exists: ${input.dst}`);
@@ -25,4 +26,4 @@ export const fileMoveTool: ToolDefinition<any, any> = {
     await moveContextItem(ctx.conn, input.src, input.dst);
     return { path: input.dst };
   },
-};
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/file/read.ts
+++ b/src/tools/file/read.ts
@@ -2,21 +2,25 @@ import { z } from "zod";
 import { getContextItemByPath } from "../../db/context.ts";
 import type { ToolDefinition } from "../tool.ts";
 
-export const fileReadTool: ToolDefinition<any, any> = {
+const inputSchema = z.object({
+  path: z.string().describe("File path to read"),
+  offset: z
+    .number()
+    .optional()
+    .describe("Line number to start reading from (1-based)"),
+  limit: z.number().optional().describe("Maximum number of lines to return"),
+});
+
+const outputSchema = z.object({
+  content: z.string(),
+});
+
+export const fileReadTool = {
   name: "file_read",
   description: "Read a file's contents from the virtual filesystem.",
   group: "file",
-  inputSchema: z.object({
-    path: z.string().describe("File path to read"),
-    offset: z
-      .number()
-      .optional()
-      .describe("Line number to start reading from (1-based)"),
-    limit: z.number().optional().describe("Maximum number of lines to return"),
-  }),
-  outputSchema: z.object({
-    content: z.string(),
-  }),
+  inputSchema,
+  outputSchema,
   execute: async (input, ctx) => {
     const item = await getContextItemByPath(ctx.conn, input.path);
     if (!item) throw new Error(`Not found: ${input.path}`);
@@ -33,4 +37,4 @@ export const fileReadTool: ToolDefinition<any, any> = {
 
     return { content };
   },
-};
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/file/write.ts
+++ b/src/tools/file/write.ts
@@ -9,7 +9,8 @@ import {
 import type { ToolDefinition } from "../tool.ts";
 
 function mimeFromPath(path: string): string {
-  return Bun.file(path).type.split(";")[0]!;
+  const type = Bun.file(path).type.split(";")[0];
+  return type ?? "application/octet-stream";
 }
 
 function isTextualPath(path: string): boolean {
@@ -19,30 +20,34 @@ function isTextualPath(path: string): boolean {
   return result !== false;
 }
 
-export const fileWriteTool: ToolDefinition<any, any> = {
+const inputSchema = z.object({
+  path: z.string().describe("File path to write"),
+  content: z.string().describe("Text content to write"),
+  content_base64: z
+    .string()
+    .optional()
+    .describe(
+      "Base64-encoded binary content (used instead of content for binary files)",
+    ),
+  title: z
+    .string()
+    .optional()
+    .describe("Title for the file (defaults to filename)"),
+  description: z.string().optional().describe("Description of the file"),
+});
+
+const outputSchema = z.object({
+  id: z.string(),
+  path: z.string(),
+});
+
+export const fileWriteTool = {
   name: "file_write",
   description:
     "Write content to a file in the virtual filesystem. Creates the file if it doesn't exist, or overwrites if it does.",
   group: "file",
-  inputSchema: z.object({
-    path: z.string().describe("File path to write"),
-    content: z.string().describe("Text content to write"),
-    content_base64: z
-      .string()
-      .optional()
-      .describe(
-        "Base64-encoded binary content (used instead of content for binary files)",
-      ),
-    title: z
-      .string()
-      .optional()
-      .describe("Title for the file (defaults to filename)"),
-    description: z.string().optional().describe("Description of the file"),
-  }),
-  outputSchema: z.object({
-    id: z.string(),
-    path: z.string(),
-  }),
+  inputSchema,
+  outputSchema,
   execute: async (input, ctx) => {
     const mimeType = mimeFromPath(input.path);
     const isTextual = isTextualPath(input.path);
@@ -82,4 +87,4 @@ export const fileWriteTool: ToolDefinition<any, any> = {
 
     return { id: item.id, path: item.context_path };
   },
-};
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -21,35 +21,33 @@ import { completeTaskTool } from "./task/complete.ts";
 import { createTaskTool } from "./task/create.ts";
 import { failTaskTool } from "./task/fail.ts";
 import { waitTaskTool } from "./task/wait.ts";
-import { registerTools } from "./tool.ts";
+import { registerTool } from "./tool.ts";
 
 export function registerAllTools(): void {
-  registerTools([
-    // Task
-    completeTaskTool,
-    failTaskTool,
-    waitTaskTool,
-    createTaskTool,
+  // Task
+  registerTool(completeTaskTool);
+  registerTool(failTaskTool);
+  registerTool(waitTaskTool);
+  registerTool(createTaskTool);
 
-    // Directory
-    dirCreateTool,
-    dirListTool,
-    dirTreeTool,
-    dirSizeTool,
+  // Directory
+  registerTool(dirCreateTool);
+  registerTool(dirListTool);
+  registerTool(dirTreeTool);
+  registerTool(dirSizeTool);
 
-    // File
-    fileReadTool,
-    fileWriteTool,
-    fileEditTool,
-    fileDeleteTool,
-    fileCopyTool,
-    fileMoveTool,
-    fileInfoTool,
-    fileExistsTool,
-    fileCountLinesTool,
+  // File
+  registerTool(fileReadTool);
+  registerTool(fileWriteTool);
+  registerTool(fileEditTool);
+  registerTool(fileDeleteTool);
+  registerTool(fileCopyTool);
+  registerTool(fileMoveTool);
+  registerTool(fileInfoTool);
+  registerTool(fileExistsTool);
+  registerTool(fileCountLinesTool);
 
-    // Search
-    searchGrepTool,
-    searchSemanticTool,
-  ]);
+  // Search
+  registerTool(searchGrepTool);
+  registerTool(searchSemanticTool);
 }

--- a/src/tools/search/grep.ts
+++ b/src/tools/search/grep.ts
@@ -9,34 +9,38 @@ const GrepMatchSchema = z.object({
   context_lines: z.array(z.string()),
 });
 
-export const searchGrepTool: ToolDefinition<any, any> = {
+const inputSchema = z.object({
+  pattern: z.string().describe("Regex pattern to search for"),
+  path: z
+    .string()
+    .optional()
+    .describe("Directory to search in (defaults to /)"),
+  glob: z
+    .string()
+    .optional()
+    .describe("Only search files matching this glob pattern"),
+  ignore_case: z.boolean().optional().describe("Case-insensitive search"),
+  context: z
+    .number()
+    .optional()
+    .describe("Number of context lines before and after each match"),
+  max_results: z
+    .number()
+    .optional()
+    .describe("Maximum number of matches to return"),
+});
+
+const outputSchema = z.object({
+  matches: z.array(GrepMatchSchema),
+});
+
+export const searchGrepTool = {
   name: "search_grep",
   description:
     "Search file contents by regex pattern in the virtual filesystem.",
   group: "search",
-  inputSchema: z.object({
-    pattern: z.string().describe("Regex pattern to search for"),
-    path: z
-      .string()
-      .optional()
-      .describe("Directory to search in (defaults to /)"),
-    glob: z
-      .string()
-      .optional()
-      .describe("Only search files matching this glob pattern"),
-    ignore_case: z.boolean().optional().describe("Case-insensitive search"),
-    context: z
-      .number()
-      .optional()
-      .describe("Number of context lines before and after each match"),
-    max_results: z
-      .number()
-      .optional()
-      .describe("Maximum number of matches to return"),
-  }),
-  outputSchema: z.object({
-    matches: z.array(GrepMatchSchema),
-  }),
+  inputSchema,
+  outputSchema,
   execute: async (input, ctx) => {
     const searchPath = input.path ?? "/";
     const items = await listContextItemsByPrefix(ctx.conn, searchPath, {
@@ -62,13 +66,14 @@ export const searchGrepTool: ToolDefinition<any, any> = {
       const lines = item.content.split("\n");
       for (let i = 0; i < lines.length; i++) {
         regex.lastIndex = 0;
-        if (regex.test(lines[i]!)) {
+        const line = lines[i];
+        if (line !== undefined && regex.test(line)) {
           const start = Math.max(0, i - contextLines);
           const end = Math.min(lines.length, i + contextLines + 1);
           matches.push({
             path: item.context_path,
             line: i + 1,
-            content: lines[i]!,
+            content: line,
             context_lines: lines.slice(start, end),
           });
           if (matches.length >= maxResults) return { matches };
@@ -78,7 +83,7 @@ export const searchGrepTool: ToolDefinition<any, any> = {
 
     return { matches };
   },
-};
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;
 
 function globToRegex(glob: string): RegExp {
   const escaped = glob

--- a/src/tools/search/semantic.ts
+++ b/src/tools/search/semantic.ts
@@ -1,36 +1,40 @@
 import { z } from "zod";
 import type { ToolDefinition } from "../tool.ts";
 
-export const searchSemanticTool: ToolDefinition<any, any> = {
+const inputSchema = z.object({
+  query: z.string().describe("Natural language search query"),
+  top_k: z
+    .number()
+    .optional()
+    .default(10)
+    .describe("Maximum number of results to return (defaults to 10)"),
+  threshold: z
+    .number()
+    .optional()
+    .describe("Minimum similarity score (0-1) to include in results"),
+});
+
+const outputSchema = z.object({
+  results: z.array(
+    z.object({
+      path: z.string(),
+      title: z.string(),
+      score: z.number(),
+      snippet: z.string(),
+    }),
+  ),
+});
+
+export const searchSemanticTool = {
   name: "search_semantic",
   description:
     "Semantic search over indexed files using vector embeddings. Finds conceptually related content, not just keyword matches.",
   group: "search",
-  inputSchema: z.object({
-    query: z.string().describe("Natural language search query"),
-    top_k: z
-      .number()
-      .optional()
-      .default(10)
-      .describe("Maximum number of results to return (defaults to 10)"),
-    threshold: z
-      .number()
-      .optional()
-      .describe("Minimum similarity score (0-1) to include in results"),
-  }),
-  outputSchema: z.object({
-    results: z.array(
-      z.object({
-        path: z.string(),
-        title: z.string(),
-        score: z.number(),
-        snippet: z.string(),
-      }),
-    ),
-  }),
+  inputSchema,
+  outputSchema,
   execute: async () => {
     throw new Error(
       "Semantic search is not yet available — requires the embeddings pipeline (M2)",
     );
   },
-};
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/task/complete.ts
+++ b/src/tools/task/complete.ts
@@ -1,19 +1,23 @@
 import { z } from "zod";
 import type { ToolDefinition } from "../tool.ts";
 
-export const completeTaskTool: ToolDefinition<any, any> = {
+const inputSchema = z.object({
+  summary: z.string().describe("Summary of work done"),
+});
+
+const outputSchema = z.object({
+  message: z.string(),
+});
+
+export const completeTaskTool = {
   name: "complete_task",
   description:
     "Mark the current task as complete with a summary of what was accomplished.",
   group: "task",
   terminal: true,
-  inputSchema: z.object({
-    summary: z.string().describe("Summary of work done"),
-  }),
-  outputSchema: z.object({
-    message: z.string(),
-  }),
+  inputSchema,
+  outputSchema,
   execute: async (input) => ({
     message: `Task completed: ${input.summary}`,
   }),
-};
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/task/create.ts
+++ b/src/tools/task/create.ts
@@ -1,27 +1,30 @@
 import { z } from "zod";
-import type { Task } from "../../db/tasks.ts";
 import { createTask, TASK_PRIORITIES } from "../../db/tasks.ts";
 import { logger } from "../../utils/logger.ts";
 import type { ToolDefinition } from "../tool.ts";
 
-export const createTaskTool: ToolDefinition<any, any> = {
+const inputSchema = z.object({
+  name: z.string().describe("Task name"),
+  description: z.string().optional().describe("Task description"),
+  priority: z.enum(TASK_PRIORITIES).optional().describe("Task priority"),
+  blocked_by: z
+    .array(z.string())
+    .optional()
+    .describe("IDs of tasks that must complete first"),
+});
+
+const outputSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  message: z.string(),
+});
+
+export const createTaskTool = {
   name: "create_task",
   description: "Create a new task to be worked on later.",
   group: "task",
-  inputSchema: z.object({
-    name: z.string().describe("Task name"),
-    description: z.string().optional().describe("Task description"),
-    priority: z.enum(TASK_PRIORITIES).optional().describe("Task priority"),
-    blocked_by: z
-      .array(z.string())
-      .optional()
-      .describe("IDs of tasks that must complete first"),
-  }),
-  outputSchema: z.object({
-    id: z.string(),
-    name: z.string(),
-    message: z.string(),
-  }),
+  inputSchema,
+  outputSchema,
   execute: async (input, ctx) => {
     const newTask = await createTask(ctx.conn, {
       name: input.name,
@@ -36,4 +39,4 @@ export const createTaskTool: ToolDefinition<any, any> = {
       message: `Created task "${newTask.name}" with ID ${newTask.id}`,
     };
   },
-};
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/task/fail.ts
+++ b/src/tools/task/fail.ts
@@ -1,18 +1,22 @@
 import { z } from "zod";
 import type { ToolDefinition } from "../tool.ts";
 
-export const failTaskTool: ToolDefinition<any, any> = {
+const inputSchema = z.object({
+  reason: z.string().describe("Why the task failed"),
+});
+
+const outputSchema = z.object({
+  message: z.string(),
+});
+
+export const failTaskTool = {
   name: "fail_task",
   description: "Mark the current task as failed with a reason.",
   group: "task",
   terminal: true,
-  inputSchema: z.object({
-    reason: z.string().describe("Why the task failed"),
-  }),
-  outputSchema: z.object({
-    message: z.string(),
-  }),
+  inputSchema,
+  outputSchema,
   execute: async (input) => ({
     message: `Task failed: ${input.reason}`,
   }),
-};
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/task/wait.ts
+++ b/src/tools/task/wait.ts
@@ -1,19 +1,23 @@
 import { z } from "zod";
 import type { ToolDefinition } from "../tool.ts";
 
-export const waitTaskTool: ToolDefinition<any, any> = {
+const inputSchema = z.object({
+  reason: z.string().describe("Why the task is waiting"),
+});
+
+const outputSchema = z.object({
+  message: z.string(),
+});
+
+export const waitTaskTool = {
   name: "wait_task",
   description:
     "Put the task in waiting status (e.g., needs human input, rate limited).",
   group: "task",
   terminal: true,
-  inputSchema: z.object({
-    reason: z.string().describe("Why the task is waiting"),
-  }),
-  outputSchema: z.object({
-    message: z.string(),
-  }),
+  inputSchema,
+  outputSchema,
   execute: async (input) => ({
     message: `Task waiting: ${input.reason}`,
   }),
-};
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -10,7 +10,7 @@ export interface ToolContext {
 }
 
 export interface ToolDefinition<
-  TInput extends z.ZodObject,
+  TInput extends z.ZodObject<z.ZodRawShape>,
   TOutput extends z.ZodType,
 > {
   name: string;
@@ -27,33 +27,35 @@ export interface ToolDefinition<
 
 // --- Registry ---
 
-const tools = new Map<string, ToolDefinition<any, any>>();
+export type AnyToolDefinition = ToolDefinition<
+  z.ZodObject<z.ZodRawShape>,
+  z.ZodType
+>;
 
-export function registerTool(tool: ToolDefinition<any, any>): void {
-  tools.set(tool.name, tool);
+const tools = new Map<string, AnyToolDefinition>();
+
+export function registerTool<
+  TInput extends z.ZodObject<z.ZodRawShape>,
+  TOutput extends z.ZodType,
+>(tool: ToolDefinition<TInput, TOutput>): void {
+  tools.set(tool.name, tool as unknown as AnyToolDefinition);
 }
 
-export function registerTools(toolList: ToolDefinition<any, any>[]): void {
-  for (const tool of toolList) {
-    registerTool(tool);
-  }
-}
-
-export function getTool(name: string): ToolDefinition<any, any> | undefined {
+export function getTool(name: string): AnyToolDefinition | undefined {
   return tools.get(name);
 }
 
-export function getAllTools(): ToolDefinition<any, any>[] {
+export function getAllTools(): AnyToolDefinition[] {
   return Array.from(tools.values());
 }
 
-export function getToolsByGroup(group: string): ToolDefinition<any, any>[] {
+export function getToolsByGroup(group: string): AnyToolDefinition[] {
   return getAllTools().filter((t) => t.group === group);
 }
 
 // --- Anthropic adapter ---
 
-export function toAnthropicTool(tool: ToolDefinition<any, any>): AnthropicTool {
+export function toAnthropicTool(tool: AnyToolDefinition): AnthropicTool {
   const jsonSchema = z.toJSONSchema(tool.inputSchema);
   return {
     name: tool.name,

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -1,5 +1,4 @@
 import { Box, Text } from "ink";
-import React from "react";
 
 export function App() {
   return (

--- a/src/utils/frontmatter.ts
+++ b/src/utils/frontmatter.ts
@@ -20,5 +20,5 @@ export function serializeContextFile(
   meta: ContextFileMeta,
   content: string,
 ): string {
-  return matter.stringify("\n" + content + "\n", meta);
+  return matter.stringify(`\n${content}\n`, meta);
 }

--- a/src/utils/pid.ts
+++ b/src/utils/pid.ts
@@ -1,4 +1,4 @@
-import { unlink } from "fs/promises";
+import { unlink } from "node:fs/promises";
 import { getPidPath } from "../constants.ts";
 
 export function writePidFile(projectDir: string, pid: number): void {
@@ -10,7 +10,7 @@ export async function readPidFile(projectDir: string): Promise<number | null> {
   if (!(await file.exists())) return null;
   const text = await file.text();
   const pid = parseInt(text.trim(), 10);
-  return isNaN(pid) ? null : pid;
+  return Number.isNaN(pid) ? null : pid;
 }
 
 export async function removePidFile(projectDir: string): Promise<void> {

--- a/test/daemon/tick.test.ts
+++ b/test/daemon/tick.test.ts
@@ -57,7 +57,7 @@ describe("daemon tick", () => {
 
     // Task should be completed
     const updated = await getTask(conn, task.id);
-    expect(updated!.status).toBe("complete");
+    expect(updated?.status).toBe("complete");
   });
 
   test("creates a thread with interactions", async () => {
@@ -77,14 +77,16 @@ describe("daemon tick", () => {
     // Should have created a thread
     const threads = await listThreads(conn, { type: "daemon_tick" });
     expect(threads).toHaveLength(1);
-    expect(threads[0]!.ended_at).not.toBeNull();
+    expect(threads[0]?.ended_at).not.toBeNull();
 
     // Thread should have interactions
-    const threadData = await getThread(conn, threads[0]!.id);
-    expect(threadData!.interactions.length).toBeGreaterThan(0);
+    const threadId = threads[0]?.id;
+    expect(threadId).toBeDefined();
+    const threadData = await getThread(conn, threadId as string);
+    expect(threadData?.interactions.length).toBeGreaterThan(0);
 
     // Should have: user message, assistant message, tool_use, tool_result, status_change
-    const kinds = threadData!.interactions.map((i) => i.kind);
+    const kinds = threadData?.interactions.map((i) => i.kind);
     expect(kinds).toContain("message");
     expect(kinds).toContain("tool_use");
     expect(kinds).toContain("tool_result");

--- a/test/db/context.test.ts
+++ b/test/db/context.test.ts
@@ -45,7 +45,7 @@ describe("context CRUD", () => {
 
     const fetched = await getContextItem(conn, item.id);
     expect(fetched).not.toBeNull();
-    expect(fetched!.title).toBe("Test");
+    expect(fetched?.title).toBe("Test");
   });
 
   test("get by path", async () => {
@@ -57,7 +57,7 @@ describe("context CRUD", () => {
 
     const item = await getContextItemByPath(conn, "/notes/meeting.md");
     expect(item).not.toBeNull();
-    expect(item!.title).toBe("Notes");
+    expect(item?.title).toBe("Notes");
 
     const missing = await getContextItemByPath(conn, "/nonexistent");
     expect(missing).toBeNull();
@@ -83,7 +83,7 @@ describe("context CRUD", () => {
       mimeType: "application/json",
     });
     expect(jsonOnly.length).toBe(1);
-    expect(jsonOnly[0]!.title).toBe("B");
+    expect(jsonOnly[0]?.title).toBe("B");
   });
 });
 
@@ -151,8 +151,8 @@ describe("mutations", () => {
       content: "new content",
     });
     expect(updated).not.toBeNull();
-    expect(updated!.title).toBe("New");
-    expect(updated!.content).toBe("new content");
+    expect(updated?.title).toBe("New");
+    expect(updated?.content).toBe("new content");
   });
 
   test("updateContextItemContent", async () => {
@@ -168,7 +168,7 @@ describe("mutations", () => {
       "replaced",
     );
     expect(updated).not.toBeNull();
-    expect(updated!.content).toBe("replaced");
+    expect(updated?.content).toBe("replaced");
   });
 
   test("applyPatches — replace lines", async () => {
@@ -260,7 +260,7 @@ describe("mutations", () => {
     expect(await getContextItemByPath(conn, "/old.md")).toBeNull();
     const moved = await getContextItemByPath(conn, "/new.md");
     expect(moved).not.toBeNull();
-    expect(moved!.content).toBe("content");
+    expect(moved?.content).toBe("content");
   });
 });
 
@@ -327,7 +327,7 @@ describe("search", () => {
 
     const results = await searchContextByKeyword(conn, "revenue");
     expect(results.length).toBe(1);
-    expect(results[0]!.title).toBe("Meeting");
+    expect(results[0]?.title).toBe("Meeting");
   });
 
   test("searchContextByKeyword finds by title", async () => {

--- a/test/db/schema.test.ts
+++ b/test/db/schema.test.ts
@@ -29,7 +29,7 @@ describe("schema migrations", () => {
     await migrate(conn); // should not throw
 
     const result = await conn.runAndReadAll("SELECT COUNT(*) FROM _migrations");
-    const count = Number(result.getRows()[0]![0]);
+    const count = Number(result.getRows()[0]?.[0]);
     expect(count).toBe(3);
   });
 

--- a/test/db/tasks.test.ts
+++ b/test/db/tasks.test.ts
@@ -35,7 +35,7 @@ describe("task CRUD", () => {
 
     const fetched = await getTask(conn, task.id);
     expect(fetched).not.toBeNull();
-    expect(fetched!.name).toBe("Test task");
+    expect(fetched?.name).toBe("Test task");
   });
 
   test("list tasks ordered by priority", async () => {
@@ -45,9 +45,9 @@ describe("task CRUD", () => {
 
     const tasks = await listTasks(conn);
     expect(tasks.length).toBe(3);
-    expect(tasks[0]!.name).toBe("High");
-    expect(tasks[1]!.name).toBe("Medium");
-    expect(tasks[2]!.name).toBe("Low");
+    expect(tasks[0]?.name).toBe("High");
+    expect(tasks[1]?.name).toBe("Medium");
+    expect(tasks[2]?.name).toBe("Low");
   });
 
   test("list tasks with status filter", async () => {
@@ -57,7 +57,7 @@ describe("task CRUD", () => {
 
     const pending = await listTasks(conn, { status: "pending" });
     expect(pending.length).toBe(1);
-    expect(pending[0]!.name).toBe("Task 2");
+    expect(pending[0]?.name).toBe("Task 2");
   });
 
   test("update task status", async () => {
@@ -65,8 +65,8 @@ describe("task CRUD", () => {
     await updateTaskStatus(conn, task.id, "waiting", "needs clarification");
 
     const updated = await getTask(conn, task.id);
-    expect(updated!.status).toBe("waiting");
-    expect(updated!.waiting_reason).toBe("needs clarification");
+    expect(updated?.status).toBe("waiting");
+    expect(updated?.waiting_reason).toBe("needs clarification");
   });
 
   test("get nonexistent task returns null", async () => {
@@ -82,9 +82,9 @@ describe("claimNextTask", () => {
 
     const claimed = await claimNextTask(conn);
     expect(claimed).not.toBeNull();
-    expect(claimed!.name).toBe("High");
-    expect(claimed!.status).toBe("in_progress");
-    expect(claimed!.claimed_by).toBe("daemon");
+    expect(claimed?.name).toBe("High");
+    expect(claimed?.status).toBe("in_progress");
+    expect(claimed?.claimed_by).toBe("daemon");
   });
 
   test("returns null when no tasks available", async () => {
@@ -111,7 +111,7 @@ describe("claimNextTask", () => {
     // Should not claim the blocked task even though it's higher priority
     const claimed = await claimNextTask(conn);
     expect(claimed).not.toBeNull();
-    expect(claimed!.name).toBe("Blocker");
+    expect(claimed?.name).toBe("Blocker");
   });
 
   test("unblocks task when blocker completes", async () => {
@@ -128,6 +128,6 @@ describe("claimNextTask", () => {
     // Now claim — should get the previously blocked task
     const claimed = await claimNextTask(conn);
     expect(claimed).not.toBeNull();
-    expect(claimed!.name).toBe("Blocked");
+    expect(claimed?.name).toBe("Blocked");
   });
 });

--- a/test/db/threads.test.ts
+++ b/test/db/threads.test.ts
@@ -30,10 +30,10 @@ describe("thread CRUD", () => {
 
     const result = await getThread(conn, threadId);
     expect(result).not.toBeNull();
-    expect(result!.thread.type).toBe("daemon_tick");
-    expect(result!.thread.title).toBe("Test tick");
-    expect(result!.thread.ended_at).toBeNull();
-    expect(result!.interactions).toHaveLength(0);
+    expect(result?.thread.type).toBe("daemon_tick");
+    expect(result?.thread.title).toBe("Test tick");
+    expect(result?.thread.ended_at).toBeNull();
+    expect(result?.interactions).toHaveLength(0);
   });
 
   test("create thread with task_id", async () => {
@@ -45,7 +45,7 @@ describe("thread CRUD", () => {
     );
 
     const result = await getThread(conn, threadId);
-    expect(result!.thread.task_id).toBe("task-123");
+    expect(result?.thread.task_id).toBe("task-123");
   });
 
   test("end a thread sets ended_at", async () => {
@@ -53,7 +53,7 @@ describe("thread CRUD", () => {
     await endThread(conn, threadId);
 
     const result = await getThread(conn, threadId);
-    expect(result!.thread.ended_at).not.toBeNull();
+    expect(result?.thread.ended_at).not.toBeNull();
   });
 
   test("get nonexistent thread returns null", async () => {
@@ -102,21 +102,21 @@ describe("interaction logging", () => {
     });
 
     const result = await getThread(conn, threadId);
-    expect(result!.interactions).toHaveLength(5);
+    expect(result?.interactions).toHaveLength(5);
 
     // Verify ordering
-    expect(result!.interactions[0]!.sequence).toBe(1);
-    expect(result!.interactions[4]!.sequence).toBe(5);
+    expect(result?.interactions[0]?.sequence).toBe(1);
+    expect(result?.interactions[4]?.sequence).toBe(5);
 
     // Verify content
-    expect(result!.interactions[0]!.role).toBe("user");
-    expect(result!.interactions[0]!.kind).toBe("message");
-    expect(result!.interactions[2]!.tool_name).toBe("search_context");
-    expect(result!.interactions[2]!.tool_input).toBe(
+    expect(result?.interactions[0]?.role).toBe("user");
+    expect(result?.interactions[0]?.kind).toBe("message");
+    expect(result?.interactions[2]?.tool_name).toBe("search_context");
+    expect(result?.interactions[2]?.tool_input).toBe(
       '{"query": "relevant docs"}',
     );
-    expect(result!.interactions[3]!.duration_ms).toBe(150);
-    expect(result!.interactions[4]!.token_count).toBe(500);
+    expect(result?.interactions[3]?.duration_ms).toBe(150);
+    expect(result?.interactions[4]?.token_count).toBe(500);
   });
 
   test("interactions with special characters in content", async () => {
@@ -129,7 +129,7 @@ describe("interaction logging", () => {
     });
 
     const result = await getThread(conn, threadId);
-    expect(result!.interactions[0]!.content).toBe(
+    expect(result?.interactions[0]?.content).toBe(
       "What's the user's name? It's O'Brien.",
     );
   });

--- a/test/init/index.test.ts
+++ b/test/init/index.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtemp, rm } from "fs/promises";
-import { tmpdir } from "os";
-import { join } from "path";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { initProject } from "../../src/init/index.ts";
 import { parseContextFile } from "../../src/utils/frontmatter.ts";
 

--- a/test/tools/tool.test.ts
+++ b/test/tools/tool.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import { z } from "zod";
+import type { ToolContext } from "../../src/tools/tool.ts";
 
 // Fresh-import the module each test to reset the registry
 let registerTool: typeof import("../../src/tools/tool.ts").registerTool;
@@ -115,10 +116,10 @@ describe("Tool execution", () => {
       }),
     });
 
-    const result = await tool.execute(
+    const result = (await tool.execute(
       { path: "/test.md" },
-      {} as any, // ctx not needed for this test
-    );
+      {} as ToolContext, // ctx not needed for this test
+    )) as { content: string; lines: number };
     expect(result.content).toBe("read: /test.md");
     expect(result.lines).toBe(0);
   });


### PR DESCRIPTION
## Summary
- Strongly type all 16 tool definitions using `satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>` instead of `ToolDefinition<any, any>` annotations
- Add `AnyToolDefinition` as the type-erased registry boundary backed by `ZodObject<ZodRawShape>`, with a generic `registerTool` that casts at the boundary
- Replace 74 non-null assertions (`!`) with proper guards and optional chaining
- Auto-fix `node:` import protocol, template literals, unused imports, and other Biome rules
- Migrate biome.json schema from 2.0.0 to 2.4.11

## Test plan
- [x] `bun lint` passes with 0 warnings (was 137 warnings + 19 infos)
- [x] `bun test` passes — 62 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)