### PR TITLE
Migrate from DuckDB to SQLite via bun:sqlite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ An AI agent for knowledge work. See `docs/plans/README.md` for the milestone roa
   - `commands/` — CLI subcommand handlers
   - `config/` — Configuration loading/schemas
   - `daemon/` — Daemon tick loop, LLM integration, prompt building
-  - `db/` — DuckDB connection, schema migrations, CRUD modules
+  - `db/` — SQLite connection (bun:sqlite), schema migrations, CRUD modules
   - `init/` — Project initialization
   - `tui/` — Ink (React) TUI components
   - `utils/` — Logger, frontmatter, PID management
@@ -25,7 +25,7 @@ An AI agent for knowledge work. See `docs/plans/README.md` for the milestone roa
 ## Tech Stack
 
 - **Runtime**: Bun + TypeScript
-- **Database**: DuckDB (`@duckdb/node-api`)
+- **Database**: SQLite (`bun:sqlite`)
 - **LLM**: Anthropic SDK (`@anthropic-ai/sdk`)
 - **CLI**: Commander.js
 - **TUI**: Ink 6 + React 19
@@ -33,7 +33,24 @@ An AI agent for knowledge work. See `docs/plans/README.md` for the milestone roa
 
 ## Conventions
 
-- Use `bun test` before committing
+- Run `bun run lint` and `bun test` before committing
+- `bun run lint` runs both `tsc --noEmit` and `biome check`
 - All database access goes through `src/db/` modules
 - All agent interactions are logged to the threads/interactions tables
 - No filesystem tools for the agent — FS access is abstracted through CRUD modules scoped to `.botholomew/`
+
+## Database Patterns
+
+- **Connection**: use `DbConnection` type from `src/db/connection.ts` (re-export of `bun:sqlite` `Database`)
+- **Migrations**: always call `migrate(db)` after opening a connection — it's idempotent
+- **IDs**: UUIDv7 generated in application code via `uuidv7()` from `src/db/uuid.ts` (re-exports `uuid` package)
+- **Queries**: use parameterized queries (`?1, ?2, ...`) — never string interpolation
+- **Timestamps**: stored as ISO 8601 TEXT in SQLite (`datetime('now')`), converted to `Date` objects in TypeScript interfaces
+- **Booleans**: stored as INTEGER (0/1) in SQLite, converted to `boolean` in TypeScript
+- **Arrays**: `blocked_by`/`context_ids` are JSON TEXT columns — `JSON.stringify()` on write, `JSON.parse()` on read, `json_each()` for in-SQL filtering
+- **Row mapping**: each module has a `RowType` interface (raw SQLite strings/numbers) and a `rowToX()` function that converts to the public TypeScript interface with proper types
+
+## Testing
+
+- Use `getConnection(":memory:")` for in-memory test databases
+- Call `migrate(conn)` in `beforeEach` to get a fresh schema each test

--- a/bun.lock
+++ b/bun.lock
@@ -6,19 +6,20 @@
       "name": "botholomew",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.88.0",
-        "@duckdb/node-api": "1.5.1-r.2",
         "ansis": "^4.2.0",
         "commander": "^14.0.0",
         "gray-matter": "^4.0.3",
         "ink": "^6.0.0",
         "istextorbinary": "^9.5.0",
         "react": "^19.1.0",
+        "uuid": "^13.0.0",
         "zod": "^4.3.6",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.11",
         "@types/bun": "latest",
         "@types/react": "^19.1.0",
+        "@types/uuid": "^11.0.0",
         "typescript": "^6.0.2",
       },
     },
@@ -48,27 +49,13 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.11", "", { "os": "win32", "cpu": "x64" }, "sha512-A8D3JM/00C2KQgUV3oj8Ba15EHEYwebAGCy5Sf9GAjr5Y3+kJIYOiESoqRDeuRZueuMdCsbLZIUqmPhpYXJE9A=="],
 
-    "@duckdb/node-api": ["@duckdb/node-api@1.5.1-r.2", "", { "dependencies": { "@duckdb/node-bindings": "1.5.1-r.2" } }, "sha512-WF2CnGcvIix4gik322dKa+pvvOOZ3ZS6I0NplY4RJGGaIKvWIPsg4v3+7o2D2KlpS7SsJyE2c/wXPtuLGSwzyQ=="],
-
-    "@duckdb/node-bindings": ["@duckdb/node-bindings@1.5.1-r.2", "", { "optionalDependencies": { "@duckdb/node-bindings-darwin-arm64": "1.5.1-r.2", "@duckdb/node-bindings-darwin-x64": "1.5.1-r.2", "@duckdb/node-bindings-linux-arm64": "1.5.1-r.2", "@duckdb/node-bindings-linux-x64": "1.5.1-r.2", "@duckdb/node-bindings-win32-arm64": "1.5.1-r.2", "@duckdb/node-bindings-win32-x64": "1.5.1-r.2" } }, "sha512-ifURcVwVEfR7H1LC2X+RQ6AFFI+oQznfzBYb8tOR50gzqAGCbYJy4tsF8jb/1k3L4lMte/pfH9cI8uW6xG7U9Q=="],
-
-    "@duckdb/node-bindings-darwin-arm64": ["@duckdb/node-bindings-darwin-arm64@1.5.1-r.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-SHvnTwJxp8BYMNxkHZs0RDdWK0fvghsMNtuxOkeMTQTh1AIv/rINWE+X9eIjU6IvlSBps5D2X0l6cbW7butomQ=="],
-
-    "@duckdb/node-bindings-darwin-x64": ["@duckdb/node-bindings-darwin-x64@1.5.1-r.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-D/ofaglTRnhK76gDevO+xfXspprOHa7qwuwIX2Hwvv9Vz3yJt/y/gre3g6miwU4RJZ+hHxzGYTwGsL832cEjbg=="],
-
-    "@duckdb/node-bindings-linux-arm64": ["@duckdb/node-bindings-linux-arm64@1.5.1-r.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Sf8840uIDwFVw7ALp+eImYlreGRMYhu815t1xvE6L1wiLRkjWJUDECNRLQ/GviORScrOKj5WVvOgZNPAlItgYw=="],
-
-    "@duckdb/node-bindings-linux-x64": ["@duckdb/node-bindings-linux-x64@1.5.1-r.2", "", { "os": "linux", "cpu": "x64" }, "sha512-UN/Mly9S53o2LCnIyH8almwcKejxpdSenjqsLtmf3fOrDkP8KcrDL3ln4MSKEj3fIoJjyvbl1IyVqWKYPBTrLA=="],
-
-    "@duckdb/node-bindings-win32-arm64": ["@duckdb/node-bindings-win32-arm64@1.5.1-r.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-o0R4POcc4ZvYdM3ydCtQDYZRAPPk5d1rZAMgJ85wcZUF8Tf1jP6YDpTrTm1oghXEUtsZ0pwsTuZ8PijYhG2/5Q=="],
-
-    "@duckdb/node-bindings-win32-x64": ["@duckdb/node-bindings-win32-x64@1.5.1-r.2", "", { "os": "win32", "cpu": "x64" }, "sha512-rT9YU/FwWR3XHXDTnEJthEiMemr3GFIvYCuR58nQfPhjv8qnZ4c0sUu6HOkl+fXYNTkDeTzE6//Ydr1BF2ixdA=="],
-
     "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
+
+    "@types/uuid": ["@types/uuid@11.0.0", "", { "dependencies": { "uuid": "*" } }, "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA=="],
 
     "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
 
@@ -181,6 +168,8 @@
     "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "uuid": ["uuid@13.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w=="],
 
     "version-range": ["version-range@4.15.0", "", {}, "sha512-Ck0EJbAGxHwprkzFO966t4/5QkRuzh+/I1RxhLgUKKwEn+Cd8NwM60mE3AqBZg5gYODoXW0EFsQvbZjRlvdqbg=="],
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -2,7 +2,7 @@
 
 | # | Milestone | Status | Summary |
 |---|-----------|--------|---------|
-| 1 | [Foundation](milestone-1-foundation.md) | **Done** | Scaffolding, DuckDB schema, CLI skeleton, daemon tick loop |
+| 1 | [Foundation](milestone-1-foundation.md) | **Done** | Scaffolding, SQLite schema, CLI skeleton, daemon tick loop |
 | 2 | [Context & Embeddings](milestone-2-context-and-embeddings.md) | Planned | Ingest, chunk, embed, and search content with hybrid vector search |
 | 3 | [Schedules & Task Hardening](milestone-3-schedules-and-task-hardening.md) | Planned | Recurring schedules, cycle detection, timeouts, full task/schedule CLI |
 | 4 | [MCPX Integration](milestone-4-mcpx-integration.md) | Planned | External tools via MCP servers (Gmail, Slack, web, etc.) |

--- a/docs/plans/milestone-1-foundation.md
+++ b/docs/plans/milestone-1-foundation.md
@@ -7,7 +7,7 @@ An AI Agent for knowledge work. Unlike coding agents, Botholomew is focused on i
 1. **No shell / filesystem access.** The agent has no bash, read/write, or direct filesystem tools. All storage is abstracted through manage-context tools scoped to `.botholomew/`.
 2. **Distributed from the start.** Orchestrator, tool execution, memory, and context are separate modules, making it possible to run locally and on the web.
 3. **TUI interface.** A terminal UI built with Ink (React for CLI), styled after Claude Code.
-4. **It's all files.** Each Botholomew project is a collection of markdown and DuckDB files — portable and shareable.
+4. **It's all files.** Each Botholomew project is a collection of markdown and a SQLite database — portable and shareable.
 
 ---
 
@@ -23,7 +23,7 @@ The interactive TUI session. The chat agent doesn't work tasks itself — it enq
 
 ### Data
 
-Both daemon and chat share the same DuckDB file at `.botholomew/data.duckdb`. Each opens its own connection. DuckDB handles concurrent access with file-level locking; a retry-on-lock layer handles contention.
+Both daemon and chat share the same SQLite database at `.botholomew/data.sqlite`. Each opens its own connection. SQLite WAL mode enables concurrent readers; a retry-on-lock layer handles write contention.
 
 ---
 
@@ -55,9 +55,9 @@ New projects start with:
 
 ---
 
-## Dynamic Context (DuckDB)
+## Dynamic Context (SQLite)
 
-The `.botholomew/data.duckdb` file powers tasks, schedules, context, embeddings, and interaction logs.
+The `.botholomew/data.sqlite` file powers tasks, schedules, context, embeddings, and interaction logs.
 
 ### Tasks
 
@@ -82,9 +82,9 @@ Context is stored in the database (not raw files), with:
 
 Content is chunked and vectorized locally using `@huggingface/transformers` with `Xenova/bge-small-en-v1.5` (384-dimensional embeddings). Chunking strategy is determined by the LLM after reading each piece of content.
 
-Embeddings are stored alongside and indexed with DuckDB's `vss` extension (HNSW, cosine metric) for hybrid keyword + vector search.
+Embeddings are stored as JSON arrays in TEXT columns and searched via brute-force cosine similarity for hybrid keyword + vector search.
 
-Embedding fields: `id`, `context_item_id`, `chunk_index`, `chunk_content`, `title`, `description`, `source_path`, `embedding` (FLOAT[384]), `created_at`.
+Embedding fields: `id`, `context_item_id`, `chunk_index`, `chunk_content`, `title`, `description`, `source_path`, `embedding` (JSON array of 384 floats), `created_at`.
 
 ### Threads & Interactions (Logging)
 
@@ -149,8 +149,8 @@ Plus meta-utils: `--help`, `--version`
 - **Runtime**: Bun + TypeScript
 - **CLI framework**: Commander.js
 - **TUI**: Ink 6 (React 19 for CLI)
-- **Database**: DuckDB via `@duckdb/node-api`
-- **Vector search**: DuckDB `vss` extension (HNSW indexes)
+- **Database**: SQLite via `bun:sqlite` (built-in, zero dependencies)
+- **Vector search**: TBD (future milestone)
 - **Embeddings**: `@huggingface/transformers` with `Xenova/bge-small-en-v1.5` (local, no 3rd party)
 - **LLM**: `@anthropic-ai/sdk` (direct)
 - **Tools**: MCPX imported as TS library
@@ -176,7 +176,8 @@ botholomew/
       schemas.ts                    # BotholomewConfig type + defaults
       loader.ts                     # load/validate .botholomew/config.json
     db/
-      connection.ts                 # DuckDB connection factory w/ retry-on-lock
+      connection.ts                 # SQLite connection via bun:sqlite w/ retry-on-lock
+      uuid.ts                       # UUIDv7 re-export from uuid package
       schema.ts                     # SQL migrations + migrate()
       tasks.ts                      # task CRUD
       schedules.ts                  # schedule CRUD (stubs)
@@ -225,7 +226,7 @@ botholomew/
 {
   "dependencies": {
     "@anthropic-ai/sdk": "^0.88.0",
-    "@duckdb/node-api": "^1.5.1",
+    "uuid": "^13.0.0",
     "@evantahler/mcpx": "^0.17.0",
     "commander": "^14.0.3",
     "gray-matter": "^4.0.3",
@@ -241,126 +242,20 @@ botholomew/
 ```
 
 Notes:
-- `@duckdb/node-api` is the official new API (old `duckdb` is deprecated for v1.5+). Works with Bun v1.2.2+.
+- SQLite is built into Bun via `bun:sqlite` — zero external dependencies needed.
+- UUIDv7 for IDs generated via the `uuid` package.
 - `@xenova/transformers` for embeddings is NOT in M1 — context/embedding CRUD are stubs.
 - Ink 6 requires React 19.
 
-### DuckDB Schema
+### SQLite Schema
 
-All tables in `src/db/schema.ts`. A `_migrations` table tracks applied migrations.
-
-```sql
--- Enums
-CREATE TYPE task_priority AS ENUM ('low', 'medium', 'high');
-CREATE TYPE task_status AS ENUM ('pending', 'in_progress', 'failed', 'complete', 'waiting');
-CREATE TYPE thread_type AS ENUM ('daemon_tick', 'chat_session');
-CREATE TYPE interaction_role AS ENUM ('user', 'assistant', 'system', 'tool');
-CREATE TYPE interaction_kind AS ENUM (
-  'message', 'thinking', 'tool_use', 'tool_result', 'context_update', 'status_change'
-);
-
--- Core tables
-CREATE TABLE tasks (
-  id VARCHAR PRIMARY KEY DEFAULT gen_random_uuid()::VARCHAR,
-  name VARCHAR NOT NULL,
-  description TEXT NOT NULL DEFAULT '',
-  priority task_priority NOT NULL DEFAULT 'medium',
-  status task_status NOT NULL DEFAULT 'pending',
-  waiting_reason TEXT,
-  claimed_by VARCHAR,
-  claimed_at TIMESTAMP,
-  blocked_by VARCHAR[],
-  context_ids VARCHAR[],
-  created_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
-  updated_at TIMESTAMP NOT NULL DEFAULT current_timestamp
-);
-
-CREATE TABLE schedules (
-  id VARCHAR PRIMARY KEY DEFAULT gen_random_uuid()::VARCHAR,
-  name VARCHAR NOT NULL,
-  description TEXT NOT NULL DEFAULT '',
-  frequency VARCHAR NOT NULL,
-  last_run_at TIMESTAMP,
-  enabled BOOLEAN NOT NULL DEFAULT true,
-  created_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
-  updated_at TIMESTAMP NOT NULL DEFAULT current_timestamp
-);
-
-CREATE TABLE context_items (
-  id VARCHAR PRIMARY KEY DEFAULT gen_random_uuid()::VARCHAR,
-  title VARCHAR NOT NULL,
-  description TEXT NOT NULL DEFAULT '',
-  content TEXT,
-  content_blob BLOB,
-  mime_type VARCHAR NOT NULL DEFAULT 'text/plain',
-  is_textual BOOLEAN NOT NULL DEFAULT true,
-  source_path VARCHAR,
-  context_path VARCHAR NOT NULL,
-  indexed_at TIMESTAMP,
-  created_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
-  updated_at TIMESTAMP NOT NULL DEFAULT current_timestamp
-);
-
-CREATE TABLE embeddings (
-  id VARCHAR PRIMARY KEY DEFAULT gen_random_uuid()::VARCHAR,
-  context_item_id VARCHAR NOT NULL REFERENCES context_items(id) ON DELETE CASCADE,
-  chunk_index INTEGER NOT NULL,
-  chunk_content TEXT,
-  title VARCHAR NOT NULL,
-  description TEXT NOT NULL DEFAULT '',
-  source_path VARCHAR,
-  embedding FLOAT[384],
-  created_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
-  UNIQUE(context_item_id, chunk_index)
-);
-
--- Logging tables
-CREATE TABLE threads (
-  id VARCHAR PRIMARY KEY DEFAULT gen_random_uuid()::VARCHAR,
-  type thread_type NOT NULL,
-  task_id VARCHAR,
-  title VARCHAR NOT NULL DEFAULT '',
-  started_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
-  ended_at TIMESTAMP,
-  metadata TEXT
-);
-
-CREATE TABLE interactions (
-  id VARCHAR PRIMARY KEY DEFAULT gen_random_uuid()::VARCHAR,
-  thread_id VARCHAR NOT NULL REFERENCES threads(id) ON DELETE CASCADE,
-  sequence INTEGER NOT NULL,
-  role interaction_role NOT NULL,
-  kind interaction_kind NOT NULL,
-  content TEXT NOT NULL,
-  tool_name VARCHAR,
-  tool_input TEXT,
-  duration_ms INTEGER,
-  token_count INTEGER,
-  created_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
-  UNIQUE(thread_id, sequence)
-);
-
--- Daemon state (key-value)
-CREATE TABLE daemon_state (
-  key VARCHAR PRIMARY KEY,
-  value TEXT NOT NULL,
-  updated_at TIMESTAMP NOT NULL DEFAULT current_timestamp
-);
-```
-
-VSS index (lazy, separate migration — falls back gracefully if unavailable):
-
-```sql
-INSTALL vss;
-LOAD vss;
-CREATE INDEX embeddings_vss_idx ON embeddings USING HNSW (embedding) WITH (metric = 'cosine');
-```
+All tables in `src/db/schema.ts`. A `_migrations` table tracks applied migrations. UUIDv7 IDs are generated in application code via the `uuid` package. Enums are enforced with CHECK constraints. Array columns (blocked_by, context_ids) use JSON TEXT with `json_each()` for in-SQL filtering. Timestamps are ISO 8601 TEXT with `datetime('now')` defaults. See `src/db/sql/*.sql` for the current schema.
 
 ### Key Module Details
 
 **`src/db/connection.ts`**
-- `getConnection(dbPath)` — opens DuckDB, retries up to 5x with exponential backoff on lock
-- `getDbPath(projectDir)` — returns `${projectDir}/.botholomew/data.duckdb`
+- `getConnection(dbPath)` — opens SQLite via `bun:sqlite` with WAL mode and foreign keys enabled
+- `withRetry()` — retries on SQLITE_BUSY with exponential backoff
 
 **`src/config/loader.ts`**
 - Loads `.botholomew/config.json`, merges with defaults
@@ -368,8 +263,8 @@ CREATE INDEX embeddings_vss_idx ON embeddings USING HNSW (embedding) WITH (metri
 
 **`src/init/index.ts`**
 - Creates `.botholomew/` directory with `soul.md`, `beliefs.md`, `goals.md`, `config.json`, `mcpx/servers.json`
-- Opens DuckDB and runs migrations
-- Updates `.gitignore` to exclude `config.json` and `data.duckdb*`
+- Opens SQLite and runs migrations
+- Updates `.gitignore` to exclude `.botholomew/`
 
 **`src/daemon/tick.ts`**
 1. Creates a thread for this tick

--- a/docs/plans/milestone-2-context-and-embeddings.md
+++ b/docs/plans/milestone-2-context-and-embeddings.md
@@ -4,7 +4,7 @@
 
 Build the knowledge management foundation — the ability to ingest, chunk, embed, and search content. This is Botholomew's core differentiator: a local hybrid search system that makes the agent's context rich and relevant.
 
-The agent interacts with context items through a **virtual filesystem abstraction** — `dir`, `file`, and `search` tools that map to the `context_items` and `embeddings` tables in DuckDB. The `context_path` column acts as the file path; `content` is the file body.
+The agent interacts with context items through a **virtual filesystem abstraction** — `dir`, `file`, and `search` tools that map to the `context_items` and `embeddings` tables in SQLite. The `context_path` column acts as the file path; `content` is the file body.
 
 ## What Gets Unblocked
 
@@ -30,7 +30,7 @@ Every tool (task, dir, file, search) is an instance of a shared `Tool` base clas
 - **Name** and **description** — used for both LLM tool definitions and CLI help text
 - **Zod input schema** — per-field descriptions; validates args, generates JSON Schema for Anthropic API, generates Commander options
 - **Zod output schema** — strongly typed, guaranteed response format
-- **`execute()` method** — the actual implementation (DuckDB-backed)
+- **`execute()` method** — the actual implementation (SQLite-backed)
 
 The same Tool definition serves two consumers with thin adapters:
 1. **Daemon agent** — Zod input → Anthropic `Tool` JSON Schema; `execute()` called from `executeToolCall()`
@@ -77,7 +77,7 @@ Each file exports a single Tool instance and self-registers on import. One tool 
 
 - `Tool<TInput, TOutput>` abstract class with `name`, `description`, `group`, `inputSchema`, `outputSchema`, `execute()`
 - `toAnthropicTool()` method — converts Zod input schema to Anthropic API JSON Schema via `zod-to-json-schema`
-- `ToolContext` interface — `{ conn: DuckDBConnection, projectDir: string, config: Required<BotholomewConfig> }`
+- `ToolContext` interface — `{ conn: DbConnection, projectDir: string, config: Required<BotholomewConfig> }`
 - Global registry: `registerTool()`, `getTool()`, `getAllTools()`, `getToolsByGroup()`
 - Adapter: `toAnthropicTools()` — returns full `Tool[]` array for the Anthropic API
 - Adapter: `registerToolsAsCLI(program)` — auto-generates Commander subcommands from the registry
@@ -152,8 +152,8 @@ Replace the stub with full implementation:
 
 | Tool | Input | Output | DB operation |
 |------|-------|--------|-------------|
-| `search_find` | `{ pattern, path?, max_results? }` | `{ matches: string[] }` | `context_path` glob match via DuckDB `glob()` |
-| `search_grep` | `{ pattern, path?, glob?, ignore_case?, context?, max_results? }` | `{ matches: {path, line, content, context_lines}[] }` | `regexp_matches()` on `content` |
+| `search_find` | `{ pattern, path?, max_results? }` | `{ matches: string[] }` | `context_path` glob match via SQLite `GLOB` |
+| `search_grep` | `{ pattern, path?, glob?, ignore_case?, context?, max_results? }` | `{ matches: {path, line, content, context_lines}[] }` | `LIKE` / application-level regex on `content` |
 | `search_semantic` | `{ query, top_k?, threshold? }` | `{ results: {path, title, score, snippet}[] }` | `embed([query])` → `hybridSearch()` |
 
 ### 7. Embedding Pipeline (`src/context/`)
@@ -183,16 +183,12 @@ Replace the stub with full implementation:
 
 - `createEmbedding(conn, { contextItemId, chunkIndex, chunkContent, title, description, sourcePath, embedding })` — insert
 - `deleteEmbeddingsForItem(conn, contextItemId)` — remove all chunks for a context item
-- `searchEmbeddings(conn, queryEmbedding, limit?)` — vector similarity search via DuckDB VSS
+- `searchEmbeddings(conn, queryEmbedding, limit?)` — vector similarity search (brute-force cosine in SQL)
 - `hybridSearch(conn, query, queryEmbedding, limit?)` — combine keyword search on chunk_content/title with vector similarity, merge and re-rank results
 
-### 9. VSS Extension Management
+### 9. Vector Search
 
-In `src/db/schema.ts`, improve `installVss()`:
-- Try to install/load the vss extension
-- If available, create the HNSW index
-- Track in `daemon_state` whether VSS is available
-- `searchEmbeddings` falls back to brute-force cosine similarity in SQL if VSS unavailable
+SQLite does not have a native vector search extension. Embedding search uses brute-force cosine similarity computed in application code (or via a SQL expression over JSON-encoded float arrays). For the scale of a single-user knowledge base, this is sufficient.
 
 ### 10. Embeddings Cascade on Mutations
 

--- a/package.json
+++ b/package.json
@@ -9,24 +9,25 @@
   "scripts": {
     "dev": "bun run src/cli.ts",
     "test": "bun test",
-    "build": "bun build --minify --sourcemap ./src/cli.ts --outdir dist --external @duckdb/node-bindings",
+    "build": "bun build --compile --minify --sourcemap ./src/cli.ts --outfile dist/botholomew",
     "lint": "tsc --noEmit && biome check ."
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.88.0",
-    "@duckdb/node-api": "1.5.1-r.2",
     "ansis": "^4.2.0",
     "commander": "^14.0.0",
     "gray-matter": "^4.0.3",
     "ink": "^6.0.0",
     "istextorbinary": "^9.5.0",
     "react": "^19.1.0",
+    "uuid": "^13.0.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.11",
     "@types/bun": "latest",
     "@types/react": "^19.1.0",
+    "@types/uuid": "^11.0.0",
     "typescript": "^6.0.2"
   }
 }

--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -18,8 +18,8 @@ export function registerTaskCommand(program: Command) {
     .option("-l, --limit <n>", "max number of tasks", parseInt)
     .action(async (opts) => {
       const dir = program.opts().dir;
-      const conn = await getConnection(getDbPath(dir));
-      await migrate(conn);
+      const conn = getConnection(getDbPath(dir));
+      migrate(conn);
 
       const tasks = await listTasks(conn, {
         status: opts.status,
@@ -36,7 +36,7 @@ export function registerTaskCommand(program: Command) {
         printTask(t);
       }
 
-      conn.closeSync();
+      conn.close();
     });
 
   task
@@ -46,8 +46,8 @@ export function registerTaskCommand(program: Command) {
     .option("-p, --priority <priority>", "low, medium, or high", "medium")
     .action(async (name, opts) => {
       const dir = program.opts().dir;
-      const conn = await getConnection(getDbPath(dir));
-      await migrate(conn);
+      const conn = getConnection(getDbPath(dir));
+      migrate(conn);
 
       const t = await createTask(conn, {
         name,
@@ -56,7 +56,7 @@ export function registerTaskCommand(program: Command) {
       });
 
       logger.success(`Created task: ${t.name} (${t.id})`);
-      conn.closeSync();
+      conn.close();
     });
 
   task
@@ -64,8 +64,8 @@ export function registerTaskCommand(program: Command) {
     .description("View task details")
     .action(async (id) => {
       const dir = program.opts().dir;
-      const conn = await getConnection(getDbPath(dir));
-      await migrate(conn);
+      const conn = getConnection(getDbPath(dir));
+      migrate(conn);
 
       const t = await getTask(conn, id);
       if (!t) {
@@ -74,7 +74,7 @@ export function registerTaskCommand(program: Command) {
       }
 
       printTaskDetail(t);
-      conn.closeSync();
+      conn.close();
     });
 }
 

--- a/src/commands/tools.ts
+++ b/src/commands/tools.ts
@@ -96,8 +96,8 @@ function registerToolAsCLI(
 
   cmd.action(async (...args: unknown[]) => {
     const dir = program.opts().dir;
-    const conn = await getConnection(getDbPath(dir));
-    await migrate(conn);
+    const conn = getConnection(getDbPath(dir));
+    migrate(conn);
 
     try {
       const input = buildInput(tool, positionals, options, shape, args);
@@ -114,7 +114,7 @@ function registerToolAsCLI(
       logger.error(String(err));
       process.exit(1);
     } finally {
-      conn.closeSync();
+      conn.close();
     }
   });
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,7 @@
 import { join } from "node:path";
 
 export const BOTHOLOMEW_DIR = ".botholomew";
-export const DB_FILENAME = "data.duckdb";
+export const DB_FILENAME = "data.sqlite";
 export const PID_FILENAME = "daemon.pid";
 export const LOG_FILENAME = "daemon.log";
 export const CONFIG_FILENAME = "config.json";

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -9,15 +9,15 @@ import { tick } from "./tick.ts";
 export async function startDaemon(projectDir: string): Promise<void> {
   const config = await loadConfig(projectDir);
   const dbPath = getDbPath(projectDir);
-  const conn = await getConnection(dbPath);
-  await migrate(conn);
+  const conn = getConnection(dbPath);
+  migrate(conn);
 
   writePidFile(projectDir, process.pid);
 
   const shutdown = async () => {
     logger.info("Daemon shutting down...");
     await removePidFile(projectDir);
-    conn.closeSync();
+    conn.close();
     process.exit(0);
   };
 

--- a/src/daemon/llm.ts
+++ b/src/daemon/llm.ts
@@ -5,7 +5,7 @@ import type {
   ToolUseBlock,
 } from "@anthropic-ai/sdk/resources/messages";
 import type { BotholomewConfig } from "../config/schemas.ts";
-import type { DuckDBConnection } from "../db/connection.ts";
+import type { DbConnection } from "../db/connection.ts";
 import type { Task } from "../db/tasks.ts";
 import { logInteraction } from "../db/threads.ts";
 import { registerAllTools } from "../tools/registry.ts";
@@ -28,7 +28,7 @@ export async function runAgentLoop(input: {
   systemPrompt: string;
   task: Task;
   config: Required<BotholomewConfig>;
-  conn: DuckDBConnection;
+  conn: DbConnection;
   threadId: string;
   projectDir: string;
 }): Promise<AgentLoopResult> {

--- a/src/daemon/tick.ts
+++ b/src/daemon/tick.ts
@@ -1,5 +1,5 @@
 import type { BotholomewConfig } from "../config/schemas.ts";
-import type { DuckDBConnection } from "../db/connection.ts";
+import type { DbConnection } from "../db/connection.ts";
 import { claimNextTask, updateTaskStatus } from "../db/tasks.ts";
 import { createThread, endThread, logInteraction } from "../db/threads.ts";
 import { logger } from "../utils/logger.ts";
@@ -8,7 +8,7 @@ import { buildSystemPrompt } from "./prompt.ts";
 
 export async function tick(
   projectDir: string,
-  conn: DuckDBConnection,
+  conn: DbConnection,
   config: Required<BotholomewConfig>,
 ): Promise<void> {
   logger.debug("Tick starting...");

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -1,18 +1,12 @@
-import type { DuckDBConnection } from "@duckdb/node-api";
-import { DuckDBInstance } from "@duckdb/node-api";
+import { Database } from "bun:sqlite";
 
-export type { DuckDBConnection } from "@duckdb/node-api";
+export type DbConnection = Database;
 
-export async function getConnection(dbPath: string): Promise<DuckDBConnection> {
-  return withRetry(async () => {
-    const instance = await DuckDBInstance.create(dbPath);
-    return instance.connect();
-  });
-}
-
-export async function getMemoryConnection(): Promise<DuckDBConnection> {
-  const instance = await DuckDBInstance.create(":memory:");
-  return instance.connect();
+export function getConnection(dbPath: string): Database {
+  const db = new Database(dbPath, { create: true });
+  db.exec("PRAGMA journal_mode = WAL");
+  db.exec("PRAGMA foreign_keys = ON");
+  return db;
 }
 
 export async function withRetry<T>(
@@ -27,7 +21,8 @@ export async function withRetry<T>(
       lastError = err;
       const isBusy =
         err instanceof Error &&
-        (err.message.includes("BUSY") || err.message.includes("lock"));
+        (err.message.includes("SQLITE_BUSY") ||
+          err.message.includes("database is locked"));
       if (!isBusy || attempt === maxRetries - 1) throw err;
       // exponential backoff: 100ms, 200ms, 400ms, 800ms, 1600ms
       await Bun.sleep(100 * 2 ** attempt);

--- a/src/db/context.ts
+++ b/src/db/context.ts
@@ -1,4 +1,5 @@
-import type { DuckDBConnection } from "./connection.ts";
+import type { DbConnection } from "./connection.ts";
+import { uuidv7 } from "./uuid.ts";
 
 export interface ContextItem {
   id: string;
@@ -20,31 +21,41 @@ export interface Patch {
   content: string;
 }
 
-function rowToContextItem(row: unknown[]): ContextItem {
-  return {
-    id: String(row[0]),
-    title: String(row[1]),
-    description: String(row[2]),
-    content: row[3] != null ? String(row[3]) : null,
-    // skip content_blob (row[4])
-    mime_type: String(row[5]),
-    is_textual: Boolean(row[6]),
-    source_path: row[7] != null ? String(row[7]) : null,
-    context_path: String(row[8]),
-    indexed_at: row[9] != null ? new Date(String(row[9])) : null,
-    created_at: new Date(String(row[10])),
-    updated_at: new Date(String(row[11])),
-  };
+interface ContextItemRow {
+  id: string;
+  title: string;
+  description: string;
+  content: string | null;
+  content_blob: unknown;
+  mime_type: string;
+  is_textual: number;
+  source_path: string | null;
+  context_path: string;
+  indexed_at: string | null;
+  created_at: string;
+  updated_at: string;
 }
 
-function escapeSql(str: string): string {
-  return str.replace(/'/g, "''");
+function rowToContextItem(row: ContextItemRow): ContextItem {
+  return {
+    id: row.id,
+    title: row.title,
+    description: row.description,
+    content: row.content,
+    mime_type: row.mime_type,
+    is_textual: row.is_textual === 1,
+    source_path: row.source_path,
+    context_path: row.context_path,
+    indexed_at: row.indexed_at ? new Date(row.indexed_at) : null,
+    created_at: new Date(row.created_at),
+    updated_at: new Date(row.updated_at),
+  };
 }
 
 // --- Basic CRUD ---
 
 export async function createContextItem(
-  conn: DuckDBConnection,
+  db: DbConnection,
   params: {
     title: string;
     content?: string;
@@ -55,48 +66,49 @@ export async function createContextItem(
     isTextual?: boolean;
   },
 ): Promise<ContextItem> {
-  const result = await conn.runAndReadAll(`
-    INSERT INTO context_items (title, description, content, mime_type, is_textual, source_path, context_path)
-    VALUES (
-      '${escapeSql(params.title)}',
-      '${escapeSql(params.description ?? "")}',
-      ${params.content != null ? `'${escapeSql(params.content)}'` : "NULL"},
-      '${escapeSql(params.mimeType ?? "text/plain")}',
-      ${params.isTextual !== false},
-      ${params.sourcePath != null ? `'${escapeSql(params.sourcePath)}'` : "NULL"},
-      '${escapeSql(params.contextPath)}'
+  const id = uuidv7();
+  const row = db
+    .query(
+      `INSERT INTO context_items (id, title, description, content, mime_type, is_textual, source_path, context_path)
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+     RETURNING *`,
     )
-    RETURNING *
-  `);
-  const row = result.getRows()[0];
+    .get(
+      id,
+      params.title,
+      params.description ?? "",
+      params.content ?? null,
+      params.mimeType ?? "text/plain",
+      params.isTextual !== false ? 1 : 0,
+      params.sourcePath ?? null,
+      params.contextPath,
+    ) as ContextItemRow | null;
   if (!row) throw new Error("INSERT did not return a row");
   return rowToContextItem(row);
 }
 
 export async function getContextItem(
-  conn: DuckDBConnection,
+  db: DbConnection,
   id: string,
 ): Promise<ContextItem | null> {
-  const result = await conn.runAndReadAll(
-    `SELECT * FROM context_items WHERE id = '${escapeSql(id)}'`,
-  );
-  const rows = result.getRows();
-  return rows[0] ? rowToContextItem(rows[0]) : null;
+  const row = db
+    .query("SELECT * FROM context_items WHERE id = ?1")
+    .get(id) as ContextItemRow | null;
+  return row ? rowToContextItem(row) : null;
 }
 
 export async function getContextItemByPath(
-  conn: DuckDBConnection,
+  db: DbConnection,
   contextPath: string,
 ): Promise<ContextItem | null> {
-  const result = await conn.runAndReadAll(
-    `SELECT * FROM context_items WHERE context_path = '${escapeSql(contextPath)}'`,
-  );
-  const rows = result.getRows();
-  return rows[0] ? rowToContextItem(rows[0]) : null;
+  const row = db
+    .query("SELECT * FROM context_items WHERE context_path = ?1")
+    .get(contextPath) as ContextItemRow | null;
+  return row ? rowToContextItem(row) : null;
 }
 
 export async function listContextItems(
-  conn: DuckDBConnection,
+  db: DbConnection,
   filters?: {
     contextPath?: string;
     mimeType?: string;
@@ -104,58 +116,79 @@ export async function listContextItems(
   },
 ): Promise<ContextItem[]> {
   const conditions: string[] = [];
-  if (filters?.contextPath)
-    conditions.push(`context_path = '${escapeSql(filters.contextPath)}'`);
-  if (filters?.mimeType)
-    conditions.push(`mime_type = '${escapeSql(filters.mimeType)}'`);
+  const params: (string | null)[] = [];
+
+  if (filters?.contextPath) {
+    params.push(filters.contextPath);
+    conditions.push(`context_path = ?${params.length}`);
+  }
+  if (filters?.mimeType) {
+    params.push(filters.mimeType);
+    conditions.push(`mime_type = ?${params.length}`);
+  }
 
   const where =
     conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
   const limit = filters?.limit ? `LIMIT ${filters.limit}` : "";
 
-  const result = await conn.runAndReadAll(
-    `SELECT * FROM context_items ${where} ORDER BY context_path ASC ${limit}`,
-  );
-  return result.getRows().map(rowToContextItem);
+  const rows = db
+    .query(
+      `SELECT * FROM context_items ${where} ORDER BY context_path ASC ${limit}`,
+    )
+    .all(...params) as ContextItemRow[];
+  return rows.map(rowToContextItem);
 }
 
 export async function listContextItemsByPrefix(
-  conn: DuckDBConnection,
+  db: DbConnection,
   prefix: string,
   opts?: { recursive?: boolean; limit?: number },
 ): Promise<ContextItem[]> {
   const normalizedPrefix = prefix.endsWith("/") ? prefix : `${prefix}/`;
 
-  let where: string;
-  if (opts?.recursive) {
-    // All items under this prefix at any depth
-    where = `WHERE context_path LIKE '${escapeSql(normalizedPrefix)}%'`;
-  } else {
-    // Only immediate children: match prefix but no further slashes
-    where = `WHERE context_path LIKE '${escapeSql(normalizedPrefix)}%'
-      AND context_path NOT LIKE '${escapeSql(normalizedPrefix)}%/%'`;
-  }
-
   const limit = opts?.limit ? `LIMIT ${opts.limit}` : "";
 
-  const result = await conn.runAndReadAll(
-    `SELECT * FROM context_items ${where} ORDER BY context_path ASC ${limit}`,
-  );
-  return result.getRows().map(rowToContextItem);
+  let rows: ContextItemRow[];
+  if (opts?.recursive) {
+    rows = db
+      .query(
+        `SELECT * FROM context_items
+       WHERE context_path LIKE ?1
+       ORDER BY context_path ASC ${limit}`,
+      )
+      .all(`${normalizedPrefix}%`) as ContextItemRow[];
+  } else {
+    // Only immediate children: match prefix but no further slashes
+    rows = db
+      .query(
+        `SELECT * FROM context_items
+       WHERE context_path LIKE ?1
+         AND context_path NOT LIKE ?2
+       ORDER BY context_path ASC ${limit}`,
+      )
+      .all(
+        `${normalizedPrefix}%`,
+        `${normalizedPrefix}%/%`,
+      ) as ContextItemRow[];
+  }
+
+  return rows.map(rowToContextItem);
 }
 
 export async function contextPathExists(
-  conn: DuckDBConnection,
+  db: DbConnection,
   contextPath: string,
 ): Promise<boolean> {
-  const result = await conn.runAndReadAll(
-    `SELECT 1 FROM context_items WHERE context_path = '${escapeSql(contextPath)}' LIMIT 1`,
-  );
-  return result.getRows().length > 0;
+  const row = db
+    .query(
+      "SELECT 1 AS found FROM context_items WHERE context_path = ?1 LIMIT 1",
+    )
+    .get(contextPath);
+  return row != null;
 }
 
 export async function getDistinctDirectories(
-  conn: DuckDBConnection,
+  db: DbConnection,
   prefix?: string,
 ): Promise<string[]> {
   const normalizedPrefix = prefix
@@ -164,80 +197,87 @@ export async function getDistinctDirectories(
       : `${prefix}/`
     : "/";
 
-  // Extract the directory portion after the prefix, taking only the first path segment
-  const where = prefix
-    ? `WHERE context_path LIKE '${escapeSql(normalizedPrefix)}%/%'`
-    : `WHERE context_path LIKE '%/%'`;
+  // Extract the first path segment after the prefix
+  const rows = db
+    .query(
+      `SELECT DISTINCT
+        ?1 || CASE
+          WHEN instr(substr(context_path, length(?1) + 1), '/') > 0
+          THEN substr(substr(context_path, length(?1) + 1), 1, instr(substr(context_path, length(?1) + 1), '/') - 1)
+          ELSE substr(context_path, length(?1) + 1)
+        END AS dir
+      FROM context_items
+      WHERE context_path LIKE ?2
+      ORDER BY dir ASC`,
+    )
+    .all(normalizedPrefix, `${normalizedPrefix}%/%`) as { dir: string }[];
 
-  const result = await conn.runAndReadAll(`
-    SELECT DISTINCT
-      '${escapeSql(normalizedPrefix)}' || split_part(
-        substr(context_path, length('${escapeSql(normalizedPrefix)}') + 1),
-        '/',
-        1
-      ) AS dir
-    FROM context_items
-    ${where}
-    ORDER BY dir ASC
-  `);
-
-  return result.getRows().map((row) => String(row[0]));
+  return rows.map((row) => row.dir);
 }
 
 // --- Mutations ---
 
 export async function updateContextItem(
-  conn: DuckDBConnection,
+  db: DbConnection,
   id: string,
   updates: Partial<
     Pick<ContextItem, "title" | "description" | "content" | "mime_type">
   >,
 ): Promise<ContextItem | null> {
-  const setClauses: string[] = ["updated_at = current_timestamp"];
-  if (updates.title !== undefined)
-    setClauses.push(`title = '${escapeSql(updates.title)}'`);
-  if (updates.description !== undefined)
-    setClauses.push(`description = '${escapeSql(updates.description)}'`);
-  if (updates.content !== undefined)
-    setClauses.push(
-      updates.content === null
-        ? "content = NULL"
-        : `content = '${escapeSql(updates.content)}'`,
-    );
-  if (updates.mime_type !== undefined)
-    setClauses.push(`mime_type = '${escapeSql(updates.mime_type)}'`);
+  const setClauses: string[] = ["updated_at = datetime('now')"];
+  const params: (string | null)[] = [];
 
-  const result = await conn.runAndReadAll(`
-    UPDATE context_items
-    SET ${setClauses.join(", ")}
-    WHERE id = '${escapeSql(id)}'
-    RETURNING *
-  `);
-  const rows = result.getRows();
-  return rows[0] ? rowToContextItem(rows[0]) : null;
+  if (updates.title !== undefined) {
+    params.push(updates.title);
+    setClauses.push(`title = ?${params.length}`);
+  }
+  if (updates.description !== undefined) {
+    params.push(updates.description);
+    setClauses.push(`description = ?${params.length}`);
+  }
+  if (updates.content !== undefined) {
+    params.push(updates.content);
+    setClauses.push(`content = ?${params.length}`);
+  }
+  if (updates.mime_type !== undefined) {
+    params.push(updates.mime_type);
+    setClauses.push(`mime_type = ?${params.length}`);
+  }
+
+  params.push(id);
+  const row = db
+    .query(
+      `UPDATE context_items
+     SET ${setClauses.join(", ")}
+     WHERE id = ?${params.length}
+     RETURNING *`,
+    )
+    .get(...params) as ContextItemRow | null;
+  return row ? rowToContextItem(row) : null;
 }
 
 export async function updateContextItemContent(
-  conn: DuckDBConnection,
+  db: DbConnection,
   contextPath: string,
   content: string,
 ): Promise<ContextItem | null> {
-  const result = await conn.runAndReadAll(`
-    UPDATE context_items
-    SET content = '${escapeSql(content)}', updated_at = current_timestamp
-    WHERE context_path = '${escapeSql(contextPath)}'
-    RETURNING *
-  `);
-  const rows = result.getRows();
-  return rows[0] ? rowToContextItem(rows[0]) : null;
+  const row = db
+    .query(
+      `UPDATE context_items
+     SET content = ?1, updated_at = datetime('now')
+     WHERE context_path = ?2
+     RETURNING *`,
+    )
+    .get(content, contextPath) as ContextItemRow | null;
+  return row ? rowToContextItem(row) : null;
 }
 
 export async function applyPatchesToContextItem(
-  conn: DuckDBConnection,
+  db: DbConnection,
   contextPath: string,
   patches: Patch[],
 ): Promise<{ item: ContextItem; applied: number }> {
-  const item = await getContextItemByPath(conn, contextPath);
+  const item = await getContextItemByPath(db, contextPath);
   if (!item) throw new Error(`Not found: ${contextPath}`);
   if (item.content == null) throw new Error(`No text content: ${contextPath}`);
 
@@ -260,20 +300,20 @@ export async function applyPatchesToContextItem(
   }
 
   const newContent = lines.join("\n");
-  const updated = await updateContextItemContent(conn, contextPath, newContent);
+  const updated = await updateContextItemContent(db, contextPath, newContent);
   if (!updated) throw new Error(`Failed to update: ${contextPath}`);
   return { item: updated, applied: patches.length };
 }
 
 export async function copyContextItem(
-  conn: DuckDBConnection,
+  db: DbConnection,
   srcPath: string,
   dstPath: string,
 ): Promise<ContextItem> {
-  const src = await getContextItemByPath(conn, srcPath);
+  const src = await getContextItemByPath(db, srcPath);
   if (!src) throw new Error(`Not found: ${srcPath}`);
 
-  return createContextItem(conn, {
+  return createContextItem(db, {
     title: src.title,
     description: src.description,
     content: src.content ?? undefined,
@@ -285,17 +325,19 @@ export async function copyContextItem(
 }
 
 export async function moveContextItem(
-  conn: DuckDBConnection,
+  db: DbConnection,
   oldPath: string,
   newPath: string,
 ): Promise<void> {
-  const result = await conn.runAndReadAll(`
-    UPDATE context_items
-    SET context_path = '${escapeSql(newPath)}', updated_at = current_timestamp
-    WHERE context_path = '${escapeSql(oldPath)}'
-    RETURNING id
-  `);
-  if (result.getRows().length === 0) {
+  const row = db
+    .query(
+      `UPDATE context_items
+     SET context_path = ?1, updated_at = datetime('now')
+     WHERE context_path = ?2
+     RETURNING id`,
+    )
+    .get(newPath, oldPath);
+  if (!row) {
     throw new Error(`Not found: ${oldPath}`);
   }
 }
@@ -303,69 +345,71 @@ export async function moveContextItem(
 // --- Deletion ---
 
 export async function deleteContextItem(
-  conn: DuckDBConnection,
+  db: DbConnection,
   id: string,
 ): Promise<boolean> {
   // Delete embeddings first (foreign key)
-  await conn.run(
-    `DELETE FROM embeddings WHERE context_item_id = '${escapeSql(id)}'`,
-  );
-  const result = await conn.runAndReadAll(
-    `DELETE FROM context_items WHERE id = '${escapeSql(id)}' RETURNING id`,
-  );
-  return result.getRows().length > 0;
+  db.query("DELETE FROM embeddings WHERE context_item_id = ?1").run(id);
+  const row = db
+    .query("DELETE FROM context_items WHERE id = ?1 RETURNING id")
+    .get(id);
+  return row != null;
 }
 
 export async function deleteContextItemByPath(
-  conn: DuckDBConnection,
+  db: DbConnection,
   contextPath: string,
 ): Promise<boolean> {
   // Get ID first so we can cascade embeddings
-  const item = await getContextItemByPath(conn, contextPath);
+  const item = await getContextItemByPath(db, contextPath);
   if (!item) return false;
-  return deleteContextItem(conn, item.id);
+  return deleteContextItem(db, item.id);
 }
 
 export async function deleteContextItemsByPrefix(
-  conn: DuckDBConnection,
+  db: DbConnection,
   prefix: string,
 ): Promise<number> {
   const normalizedPrefix = prefix.endsWith("/") ? prefix : `${prefix}/`;
 
   // Delete embeddings for all matching items
-  await conn.run(`
-    DELETE FROM embeddings
-    WHERE context_item_id IN (
-      SELECT id FROM context_items
-      WHERE context_path LIKE '${escapeSql(normalizedPrefix)}%'
-    )
-  `);
+  db.query(
+    `DELETE FROM embeddings
+     WHERE context_item_id IN (
+       SELECT id FROM context_items
+       WHERE context_path LIKE ?1
+     )`,
+  ).run(`${normalizedPrefix}%`);
 
-  const result = await conn.runAndReadAll(`
-    DELETE FROM context_items
-    WHERE context_path LIKE '${escapeSql(normalizedPrefix)}%'
-    RETURNING id
-  `);
-  return result.getRows().length;
+  const rows = db
+    .query(
+      `DELETE FROM context_items
+     WHERE context_path LIKE ?1
+     RETURNING id`,
+    )
+    .all(`${normalizedPrefix}%`);
+  return rows.length;
 }
 
 // --- Search ---
 
 export async function searchContextByKeyword(
-  conn: DuckDBConnection,
+  db: DbConnection,
   query: string,
   limit = 20,
 ): Promise<ContextItem[]> {
-  const escaped = escapeSql(query);
-  const result = await conn.runAndReadAll(`
-    SELECT * FROM context_items
-    WHERE content IS NOT NULL
-      AND (
-        lower(content) LIKE lower('%${escaped}%')
-        OR lower(title) LIKE lower('%${escaped}%')
-      )
-    ORDER BY updated_at DESC
-    LIMIT ${limit}
-  `);
-  return result.getRows().map(rowToContextItem);
+  const pattern = `%${query}%`;
+  const rows = db
+    .query(
+      `SELECT * FROM context_items
+     WHERE content IS NOT NULL
+       AND (
+         content LIKE ?1 COLLATE NOCASE
+         OR title LIKE ?1 COLLATE NOCASE
+       )
+     ORDER BY updated_at DESC
+     LIMIT ?2`,
+    )
+    .all(pattern, limit) as ContextItemRow[];
+  return rows.map(rowToContextItem);
 }

--- a/src/db/embeddings.ts
+++ b/src/db/embeddings.ts
@@ -1,4 +1,4 @@
-import type { DuckDBConnection } from "./connection.ts";
+import type { DbConnection } from "./connection.ts";
 
 export interface Embedding {
   id: string;
@@ -14,7 +14,7 @@ export interface Embedding {
 
 // Stub — full implementation in a later milestone
 export async function searchEmbeddings(
-  _conn: DuckDBConnection,
+  _db: DbConnection,
   _query: number[],
   _limit?: number,
 ): Promise<Embedding[]> {

--- a/src/db/schedules.ts
+++ b/src/db/schedules.ts
@@ -1,4 +1,4 @@
-import type { DuckDBConnection } from "./connection.ts";
+import type { DbConnection } from "./connection.ts";
 
 export interface Schedule {
   id: string;
@@ -12,8 +12,6 @@ export interface Schedule {
 }
 
 // Stub — full implementation in a later milestone
-export async function listSchedules(
-  _conn: DuckDBConnection,
-): Promise<Schedule[]> {
+export async function listSchedules(_db: DbConnection): Promise<Schedule[]> {
   return [];
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,6 +1,6 @@
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import type { DuckDBConnection } from "./connection.ts";
+import type { DbConnection } from "./connection.ts";
 
 interface Migration {
   id: number;
@@ -29,19 +29,21 @@ function loadMigrations(): Migration[] {
   });
 }
 
-export async function migrate(conn: DuckDBConnection): Promise<void> {
+export function migrate(db: DbConnection): void {
   // Create migrations tracking table
-  await conn.run(`
+  db.exec(`
     CREATE TABLE IF NOT EXISTS _migrations (
       id INTEGER PRIMARY KEY,
-      name VARCHAR NOT NULL,
-      applied_at TIMESTAMP DEFAULT current_timestamp
+      name TEXT NOT NULL,
+      applied_at TEXT DEFAULT (datetime('now'))
     )
   `);
 
   // Get already-applied migrations
-  const result = await conn.runAndReadAll("SELECT id FROM _migrations");
-  const applied = new Set(result.getRows().map((row) => Number(row[0])));
+  const rows = db.query("SELECT id FROM _migrations").all() as {
+    id: number;
+  }[];
+  const applied = new Set(rows.map((row) => row.id));
 
   // Run pending migrations in order
   for (const migration of loadMigrations()) {
@@ -54,26 +56,11 @@ export async function migrate(conn: DuckDBConnection): Promise<void> {
       .filter((s) => s.length > 0);
 
     for (const statement of statements) {
-      await conn.run(statement);
+      db.exec(statement);
     }
 
-    await conn.run(
+    db.exec(
       `INSERT INTO _migrations (id, name) VALUES (${migration.id}, '${migration.name}')`,
     );
-  }
-}
-
-export async function installVss(conn: DuckDBConnection): Promise<boolean> {
-  try {
-    await conn.run("INSTALL vss");
-    await conn.run("LOAD vss");
-    await conn.run(`
-      CREATE INDEX IF NOT EXISTS embeddings_vss_idx
-      ON embeddings USING HNSW (embedding)
-      WITH (metric = 'cosine')
-    `);
-    return true;
-  } catch {
-    return false;
   }
 }

--- a/src/db/sql/1-core_tables.sql
+++ b/src/db/sql/1-core_tables.sql
@@ -1,56 +1,53 @@
-CREATE TYPE task_priority AS ENUM ('low', 'medium', 'high');
-CREATE TYPE task_status AS ENUM ('pending', 'in_progress', 'failed', 'complete', 'waiting');
-
 CREATE TABLE tasks (
-  id VARCHAR PRIMARY KEY DEFAULT gen_random_uuid()::VARCHAR,
-  name VARCHAR NOT NULL,
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
   description TEXT NOT NULL DEFAULT '',
-  priority task_priority NOT NULL DEFAULT 'medium',
-  status task_status NOT NULL DEFAULT 'pending',
+  priority TEXT NOT NULL DEFAULT 'medium' CHECK(priority IN ('low', 'medium', 'high')),
+  status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending', 'in_progress', 'failed', 'complete', 'waiting')),
   waiting_reason TEXT,
-  claimed_by VARCHAR,
-  claimed_at TIMESTAMP,
-  blocked_by VARCHAR[],
-  context_ids VARCHAR[],
-  created_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
-  updated_at TIMESTAMP NOT NULL DEFAULT current_timestamp
+  claimed_by TEXT,
+  claimed_at TEXT,
+  blocked_by TEXT NOT NULL DEFAULT '[]',
+  context_ids TEXT NOT NULL DEFAULT '[]',
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
 CREATE TABLE schedules (
-  id VARCHAR PRIMARY KEY DEFAULT gen_random_uuid()::VARCHAR,
-  name VARCHAR NOT NULL,
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
   description TEXT NOT NULL DEFAULT '',
-  frequency VARCHAR NOT NULL,
-  last_run_at TIMESTAMP,
-  enabled BOOLEAN NOT NULL DEFAULT true,
-  created_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
-  updated_at TIMESTAMP NOT NULL DEFAULT current_timestamp
+  frequency TEXT NOT NULL,
+  last_run_at TEXT,
+  enabled INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
 CREATE TABLE context_items (
-  id VARCHAR PRIMARY KEY DEFAULT gen_random_uuid()::VARCHAR,
-  title VARCHAR NOT NULL,
+  id TEXT PRIMARY KEY,
+  title TEXT NOT NULL,
   description TEXT NOT NULL DEFAULT '',
   content TEXT,
   content_blob BLOB,
-  mime_type VARCHAR NOT NULL DEFAULT 'text/plain',
-  is_textual BOOLEAN NOT NULL DEFAULT true,
-  source_path VARCHAR,
-  context_path VARCHAR NOT NULL,
-  indexed_at TIMESTAMP,
-  created_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
-  updated_at TIMESTAMP NOT NULL DEFAULT current_timestamp
+  mime_type TEXT NOT NULL DEFAULT 'text/plain',
+  is_textual INTEGER NOT NULL DEFAULT 1,
+  source_path TEXT,
+  context_path TEXT NOT NULL,
+  indexed_at TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
 CREATE TABLE embeddings (
-  id VARCHAR PRIMARY KEY DEFAULT gen_random_uuid()::VARCHAR,
-  context_item_id VARCHAR NOT NULL REFERENCES context_items(id),
+  id TEXT PRIMARY KEY,
+  context_item_id TEXT NOT NULL REFERENCES context_items(id),
   chunk_index INTEGER NOT NULL,
   chunk_content TEXT,
-  title VARCHAR NOT NULL,
+  title TEXT NOT NULL,
   description TEXT NOT NULL DEFAULT '',
-  source_path VARCHAR,
-  embedding FLOAT[384],
-  created_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
+  source_path TEXT,
+  embedding TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
   UNIQUE(context_item_id, chunk_index)
 );

--- a/src/db/sql/2-logging_tables.sql
+++ b/src/db/sql/2-logging_tables.sql
@@ -1,35 +1,24 @@
-CREATE TYPE thread_type AS ENUM ('daemon_tick', 'chat_session');
-CREATE TYPE interaction_role AS ENUM ('user', 'assistant', 'system', 'tool');
-CREATE TYPE interaction_kind AS ENUM (
-  'message',
-  'thinking',
-  'tool_use',
-  'tool_result',
-  'context_update',
-  'status_change'
-);
-
 CREATE TABLE threads (
-  id VARCHAR PRIMARY KEY DEFAULT gen_random_uuid()::VARCHAR,
-  type thread_type NOT NULL,
-  task_id VARCHAR,
-  title VARCHAR NOT NULL DEFAULT '',
-  started_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
-  ended_at TIMESTAMP,
+  id TEXT PRIMARY KEY,
+  type TEXT NOT NULL CHECK(type IN ('daemon_tick', 'chat_session')),
+  task_id TEXT,
+  title TEXT NOT NULL DEFAULT '',
+  started_at TEXT NOT NULL DEFAULT (datetime('now')),
+  ended_at TEXT,
   metadata TEXT
 );
 
 CREATE TABLE interactions (
-  id VARCHAR PRIMARY KEY DEFAULT gen_random_uuid()::VARCHAR,
-  thread_id VARCHAR NOT NULL REFERENCES threads(id),
+  id TEXT PRIMARY KEY,
+  thread_id TEXT NOT NULL REFERENCES threads(id),
   sequence INTEGER NOT NULL,
-  role interaction_role NOT NULL,
-  kind interaction_kind NOT NULL,
+  role TEXT NOT NULL CHECK(role IN ('user', 'assistant', 'system', 'tool')),
+  kind TEXT NOT NULL CHECK(kind IN ('message', 'thinking', 'tool_use', 'tool_result', 'context_update', 'status_change')),
   content TEXT NOT NULL,
-  tool_name VARCHAR,
+  tool_name TEXT,
   tool_input TEXT,
   duration_ms INTEGER,
   token_count INTEGER,
-  created_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
   UNIQUE(thread_id, sequence)
 );

--- a/src/db/sql/3-daemon_state.sql
+++ b/src/db/sql/3-daemon_state.sql
@@ -1,5 +1,5 @@
 CREATE TABLE daemon_state (
-  key VARCHAR PRIMARY KEY,
+  key TEXT PRIMARY KEY,
   value TEXT NOT NULL,
-  updated_at TIMESTAMP NOT NULL DEFAULT current_timestamp
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );

--- a/src/db/tasks.ts
+++ b/src/db/tasks.ts
@@ -1,4 +1,5 @@
-import type { DuckDBConnection } from "./connection.ts";
+import type { DbConnection } from "./connection.ts";
+import { uuidv7 } from "./uuid.ts";
 
 export const TASK_PRIORITIES = ["low", "medium", "high"] as const;
 export const TASK_STATUSES = [
@@ -24,25 +25,40 @@ export interface Task {
   updated_at: Date;
 }
 
-function rowToTask(row: unknown[]): Task {
+interface TaskRow {
+  id: string;
+  name: string;
+  description: string;
+  priority: string;
+  status: string;
+  waiting_reason: string | null;
+  claimed_by: string | null;
+  claimed_at: string | null;
+  blocked_by: string;
+  context_ids: string;
+  created_at: string;
+  updated_at: string;
+}
+
+function rowToTask(row: TaskRow): Task {
   return {
-    id: String(row[0]),
-    name: String(row[1]),
-    description: String(row[2]),
-    priority: String(row[3]) as Task["priority"],
-    status: String(row[4]) as Task["status"],
-    waiting_reason: row[5] ? String(row[5]) : null,
-    claimed_by: row[6] ? String(row[6]) : null,
-    claimed_at: row[7] ? new Date(String(row[7])) : null,
-    blocked_by: row[8] ? (row[8] as string[]) : [],
-    context_ids: row[9] ? (row[9] as string[]) : [],
-    created_at: new Date(String(row[10])),
-    updated_at: new Date(String(row[11])),
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    priority: row.priority as Task["priority"],
+    status: row.status as Task["status"],
+    waiting_reason: row.waiting_reason,
+    claimed_by: row.claimed_by,
+    claimed_at: row.claimed_at ? new Date(row.claimed_at) : null,
+    blocked_by: JSON.parse(row.blocked_by || "[]"),
+    context_ids: JSON.parse(row.context_ids || "[]"),
+    created_at: new Date(row.created_at),
+    updated_at: new Date(row.updated_at),
   };
 }
 
 export async function createTask(
-  conn: DuckDBConnection,
+  db: DbConnection,
   params: {
     name: string;
     description?: string;
@@ -51,36 +67,40 @@ export async function createTask(
     context_ids?: string[];
   },
 ): Promise<Task> {
-  const blockedBy = params.blocked_by?.length
-    ? `ARRAY[${params.blocked_by.map((id) => `'${id}'`).join(",")}]::VARCHAR[]`
-    : "NULL";
-  const contextIds = params.context_ids?.length
-    ? `ARRAY[${params.context_ids.map((id) => `'${id}'`).join(",")}]::VARCHAR[]`
-    : "NULL";
+  const id = uuidv7();
+  const blockedBy = JSON.stringify(params.blocked_by ?? []);
+  const contextIds = JSON.stringify(params.context_ids ?? []);
 
-  const result = await conn.runAndReadAll(`
-    INSERT INTO tasks (name, description, priority, blocked_by, context_ids)
-    VALUES ('${escapeSql(params.name)}', '${escapeSql(params.description ?? "")}', '${params.priority ?? "medium"}', ${blockedBy}, ${contextIds})
-    RETURNING *
-  `);
-  const row = result.getRows()[0];
+  const row = db
+    .query(
+      `INSERT INTO tasks (id, name, description, priority, blocked_by, context_ids)
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+     RETURNING *`,
+    )
+    .get(
+      id,
+      params.name,
+      params.description ?? "",
+      params.priority ?? "medium",
+      blockedBy,
+      contextIds,
+    ) as TaskRow | null;
   if (!row) throw new Error("INSERT did not return a row");
   return rowToTask(row);
 }
 
 export async function getTask(
-  conn: DuckDBConnection,
+  db: DbConnection,
   id: string,
 ): Promise<Task | null> {
-  const result = await conn.runAndReadAll(
-    `SELECT * FROM tasks WHERE id = '${escapeSql(id)}'`,
-  );
-  const rows = result.getRows();
-  return rows[0] ? rowToTask(rows[0]) : null;
+  const row = db
+    .query("SELECT * FROM tasks WHERE id = ?1")
+    .get(id) as TaskRow | null;
+  return row ? rowToTask(row) : null;
 }
 
 export async function listTasks(
-  conn: DuckDBConnection,
+  db: DbConnection,
   filters?: {
     status?: Task["status"];
     priority?: Task["priority"];
@@ -88,82 +108,87 @@ export async function listTasks(
   },
 ): Promise<Task[]> {
   const conditions: string[] = [];
-  if (filters?.status) conditions.push(`status = '${filters.status}'`);
-  if (filters?.priority) conditions.push(`priority = '${filters.priority}'`);
+  const params: string[] = [];
+
+  if (filters?.status) {
+    params.push(filters.status);
+    conditions.push(`status = ?${params.length}`);
+  }
+  if (filters?.priority) {
+    params.push(filters.priority);
+    conditions.push(`priority = ?${params.length}`);
+  }
 
   const where =
     conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
   const limit = filters?.limit ? `LIMIT ${filters.limit}` : "";
 
-  const result = await conn.runAndReadAll(`
-    SELECT * FROM tasks ${where}
-    ORDER BY
-      CASE priority WHEN 'high' THEN 0 WHEN 'medium' THEN 1 WHEN 'low' THEN 2 END,
-      created_at ASC
-    ${limit}
-  `);
-  return result.getRows().map(rowToTask);
+  const rows = db
+    .query(
+      `SELECT * FROM tasks ${where}
+     ORDER BY
+       CASE priority WHEN 'high' THEN 0 WHEN 'medium' THEN 1 WHEN 'low' THEN 2 END,
+       created_at ASC
+     ${limit}`,
+    )
+    .all(...params) as TaskRow[];
+  return rows.map(rowToTask);
 }
 
 export async function updateTaskStatus(
-  conn: DuckDBConnection,
+  db: DbConnection,
   id: string,
   status: Task["status"],
   reason?: string,
 ): Promise<void> {
-  const reasonClause = reason
-    ? `, waiting_reason = '${escapeSql(reason)}'`
-    : ", waiting_reason = NULL";
-
-  await conn.run(`
-    UPDATE tasks
-    SET status = '${status}', updated_at = current_timestamp ${reasonClause}
-    WHERE id = '${escapeSql(id)}'
-  `);
+  db.query(
+    `UPDATE tasks
+     SET status = ?1, waiting_reason = ?2, updated_at = datetime('now')
+     WHERE id = ?3`,
+  ).run(status, reason ?? null, id);
 }
 
 export async function claimNextTask(
-  conn: DuckDBConnection,
+  db: DbConnection,
   claimedBy = "daemon",
 ): Promise<Task | null> {
   // Find highest-priority unblocked pending task
-  const result = await conn.runAndReadAll(`
-    SELECT * FROM tasks
-    WHERE status = 'pending'
-      AND (
-        blocked_by IS NULL
-        OR array_length(blocked_by) = 0
-        OR NOT EXISTS (
-          SELECT 1 FROM unnest(blocked_by) AS b(id)
-          WHERE b.id NOT IN (SELECT id FROM tasks WHERE status = 'complete')
-        )
-      )
-    ORDER BY
-      CASE priority WHEN 'high' THEN 0 WHEN 'medium' THEN 1 WHEN 'low' THEN 2 END,
-      created_at ASC
-    LIMIT 1
-  `);
+  const row = db
+    .query(
+      `SELECT * FROM tasks
+     WHERE status = 'pending'
+       AND (
+         blocked_by = '[]'
+         OR blocked_by IS NULL
+         OR NOT EXISTS (
+           SELECT 1 FROM json_each(blocked_by) AS b
+           WHERE b.value NOT IN (SELECT id FROM tasks WHERE status = 'complete')
+         )
+       )
+     ORDER BY
+       CASE priority WHEN 'high' THEN 0 WHEN 'medium' THEN 1 WHEN 'low' THEN 2 END,
+       created_at ASC
+     LIMIT 1`,
+    )
+    .get() as TaskRow | null;
 
-  const rows = result.getRows();
-  if (rows.length === 0) return null;
+  if (!row) return null;
+  const task = rowToTask(row);
 
-  const firstRow = rows[0];
-  if (!firstRow) return null;
-  const task = rowToTask(firstRow);
+  // Claim it
+  db.query(
+    `UPDATE tasks
+     SET status = 'in_progress',
+         claimed_by = ?1,
+         claimed_at = datetime('now'),
+         updated_at = datetime('now')
+     WHERE id = ?2 AND status = 'pending'`,
+  ).run(claimedBy, task.id);
 
-  // Claim it atomically
-  await conn.run(`
-    UPDATE tasks
-    SET status = 'in_progress',
-        claimed_by = '${escapeSql(claimedBy)}',
-        claimed_at = current_timestamp,
-        updated_at = current_timestamp
-    WHERE id = '${escapeSql(task.id)}' AND status = 'pending'
-  `);
-
-  return { ...task, status: "in_progress", claimed_by: claimedBy };
-}
-
-function escapeSql(str: string): string {
-  return str.replace(/'/g, "''");
+  return {
+    ...task,
+    status: "in_progress",
+    claimed_by: claimedBy,
+    claimed_at: new Date(),
+  };
 }

--- a/src/db/threads.ts
+++ b/src/db/threads.ts
@@ -1,4 +1,5 @@
-import type { DuckDBConnection } from "./connection.ts";
+import type { DbConnection } from "./connection.ts";
+import { uuidv7 } from "./uuid.ts";
 
 export interface Thread {
   id: string;
@@ -30,53 +31,74 @@ export interface Interaction {
   created_at: Date;
 }
 
-function rowToThread(row: unknown[]): Thread {
+interface ThreadRow {
+  id: string;
+  type: string;
+  task_id: string | null;
+  title: string;
+  started_at: string;
+  ended_at: string | null;
+  metadata: string | null;
+}
+
+interface InteractionRow {
+  id: string;
+  thread_id: string;
+  sequence: number;
+  role: string;
+  kind: string;
+  content: string;
+  tool_name: string | null;
+  tool_input: string | null;
+  duration_ms: number | null;
+  token_count: number | null;
+  created_at: string;
+}
+
+function rowToThread(row: ThreadRow): Thread {
   return {
-    id: String(row[0]),
-    type: String(row[1]) as Thread["type"],
-    task_id: row[2] ? String(row[2]) : null,
-    title: String(row[3]),
-    started_at: new Date(String(row[4])),
-    ended_at: row[5] ? new Date(String(row[5])) : null,
-    metadata: row[6] ? String(row[6]) : null,
+    id: row.id,
+    type: row.type as Thread["type"],
+    task_id: row.task_id,
+    title: row.title,
+    started_at: new Date(row.started_at),
+    ended_at: row.ended_at ? new Date(row.ended_at) : null,
+    metadata: row.metadata,
   };
 }
 
-function rowToInteraction(row: unknown[]): Interaction {
+function rowToInteraction(row: InteractionRow): Interaction {
   return {
-    id: String(row[0]),
-    thread_id: String(row[1]),
-    sequence: Number(row[2]),
-    role: String(row[3]) as Interaction["role"],
-    kind: String(row[4]) as Interaction["kind"],
-    content: String(row[5]),
-    tool_name: row[6] ? String(row[6]) : null,
-    tool_input: row[7] ? String(row[7]) : null,
-    duration_ms: row[8] ? Number(row[8]) : null,
-    token_count: row[9] ? Number(row[9]) : null,
-    created_at: new Date(String(row[10])),
+    id: row.id,
+    thread_id: row.thread_id,
+    sequence: row.sequence,
+    role: row.role as Interaction["role"],
+    kind: row.kind as Interaction["kind"],
+    content: row.content,
+    tool_name: row.tool_name,
+    tool_input: row.tool_input,
+    duration_ms: row.duration_ms,
+    token_count: row.token_count,
+    created_at: new Date(row.created_at),
   };
 }
 
 export async function createThread(
-  conn: DuckDBConnection,
+  db: DbConnection,
   type: Thread["type"],
   taskId?: string,
   title?: string,
 ): Promise<string> {
-  const taskIdVal = taskId ? `'${escapeSql(taskId)}'` : "NULL";
-  const titleVal = title ? `'${escapeSql(title)}'` : "''";
-
-  const result = await conn.runAndReadAll(`
-    INSERT INTO threads (type, task_id, title)
-    VALUES ('${type}', ${taskIdVal}, ${titleVal})
-    RETURNING id
-  `);
-  return String(result.getRows()[0]?.[0]);
+  const id = uuidv7();
+  db.query(
+    `INSERT INTO threads (id, type, task_id, title)
+     VALUES (?1, ?2, ?3, ?4)`,
+  ).run(id, type, taskId ?? null, title ?? "");
+  return id;
 }
 
 export async function logInteraction(
-  conn: DuckDBConnection,
+  db: DbConnection,
   threadId: string,
   params: {
     role: Interaction["role"];
@@ -89,58 +111,64 @@ export async function logInteraction(
   },
 ): Promise<string> {
   // Get next sequence number
-  const seqResult = await conn.runAndReadAll(`
-    SELECT COALESCE(MAX(sequence), 0) + 1 FROM interactions WHERE thread_id = '${escapeSql(threadId)}'
-  `);
-  const sequence = Number(seqResult.getRows()[0]?.[0]);
+  const seqRow = db
+    .query(
+      "SELECT COALESCE(MAX(sequence), 0) + 1 AS next_seq FROM interactions WHERE thread_id = ?1",
+    )
+    .get(threadId) as { next_seq: number };
+  const sequence = seqRow.next_seq;
 
-  const toolName = params.toolName ? `'${escapeSql(params.toolName)}'` : "NULL";
-  const toolInput = params.toolInput
-    ? `'${escapeSql(params.toolInput)}'`
-    : "NULL";
-  const durationMs = params.durationMs ?? "NULL";
-  const tokenCount = params.tokenCount ?? "NULL";
-
-  const result = await conn.runAndReadAll(`
-    INSERT INTO interactions (thread_id, sequence, role, kind, content, tool_name, tool_input, duration_ms, token_count)
-    VALUES ('${escapeSql(threadId)}', ${sequence}, '${params.role}', '${params.kind}', '${escapeSql(params.content)}', ${toolName}, ${toolInput}, ${durationMs}, ${tokenCount})
-    RETURNING id
-  `);
-  return String(result.getRows()[0]?.[0]);
+  const id = uuidv7();
+  db.query(
+    `INSERT INTO interactions (id, thread_id, sequence, role, kind, content, tool_name, tool_input, duration_ms, token_count)
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)`,
+  ).run(
+    id,
+    threadId,
+    sequence,
+    params.role,
+    params.kind,
+    params.content,
+    params.toolName ?? null,
+    params.toolInput ?? null,
+    params.durationMs ?? null,
+    params.tokenCount ?? null,
+  );
+  return id;
 }
 
 export async function endThread(
-  conn: DuckDBConnection,
+  db: DbConnection,
   threadId: string,
 ): Promise<void> {
-  await conn.run(`
-    UPDATE threads SET ended_at = current_timestamp WHERE id = '${escapeSql(threadId)}'
-  `);
+  db.query("UPDATE threads SET ended_at = datetime('now') WHERE id = ?1").run(
+    threadId,
+  );
 }
 
 export async function getThread(
-  conn: DuckDBConnection,
+  db: DbConnection,
   threadId: string,
 ): Promise<{ thread: Thread; interactions: Interaction[] } | null> {
-  const threadResult = await conn.runAndReadAll(
-    `SELECT * FROM threads WHERE id = '${escapeSql(threadId)}'`,
-  );
-  const threadRows = threadResult.getRows();
-  const firstRow = threadRows[0];
-  if (!firstRow) return null;
+  const threadRow = db
+    .query("SELECT * FROM threads WHERE id = ?1")
+    .get(threadId) as ThreadRow | null;
+  if (!threadRow) return null;
 
-  const interactionsResult = await conn.runAndReadAll(`
-    SELECT * FROM interactions WHERE thread_id = '${escapeSql(threadId)}' ORDER BY sequence ASC
-  `);
+  const interactionRows = db
+    .query(
+      "SELECT * FROM interactions WHERE thread_id = ?1 ORDER BY sequence ASC",
+    )
+    .all(threadId) as InteractionRow[];
 
   return {
-    thread: rowToThread(firstRow),
-    interactions: interactionsResult.getRows().map(rowToInteraction),
+    thread: rowToThread(threadRow),
+    interactions: interactionRows.map(rowToInteraction),
   };
 }
 
 export async function listThreads(
-  conn: DuckDBConnection,
+  db: DbConnection,
   filters?: {
     type?: Thread["type"];
     taskId?: string;
@@ -148,22 +176,27 @@ export async function listThreads(
   },
 ): Promise<Thread[]> {
   const conditions: string[] = [];
-  if (filters?.type) conditions.push(`type = '${filters.type}'`);
-  if (filters?.taskId)
-    conditions.push(`task_id = '${escapeSql(filters.taskId)}'`);
+  const params: string[] = [];
+
+  if (filters?.type) {
+    params.push(filters.type);
+    conditions.push(`type = ?${params.length}`);
+  }
+  if (filters?.taskId) {
+    params.push(filters.taskId);
+    conditions.push(`task_id = ?${params.length}`);
+  }
 
   const where =
     conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
   const limit = filters?.limit ? `LIMIT ${filters.limit}` : "";
 
-  const result = await conn.runAndReadAll(`
-    SELECT * FROM threads ${where}
-    ORDER BY started_at DESC
-    ${limit}
-  `);
-  return result.getRows().map(rowToThread);
-}
-
-function escapeSql(str: string): string {
-  return str.replace(/'/g, "''");
+  const rows = db
+    .query(
+      `SELECT * FROM threads ${where}
+     ORDER BY started_at DESC
+     ${limit}`,
+    )
+    .all(...params) as ThreadRow[];
+  return rows.map(rowToThread);
 }

--- a/src/db/uuid.ts
+++ b/src/db/uuid.ts
@@ -1,0 +1,1 @@
+export { v7 as uuidv7 } from "uuid";

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -50,9 +50,9 @@ export async function initProject(
 
   // Initialize database
   const dbPath = getDbPath(projectDir);
-  const conn = await getConnection(dbPath);
-  await migrate(conn);
-  conn.closeSync();
+  const conn = getConnection(dbPath);
+  migrate(conn);
+  conn.close();
 
   // Update .gitignore
   await updateGitignore(projectDir);

--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -1,10 +1,10 @@
 import type { Tool as AnthropicTool } from "@anthropic-ai/sdk/resources/messages";
 import { z } from "zod";
 import type { BotholomewConfig } from "../config/schemas.ts";
-import type { DuckDBConnection } from "../db/connection.ts";
+import type { DbConnection } from "../db/connection.ts";
 
 export interface ToolContext {
-  conn: DuckDBConnection;
+  conn: DbConnection;
   projectDir: string;
   config: Required<BotholomewConfig>;
 }

--- a/test/daemon/tick.test.ts
+++ b/test/daemon/tick.test.ts
@@ -1,8 +1,5 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
-import {
-  type DuckDBConnection,
-  getMemoryConnection,
-} from "../../src/db/connection.ts";
+import { type DbConnection, getConnection } from "../../src/db/connection.ts";
 import { migrate } from "../../src/db/schema.ts";
 import { createTask, getTask } from "../../src/db/tasks.ts";
 import { getThread, listThreads } from "../../src/db/threads.ts";
@@ -33,11 +30,11 @@ mock.module("@anthropic-ai/sdk", () => {
 // Import tick after mocking
 const { tick } = await import("../../src/daemon/tick.ts");
 
-let conn: DuckDBConnection;
+let conn: DbConnection;
 
-beforeEach(async () => {
-  conn = await getMemoryConnection();
-  await migrate(conn);
+beforeEach(() => {
+  conn = getConnection(":memory:");
+  migrate(conn);
 });
 
 describe("daemon tick", () => {

--- a/test/db/context.test.ts
+++ b/test/db/context.test.ts
@@ -1,8 +1,5 @@
 import { beforeEach, describe, expect, test } from "bun:test";
-import {
-  type DuckDBConnection,
-  getMemoryConnection,
-} from "../../src/db/connection.ts";
+import { type DbConnection, getConnection } from "../../src/db/connection.ts";
 import {
   applyPatchesToContextItem,
   contextPathExists,
@@ -23,11 +20,11 @@ import {
 } from "../../src/db/context.ts";
 import { migrate } from "../../src/db/schema.ts";
 
-let conn: DuckDBConnection;
+let conn: DbConnection;
 
-beforeEach(async () => {
-  conn = await getMemoryConnection();
-  await migrate(conn);
+beforeEach(() => {
+  conn = getConnection(":memory:");
+  migrate(conn);
 });
 
 describe("context CRUD", () => {

--- a/test/db/schema.test.ts
+++ b/test/db/schema.test.ts
@@ -1,17 +1,17 @@
 import { describe, expect, test } from "bun:test";
-import { getMemoryConnection } from "../../src/db/connection.ts";
+import { getConnection } from "../../src/db/connection.ts";
 import { migrate } from "../../src/db/schema.ts";
 
 describe("schema migrations", () => {
-  test("migrate runs cleanly on a fresh database", async () => {
-    const conn = await getMemoryConnection();
-    await migrate(conn);
+  test("migrate runs cleanly on a fresh database", () => {
+    const db = getConnection(":memory:");
+    migrate(db);
 
     // Verify all tables exist
-    const result = await conn.runAndReadAll(
-      "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main' ORDER BY table_name",
-    );
-    const tables = result.getRows().map((row) => String(row[0]));
+    const rows = db
+      .query("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+      .all() as { name: string }[];
+    const tables = rows.map((row) => row.name);
 
     expect(tables).toContain("_migrations");
     expect(tables).toContain("tasks");
@@ -21,26 +21,31 @@ describe("schema migrations", () => {
     expect(tables).toContain("threads");
     expect(tables).toContain("interactions");
     expect(tables).toContain("daemon_state");
+
+    db.close();
   });
 
-  test("migrate is idempotent", async () => {
-    const conn = await getMemoryConnection();
-    await migrate(conn);
-    await migrate(conn); // should not throw
+  test("migrate is idempotent", () => {
+    const db = getConnection(":memory:");
+    migrate(db);
+    migrate(db); // should not throw
 
-    const result = await conn.runAndReadAll("SELECT COUNT(*) FROM _migrations");
-    const count = Number(result.getRows()[0]?.[0]);
-    expect(count).toBe(3);
+    const row = db.query("SELECT COUNT(*) AS count FROM _migrations").get() as {
+      count: number;
+    };
+    expect(row.count).toBe(3);
+
+    db.close();
   });
 
-  test("tasks table has correct columns", async () => {
-    const conn = await getMemoryConnection();
-    await migrate(conn);
+  test("tasks table has correct columns", () => {
+    const db = getConnection(":memory:");
+    migrate(db);
 
-    const result = await conn.runAndReadAll(
-      "SELECT column_name FROM information_schema.columns WHERE table_name = 'tasks' ORDER BY ordinal_position",
-    );
-    const columns = result.getRows().map((row) => String(row[0]));
+    const rows = db.query("PRAGMA table_info('tasks')").all() as {
+      name: string;
+    }[];
+    const columns = rows.map((row) => row.name);
 
     expect(columns).toEqual([
       "id",
@@ -56,16 +61,18 @@ describe("schema migrations", () => {
       "created_at",
       "updated_at",
     ]);
+
+    db.close();
   });
 
-  test("threads table has correct columns", async () => {
-    const conn = await getMemoryConnection();
-    await migrate(conn);
+  test("threads table has correct columns", () => {
+    const db = getConnection(":memory:");
+    migrate(db);
 
-    const result = await conn.runAndReadAll(
-      "SELECT column_name FROM information_schema.columns WHERE table_name = 'threads' ORDER BY ordinal_position",
-    );
-    const columns = result.getRows().map((row) => String(row[0]));
+    const rows = db.query("PRAGMA table_info('threads')").all() as {
+      name: string;
+    }[];
+    const columns = rows.map((row) => row.name);
 
     expect(columns).toEqual([
       "id",
@@ -76,16 +83,18 @@ describe("schema migrations", () => {
       "ended_at",
       "metadata",
     ]);
+
+    db.close();
   });
 
-  test("interactions table has correct columns", async () => {
-    const conn = await getMemoryConnection();
-    await migrate(conn);
+  test("interactions table has correct columns", () => {
+    const db = getConnection(":memory:");
+    migrate(db);
 
-    const result = await conn.runAndReadAll(
-      "SELECT column_name FROM information_schema.columns WHERE table_name = 'interactions' ORDER BY ordinal_position",
-    );
-    const columns = result.getRows().map((row) => String(row[0]));
+    const rows = db.query("PRAGMA table_info('interactions')").all() as {
+      name: string;
+    }[];
+    const columns = rows.map((row) => row.name);
 
     expect(columns).toEqual([
       "id",
@@ -100,5 +109,7 @@ describe("schema migrations", () => {
       "token_count",
       "created_at",
     ]);
+
+    db.close();
   });
 });

--- a/test/db/tasks.test.ts
+++ b/test/db/tasks.test.ts
@@ -1,8 +1,5 @@
 import { beforeEach, describe, expect, test } from "bun:test";
-import {
-  type DuckDBConnection,
-  getMemoryConnection,
-} from "../../src/db/connection.ts";
+import { type DbConnection, getConnection } from "../../src/db/connection.ts";
 import { migrate } from "../../src/db/schema.ts";
 import {
   claimNextTask,
@@ -12,11 +9,11 @@ import {
   updateTaskStatus,
 } from "../../src/db/tasks.ts";
 
-let conn: DuckDBConnection;
+let conn: DbConnection;
 
-beforeEach(async () => {
-  conn = await getMemoryConnection();
-  await migrate(conn);
+beforeEach(() => {
+  conn = getConnection(":memory:");
+  migrate(conn);
 });
 
 describe("task CRUD", () => {

--- a/test/db/threads.test.ts
+++ b/test/db/threads.test.ts
@@ -1,8 +1,5 @@
 import { beforeEach, describe, expect, test } from "bun:test";
-import {
-  type DuckDBConnection,
-  getMemoryConnection,
-} from "../../src/db/connection.ts";
+import { type DbConnection, getConnection } from "../../src/db/connection.ts";
 import { migrate } from "../../src/db/schema.ts";
 import {
   createThread,
@@ -12,11 +9,11 @@ import {
   logInteraction,
 } from "../../src/db/threads.ts";
 
-let conn: DuckDBConnection;
+let conn: DbConnection;
 
-beforeEach(async () => {
-  conn = await getMemoryConnection();
-  await migrate(conn);
+beforeEach(() => {
+  conn = getConnection(":memory:");
+  migrate(conn);
 });
 
 describe("thread CRUD", () => {

--- a/test/init/index.test.ts
+++ b/test/init/index.test.ts
@@ -28,7 +28,7 @@ describe("initProject", () => {
     expect(await Bun.file(join(dotDir, "mcpx", "servers.json")).exists()).toBe(
       true,
     );
-    expect(await Bun.file(join(dotDir, "data.duckdb")).exists()).toBe(true);
+    expect(await Bun.file(join(dotDir, "data.sqlite")).exists()).toBe(true);
   });
 
   test("soul.md has correct frontmatter", async () => {


### PR DESCRIPTION
## Summary

- Replace DuckDB (`@duckdb/node-api`) with **bun:sqlite** — zero external dependencies, built into Bun
- Enables **standalone binary compilation** via `bun build --compile` (was blocked by DuckDB native bindings)
- Switch all SQL queries to **parameterized queries** (`?1, ?2, ...`), eliminating `escapeSql()` string interpolation
- Use **UUIDv7** via the `uuid` package for all primary keys (replaces `gen_random_uuid()`)
- ENUMs → `CHECK` constraints, `VARCHAR[]` arrays → JSON TEXT with `json_each()`, timestamps → ISO 8601 TEXT
- Remove `getMemoryConnection()` — tests use `getConnection(":memory:")`
- Update all docs/plans and CLAUDE.md to reflect SQLite conventions

## Changes across 31 files

- **`src/db/`** — Complete rewrite of connection, schema, and all CRUD modules (tasks, context, threads, embeddings, schedules)
- **`src/db/sql/*.sql`** — Schema migrations rewritten for SQLite syntax
- **`src/db/uuid.ts`** — New file, re-exports `v7` from `uuid` package
- **`src/daemon/`**, **`src/commands/`**, **`src/tools/`** — Updated `DuckDBConnection` → `DbConnection`, `closeSync()` → `close()`
- **`package.json`** — Removed `@duckdb/node-api`, added `uuid`, build now uses `--compile`
- **`test/`** — All 6 test files updated for SQLite API
- **Docs** — CLAUDE.md, README.md, milestone-1, milestone-2 updated

## Test plan

- [x] `bun run lint` passes (tsc + biome)
- [x] `bun test` — all 62 tests pass
- [x] `bun run build` — produces 60MB standalone Mach-O arm64 binary
- [x] No DuckDB references remain in source code

🤖 Generated with [Claude Code](https://claude.com/claude-code)