### PR TITLE
Add color styling to CLI help output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
 
+import ansis from "ansis";
 import { program } from "commander";
 import { registerChatCommand } from "./commands/chat.ts";
 import { registerContextCommand } from "./commands/context.ts";
@@ -13,9 +14,16 @@ const pkg = await Bun.file(new URL("../package.json", import.meta.url)).json();
 
 program
   .name("botholomew")
-  .description("An AI agent for knowledge work")
+  .description(ansis.bold(pkg.description))
   .version(pkg.version)
-  .option("-d, --dir <path>", "project directory", process.cwd());
+  .option("-d, --dir <path>", "project directory", process.cwd())
+  .configureHelp({
+    styleTitle: (str) => ansis.bold(str),
+    styleUsage: (str) => ansis.cyan(str),
+    styleCommandText: (str) => ansis.green(str),
+    styleOptionTerm: (str) => ansis.yellow(str),
+    styleDescriptionText: (str) => ansis.dim(str),
+  });
 
 registerInitCommand(program);
 registerDaemonCommand(program);


### PR DESCRIPTION
## Summary
- Colorize CLI help text using Commander.js `configureHelp()` style hooks with `ansis` (already a dependency)
- Bold section titles, cyan usage line, green command names, yellow option flags, dim descriptions
- Program description now loaded from `package.json` and rendered bold

## Test plan
- [ ] Run `bun dev` and verify help output is colorized
- [ ] Run `bun dev task --help` and verify subcommand help is also styled
- [ ] `bun run lint` and `bun test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)