### PR TITLE
Fix CLI exiting with code 1 when no subcommand given

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,4 +25,8 @@ registerContextCommand(program);
 registerMcpxCommand(program);
 registerToolCommands(program);
 
+program.action(() => {
+  program.help();
+});
+
 program.parse();


### PR DESCRIPTION
## Summary
- Running the CLI with no subcommand (e.g. `bun run dev`) caused Commander.js to exit with code 1 since no default action was defined
- Added a default action that calls `program.help()`, which prints help text and exits with code 0

## Test plan
- [x] `bun run dev` exits with code 0
- [x] All 62 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)