### PR TITLE
Add NPM publishing pipeline with check-update and upgrade commands

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,121 @@
+name: Auto Release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.check.outputs.should_release }}
+      tag: ${{ steps.version.outputs.tag }}
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get version from package.json
+        id: version
+        run: |
+          VERSION=$(jq -r .version package.json)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check if release exists
+        id: check
+        run: |
+          if gh release view "${{ steps.version.outputs.tag }}" &>/dev/null; then
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  create-release:
+    needs: check-version
+    if: needs.check-version.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create release
+        run: |
+          gh release create "${{ needs.check-version.outputs.tag }}" \
+            --title "${{ needs.check-version.outputs.tag }}" \
+            --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  ci:
+    needs: [check-version, create-release]
+    if: needs.check-version.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install --frozen-lockfile
+      - run: bun run lint
+      - run: bun test
+
+  publish-npm:
+    needs: [check-version, ci]
+    if: needs.check-version.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.14.0"
+      - run: npm install -g npm@11.5.1
+      - run: bun install --frozen-lockfile
+      - run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  build-binaries:
+    needs: [check-version, ci]
+    if: needs.check-version.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - target: bun-darwin-arm64
+            artifact: botholomew-darwin-arm64
+          - target: bun-darwin-x64
+            artifact: botholomew-darwin-x64
+          - target: bun-linux-arm64
+            artifact: botholomew-linux-arm64
+          - target: bun-linux-x64
+            artifact: botholomew-linux-x64
+          - target: bun-windows-x64
+            artifact: botholomew-windows-x64.exe
+          - target: bun-windows-arm64
+            artifact: botholomew-windows-arm64.exe
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install --frozen-lockfile
+      - name: Build binary
+        run: |
+          bun build --compile --minify --sourcemap \
+            --target=${{ matrix.target }} \
+            ./src/cli.ts --outfile dist/${{ matrix.artifact }}
+      - name: Upload to release
+        run: gh release upload "${{ needs.check-version.outputs.tag }}" dist/${{ matrix.artifact }} --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ An AI agent for knowledge work. See `docs/plans/README.md` for the milestone roa
 
 ## Conventions
 
+- Bump `version` in `package.json` for every change merged to `main` — the auto-release workflow uses this to determine when to publish
 - Run `bun run lint` and `bun test` before committing
 - `bun run lint` runs both `tsc --noEmit` and `biome check`
 - All database access goes through `src/db/` modules

--- a/package.json
+++ b/package.json
@@ -6,6 +6,15 @@
   "bin": {
     "botholomew": "./src/cli.ts"
   },
+  "files": [
+    "src",
+    "README.md",
+    "LICENSE"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/evantahler/botholomew.git"
+  },
   "scripts": {
     "dev": "bun run src/cli.ts",
     "test": "bun test",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,12 +2,15 @@
 
 import { program } from "commander";
 import { registerChatCommand } from "./commands/chat.ts";
+import { registerCheckUpdateCommand } from "./commands/check-update.ts";
 import { registerContextCommand } from "./commands/context.ts";
 import { registerDaemonCommand } from "./commands/daemon.ts";
 import { registerInitCommand } from "./commands/init.ts";
 import { registerMcpxCommand } from "./commands/mcpx.ts";
 import { registerTaskCommand } from "./commands/task.ts";
 import { registerToolCommands } from "./commands/tools.ts";
+import { registerUpgradeCommand } from "./commands/upgrade.ts";
+import { maybeCheckForUpdate } from "./update/background.ts";
 
 const pkg = await Bun.file(new URL("../package.json", import.meta.url)).json();
 
@@ -24,9 +27,19 @@ registerChatCommand(program);
 registerContextCommand(program);
 registerMcpxCommand(program);
 registerToolCommands(program);
+registerCheckUpdateCommand(program);
+registerUpgradeCommand(program);
 
 program.action(() => {
   program.help();
 });
 
+// Start background update check before parsing (non-blocking)
+const updateNotice = maybeCheckForUpdate();
+
 program.parse();
+
+// Print update notice to stderr after command completes
+updateNotice.then((notice) => {
+  if (notice) process.stderr.write(notice);
+});

--- a/src/commands/check-update.ts
+++ b/src/commands/check-update.ts
@@ -1,0 +1,62 @@
+import { cyan, dim, green, yellow } from "ansis";
+import type { Command } from "commander";
+import { saveUpdateCache } from "../update/cache.ts";
+import type { UpdateCache } from "../update/checker.ts";
+import { checkForUpdate } from "../update/checker.ts";
+
+const pkg = await Bun.file(
+  new URL("../../package.json", import.meta.url),
+).json();
+
+export function registerCheckUpdateCommand(program: Command) {
+  program
+    .command("check-update")
+    .description("Check for a newer version of botholomew")
+    .action(async () => {
+      try {
+        const info = await checkForUpdate(pkg.version);
+
+        // Save to cache
+        const cache: UpdateCache = {
+          lastCheckAt: new Date().toISOString(),
+          latestVersion: info.latestVersion,
+          hasUpdate: info.hasUpdate,
+          changelog: info.changelog,
+        };
+        await saveUpdateCache(cache);
+
+        if (!info.hasUpdate) {
+          if (info.aheadOfLatest) {
+            console.log(
+              yellow(
+                `botholomew v${info.currentVersion} is ahead of latest published release (v${info.latestVersion})`,
+              ),
+            );
+          } else {
+            console.log(
+              green(`botholomew is up to date (v${info.currentVersion})`),
+            );
+          }
+          return;
+        }
+
+        console.log(
+          yellow(
+            `Update available: ${info.currentVersion} → ${info.latestVersion}`,
+          ),
+        );
+
+        if (info.changelog) {
+          console.log("");
+          console.log(dim(info.changelog));
+        }
+
+        console.log("");
+        console.log(cyan("Run `botholomew upgrade` to update"));
+      } catch (err) {
+        console.error("Failed to check for updates");
+        console.error(String(err));
+        process.exit(1);
+      }
+    });
+}

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -1,0 +1,185 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { dim, green, red, yellow } from "ansis";
+import { $ } from "bun";
+import type { Command } from "commander";
+import {
+  clearUpdateCache,
+  loadUpdateCache,
+  saveUpdateCache,
+} from "../update/cache.ts";
+import type { UpdateCache } from "../update/checker.ts";
+import {
+  checkForUpdate,
+  detectInstallMethod,
+  type InstallMethod,
+  needsCheck,
+} from "../update/checker.ts";
+
+const pkg = await Bun.file(
+  new URL("../../package.json", import.meta.url),
+).json();
+
+const GITHUB_REPO = (pkg.repository.url as string)
+  .replace(/^https:\/\/github\.com\//, "")
+  .replace(/\.git$/, "");
+
+function platformArtifactName(): string {
+  let os: string;
+  let ext = "";
+  switch (process.platform) {
+    case "darwin":
+      os = "darwin";
+      break;
+    case "win32":
+      os = "windows";
+      ext = ".exe";
+      break;
+    default:
+      os = "linux";
+      break;
+  }
+  const arch = process.arch === "arm64" ? "arm64" : "x64";
+  return `botholomew-${os}-${arch}${ext}`;
+}
+
+async function upgradeWithPackageManager(
+  command: string,
+  args: string[],
+): Promise<boolean> {
+  const result = await $`${command} ${args}`.nothrow();
+  return result.exitCode === 0;
+}
+
+async function upgradeFromBinary(latestVersion: string): Promise<boolean> {
+  const artifact = platformArtifactName();
+  const tag = `v${latestVersion}`;
+  const url = `https://github.com/${GITHUB_REPO}/releases/download/${tag}/${artifact}`;
+
+  const tmpPath = join(tmpdir(), `botholomew-upgrade-${Date.now()}`);
+  const targetPath = process.execPath;
+
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      console.error(red(`Failed to download binary: HTTP ${res.status}`));
+      return false;
+    }
+
+    const bytes = await res.arrayBuffer();
+    await Bun.write(tmpPath, bytes);
+
+    await $`chmod +x ${tmpPath}`.quiet();
+
+    // Try to move into place
+    const mv = await $`mv ${tmpPath} ${targetPath}`.quiet().nothrow();
+
+    if (mv.exitCode !== 0) {
+      // Try with sudo
+      console.log(dim("Requires elevated permissions..."));
+      const sudo = await $`sudo mv ${tmpPath} ${targetPath}`.nothrow();
+      if (sudo.exitCode !== 0) {
+        console.error(red("Failed to install binary. Try running with sudo."));
+        return false;
+      }
+    }
+
+    return true;
+  } catch (err) {
+    console.error(red(`Failed to upgrade binary: ${err}`));
+    // Clean up temp file
+    await $`rm -f ${tmpPath}`.quiet().nothrow();
+    return false;
+  }
+}
+
+export function registerUpgradeCommand(program: Command) {
+  program
+    .command("upgrade")
+    .description("Upgrade botholomew to the latest version")
+    .action(async () => {
+      try {
+        // Check for update (use cache if fresh)
+        const cache = await loadUpdateCache();
+        let latestVersion: string;
+        let hasUpdate: boolean;
+
+        if (!needsCheck(cache) && cache) {
+          latestVersion = cache.latestVersion;
+          hasUpdate = cache.hasUpdate;
+        } else {
+          const info = await checkForUpdate(pkg.version);
+          latestVersion = info.latestVersion;
+          hasUpdate = info.hasUpdate;
+
+          const newCache: UpdateCache = {
+            lastCheckAt: new Date().toISOString(),
+            latestVersion,
+            hasUpdate,
+            changelog: info.changelog,
+          };
+          await saveUpdateCache(newCache);
+        }
+
+        if (!hasUpdate) {
+          console.log(
+            green(`botholomew is already up to date (v${pkg.version})`),
+          );
+          return;
+        }
+
+        const method: InstallMethod = detectInstallMethod();
+        console.log(
+          `Upgrading from v${pkg.version} to v${latestVersion} (${method})...`,
+        );
+
+        let success = false;
+
+        switch (method) {
+          case "bun":
+            success = await upgradeWithPackageManager("bun", [
+              "install",
+              "-g",
+              `${pkg.name}@${latestVersion}`,
+            ]);
+            break;
+
+          case "npm":
+            success = await upgradeWithPackageManager("npm", [
+              "install",
+              "-g",
+              `${pkg.name}@${latestVersion}`,
+            ]);
+            break;
+
+          case "binary":
+            success = await upgradeFromBinary(latestVersion);
+            break;
+
+          case "local-dev":
+            console.log(
+              yellow(
+                "Running from source. Use `git pull && bun install` to update.",
+              ),
+            );
+            return;
+        }
+
+        if (success) {
+          await clearUpdateCache();
+          console.log(
+            green(
+              `Successfully upgraded botholomew: v${pkg.version} → v${latestVersion}`,
+            ),
+          );
+        } else {
+          console.error(red("Upgrade failed. See errors above."));
+          process.exit(1);
+        }
+      } catch (err) {
+        console.error("Upgrade failed");
+        console.error(String(err));
+        process.exit(1);
+      }
+    });
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,17 @@
+import { homedir } from "node:os";
 import { join } from "node:path";
 
 export const BOTHOLOMEW_DIR = ".botholomew";
+export const HOME_CONFIG_DIR = join(homedir(), ".botholomew");
+
+export const ENV = {
+  NO_UPDATE_CHECK: "BOTHOLOMEW_NO_UPDATE_CHECK",
+} as const;
+
+export const DEFAULTS = {
+  UPDATE_CHECK_INTERVAL_MS: 24 * 60 * 60 * 1000, // 24 hours
+  UPDATE_CHECK_TIMEOUT_MS: 5_000,
+} as const;
 export const DB_FILENAME = "data.sqlite";
 export const PID_FILENAME = "daemon.pid";
 export const LOG_FILENAME = "daemon.log";

--- a/src/update/background.ts
+++ b/src/update/background.ts
@@ -1,0 +1,89 @@
+import { cyan, dim, yellow } from "ansis";
+import { DEFAULTS, ENV } from "../constants.ts";
+import { loadUpdateCache, saveUpdateCache } from "./cache.ts";
+import { checkForUpdate, needsCheck, type UpdateCache } from "./checker.ts";
+
+const pkg = await Bun.file(
+  new URL("../../package.json", import.meta.url),
+).json();
+
+/** Format an update notice for stderr output. */
+function formatNotice(
+  currentVersion: string,
+  latestVersion: string,
+  changelog?: string,
+): string {
+  const lines: string[] = [
+    "",
+    yellow(`Update available: ${currentVersion} → ${latestVersion}`),
+  ];
+
+  if (changelog) {
+    lines.push("");
+    lines.push(dim(changelog));
+  }
+
+  lines.push("");
+  lines.push(cyan("Run `botholomew upgrade` to update"));
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+/**
+ * Non-blocking background update check. Returns a formatted notice string
+ * if an update is available, or null otherwise. Never throws.
+ */
+export async function maybeCheckForUpdate(): Promise<string | null> {
+  try {
+    // Opt-out via env var
+    if (process.env[ENV.NO_UPDATE_CHECK] === "1") return null;
+
+    // Skip if this is the check-update or upgrade command
+    const args = process.argv.slice(2);
+    const command = args.find((a) => !a.startsWith("-"));
+    if (command === "check-update" || command === "upgrade") return null;
+
+    // Only show in TTY
+    if (!(process.stderr.isTTY ?? false)) return null;
+
+    const cache = await loadUpdateCache();
+
+    if (!needsCheck(cache)) {
+      // Cache is fresh — use cached result
+      if (cache?.hasUpdate) {
+        return formatNotice(pkg.version, cache.latestVersion, cache.changelog);
+      }
+      return null;
+    }
+
+    // Cache is stale or missing — check with timeout
+    const controller = new AbortController();
+    const timeout = setTimeout(
+      () => controller.abort(),
+      DEFAULTS.UPDATE_CHECK_TIMEOUT_MS,
+    );
+
+    try {
+      const info = await checkForUpdate(pkg.version, controller.signal);
+
+      const newCache: UpdateCache = {
+        lastCheckAt: new Date().toISOString(),
+        latestVersion: info.latestVersion,
+        hasUpdate: info.hasUpdate,
+        changelog: info.changelog,
+      };
+      await saveUpdateCache(newCache);
+
+      if (info.hasUpdate) {
+        return formatNotice(pkg.version, info.latestVersion, info.changelog);
+      }
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/src/update/cache.ts
+++ b/src/update/cache.ts
@@ -1,0 +1,40 @@
+import { join } from "node:path";
+import { HOME_CONFIG_DIR } from "../constants.ts";
+import type { UpdateCache } from "./checker.ts";
+
+const UPDATE_CACHE_PATH = join(HOME_CONFIG_DIR, "update.json");
+
+/** Load the cached update check result, if it exists. */
+export async function loadUpdateCache(): Promise<UpdateCache | undefined> {
+  try {
+    const file = Bun.file(UPDATE_CACHE_PATH);
+    if (!(await file.exists())) return undefined;
+    return JSON.parse(await file.text()) as UpdateCache;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Save update check result to the cache file. */
+export async function saveUpdateCache(cache: UpdateCache): Promise<void> {
+  try {
+    const { mkdir } = await import("node:fs/promises");
+    await mkdir(HOME_CONFIG_DIR, { recursive: true });
+    await Bun.write(UPDATE_CACHE_PATH, `${JSON.stringify(cache, null, 2)}\n`);
+  } catch {
+    // Ignore write failures (e.g. permissions)
+  }
+}
+
+/** Remove the cached update check result. */
+export async function clearUpdateCache(): Promise<void> {
+  try {
+    const file = Bun.file(UPDATE_CACHE_PATH);
+    if (await file.exists()) {
+      const { unlink } = await import("node:fs/promises");
+      await unlink(UPDATE_CACHE_PATH);
+    }
+  } catch {
+    // Ignore
+  }
+}

--- a/src/update/checker.ts
+++ b/src/update/checker.ts
@@ -1,0 +1,133 @@
+import { DEFAULTS } from "../constants.ts";
+
+const pkg = await Bun.file(
+  new URL("../../package.json", import.meta.url),
+).json();
+
+const NPM_REGISTRY_URL = `https://registry.npmjs.org/${pkg.name}/latest`;
+const GITHUB_REPO = (pkg.repository.url as string)
+  .replace(/^https:\/\/github\.com\//, "")
+  .replace(/\.git$/, "");
+
+export interface UpdateInfo {
+  currentVersion: string;
+  latestVersion: string;
+  hasUpdate: boolean;
+  aheadOfLatest: boolean;
+  changelog?: string;
+}
+
+export interface UpdateCache {
+  lastCheckAt: string;
+  latestVersion: string;
+  hasUpdate: boolean;
+  changelog?: string;
+}
+
+export type InstallMethod = "npm" | "bun" | "binary" | "local-dev";
+
+/** Compare two semver strings. Returns true if latest > current. */
+export function isNewerVersion(current: string, latest: string): boolean {
+  return Bun.semver.order(current, latest) === -1;
+}
+
+/** Fetch the latest version from the npm registry. */
+export async function fetchLatestVersion(
+  signal?: AbortSignal,
+): Promise<string> {
+  try {
+    const res = await fetch(NPM_REGISTRY_URL, { signal });
+    if (!res.ok) return pkg.version;
+    const data = (await res.json()) as { version: string };
+    return data.version;
+  } catch {
+    return pkg.version;
+  }
+}
+
+/** Fetch changelog from GitHub releases between two versions. */
+export async function fetchChangelog(
+  fromVersion: string,
+  toVersion: string,
+  signal?: AbortSignal,
+): Promise<string | undefined> {
+  try {
+    const res = await fetch(
+      `https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=20`,
+      {
+        signal,
+        headers: { Accept: "application/vnd.github.v3+json" },
+      },
+    );
+    if (!res.ok) return undefined;
+
+    const releases = (await res.json()) as Array<{
+      tag_name: string;
+      body: string | null;
+    }>;
+
+    const relevant = releases.filter((r) => {
+      const v = r.tag_name.replace(/^v/, "");
+      return isNewerVersion(fromVersion, v) && !isNewerVersion(toVersion, v);
+    });
+
+    if (relevant.length === 0) return undefined;
+
+    return relevant
+      .map((r) => `## ${r.tag_name}\n${r.body ?? ""}`)
+      .join("\n\n")
+      .trim();
+  } catch {
+    return undefined;
+  }
+}
+
+/** Check npm for a newer version and fetch changelog if available. */
+export async function checkForUpdate(
+  currentVersion: string,
+  signal?: AbortSignal,
+): Promise<UpdateInfo> {
+  const latestVersion = await fetchLatestVersion(signal);
+  const hasUpdate = isNewerVersion(currentVersion, latestVersion);
+  const aheadOfLatest = isNewerVersion(latestVersion, currentVersion);
+
+  let changelog: string | undefined;
+  if (hasUpdate) {
+    changelog = await fetchChangelog(currentVersion, latestVersion, signal);
+  }
+
+  return { currentVersion, latestVersion, hasUpdate, aheadOfLatest, changelog };
+}
+
+/** Returns true if the cache is missing or older than 24 hours. */
+export function needsCheck(cache?: UpdateCache): boolean {
+  if (!cache?.lastCheckAt) return true;
+  return (
+    Date.now() - new Date(cache.lastCheckAt).getTime() >
+    DEFAULTS.UPDATE_CHECK_INTERVAL_MS
+  );
+}
+
+/** Detect how botholomew was installed. */
+export function detectInstallMethod(): InstallMethod {
+  const script = process.argv[1] ?? "";
+  const execPath = process.execPath;
+
+  // Local dev: running src/cli.ts directly outside node_modules
+  if (script.includes("src/cli.ts") && !script.includes("node_modules")) {
+    return "local-dev";
+  }
+
+  // Compiled binary: execPath is the binary itself (not bun/node)
+  if (!execPath.includes("bun") && !execPath.includes("node")) {
+    return "binary";
+  }
+
+  // Bun global install: path contains .bun/install
+  if (script.includes(".bun/install") || script.includes(".bun/bin")) {
+    return "bun";
+  }
+
+  // npm global install: fallback for node_modules paths
+  return "npm";
+}

--- a/test/update/checker.test.ts
+++ b/test/update/checker.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import type { UpdateCache } from "../../src/update/checker.ts";
+import { isNewerVersion, needsCheck } from "../../src/update/checker.ts";
+
+describe("isNewerVersion", () => {
+  test("returns true when latest is newer", () => {
+    expect(isNewerVersion("1.0.0", "1.1.0")).toBe(true);
+    expect(isNewerVersion("1.0.0", "2.0.0")).toBe(true);
+    expect(isNewerVersion("0.1.0", "0.2.0")).toBe(true);
+  });
+
+  test("returns false when versions are equal", () => {
+    expect(isNewerVersion("1.0.0", "1.0.0")).toBe(false);
+  });
+
+  test("returns false when current is newer", () => {
+    expect(isNewerVersion("2.0.0", "1.0.0")).toBe(false);
+    expect(isNewerVersion("1.1.0", "1.0.0")).toBe(false);
+  });
+});
+
+describe("needsCheck", () => {
+  test("returns true when cache is undefined", () => {
+    expect(needsCheck(undefined)).toBe(true);
+  });
+
+  test("returns true when cache has no lastCheckAt", () => {
+    expect(
+      needsCheck({ latestVersion: "1.0.0", hasUpdate: false } as UpdateCache),
+    ).toBe(true);
+  });
+
+  test("returns true when cache is older than 24 hours", () => {
+    const oldDate = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
+    expect(
+      needsCheck({
+        lastCheckAt: oldDate,
+        latestVersion: "1.0.0",
+        hasUpdate: false,
+      }),
+    ).toBe(true);
+  });
+
+  test("returns false when cache is fresh", () => {
+    const recentDate = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+    expect(
+      needsCheck({
+        lastCheckAt: recentDate,
+        latestVersion: "1.0.0",
+        hasUpdate: false,
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds auto-release GitHub Actions workflow that publishes to NPM and builds platform binaries on every version bump merged to main
- Adds `check-update` and `upgrade` CLI commands with background update checking, modeled after the mcpx publishing setup
- Updates `package.json` with `repository` and `files` fields for NPM publishing
- Adds `BOTHOLOMEW_NO_UPDATE_CHECK` env var to opt out of background update checks
- Documents version bump convention in CLAUDE.md

## Test plan

- [x] `bun run lint` passes
- [x] `bun test` passes (69 tests including new update checker tests)
- [x] `bun run dev check-update` runs successfully
- [x] `bun run dev upgrade` runs successfully
- [ ] Add `NPM_TOKEN` secret to GitHub repo settings before first release

🤖 Generated with [Claude Code](https://claude.com/claude-code)