### PR TITLE
Add embeddings CRUD with sqlite-vector for SIMD search

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "botholomew",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.88.0",
+        "@sqliteai/sqlite-vector": "^0.9.95",
         "ansis": "^4.2.0",
         "commander": "^14.0.0",
         "gray-matter": "^4.0.3",
@@ -48,6 +49,22 @@
     "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.11", "", { "os": "win32", "cpu": "arm64" }, "sha512-RJhaTnY8byzxDt4bDVb7AFPHkPcjOPK3xBip4ZRTrN3TEfyhjLRm3r3mqknqydgVTB74XG8l4jMLwEACEeihVg=="],
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.11", "", { "os": "win32", "cpu": "x64" }, "sha512-A8D3JM/00C2KQgUV3oj8Ba15EHEYwebAGCy5Sf9GAjr5Y3+kJIYOiESoqRDeuRZueuMdCsbLZIUqmPhpYXJE9A=="],
+
+    "@sqliteai/sqlite-vector": ["@sqliteai/sqlite-vector@0.9.95", "", { "optionalDependencies": { "@sqliteai/sqlite-vector-darwin-arm64": "0.9.95", "@sqliteai/sqlite-vector-darwin-x86_64": "0.9.95", "@sqliteai/sqlite-vector-linux-arm64": "0.9.95", "@sqliteai/sqlite-vector-linux-arm64-musl": "0.9.95", "@sqliteai/sqlite-vector-linux-x86_64": "0.9.95", "@sqliteai/sqlite-vector-linux-x86_64-musl": "0.9.95", "@sqliteai/sqlite-vector-win32-x86_64": "0.9.95" } }, "sha512-Y/m7yUmesZ0UQlVprs+NxdU+tnaNStufCO+g0hJmRJNy7QKzHz70wBOCpC3dENNoALB8q7+FazCthre7g9Y6Fg=="],
+
+    "@sqliteai/sqlite-vector-darwin-arm64": ["@sqliteai/sqlite-vector-darwin-arm64@0.9.95", "", { "os": "darwin", "cpu": "arm64" }, "sha512-EwAUVcFHDoPWRHRXgR7K0DpjyUU/X1OG7W348/GiLxknsD8WI1cQpMNzeq9daGfy3ayADMF33E/5zA7eanO8UA=="],
+
+    "@sqliteai/sqlite-vector-darwin-x86_64": ["@sqliteai/sqlite-vector-darwin-x86_64@0.9.95", "", { "os": "darwin", "cpu": [ "x64", "ia32", ] }, "sha512-Fnf1ImQ55XlD26nHQqnbt0noPagqo2b3OCOEeuNlH4Y+MMFRC2WGIq9sC+qhuVeltpQARRYAzMxqOl/CX0R9PA=="],
+
+    "@sqliteai/sqlite-vector-linux-arm64": ["@sqliteai/sqlite-vector-linux-arm64@0.9.95", "", { "os": "linux", "cpu": "arm64" }, "sha512-CF+c0IUd8zbx74MHVmMZuuGdTwMyId3UNcvgL5hiefywOwY5k8YVO2NfFGmpt8u/hSwR4cDh62bYa+cBPrZypQ=="],
+
+    "@sqliteai/sqlite-vector-linux-arm64-musl": ["@sqliteai/sqlite-vector-linux-arm64-musl@0.9.95", "", { "os": "linux", "cpu": "arm64" }, "sha512-OIp4PcRtRbv4dwD38iUDj3zxNxRjvFEO0FrVbl2Y0xA1c2bd4sVVk2qEKGwAMzPGF99dIU8ZI327YFOpQiEUaQ=="],
+
+    "@sqliteai/sqlite-vector-linux-x86_64": ["@sqliteai/sqlite-vector-linux-x86_64@0.9.95", "", { "os": "linux", "cpu": [ "x64", "ia32", ] }, "sha512-NqPZ7obOBh3thk+xYeDI0n/H0WwL616/RkCRITqmnUx50nDuykX2TGkG9E9ryw0QZzMYAW481TWkvVhw/s9w7Q=="],
+
+    "@sqliteai/sqlite-vector-linux-x86_64-musl": ["@sqliteai/sqlite-vector-linux-x86_64-musl@0.9.95", "", { "os": "linux", "cpu": [ "x64", "ia32", ] }, "sha512-bLZ8iJqlDylfvQStCJ4x0+DXSUd8/iIuatd36OtMnY1qO2Q4bmPBg98DVhTZprv19armIZzCut3kuh74uxG8vQ=="],
+
+    "@sqliteai/sqlite-vector-win32-x86_64": ["@sqliteai/sqlite-vector-win32-x86_64@0.9.95", "", { "os": "win32", "cpu": [ "x64", "ia32", ] }, "sha512-t8PknhQZy/yBsJ8s3A1oktevY41DMbSdh49Y8tKT7UScZinsSGttGFLtmPdFoO0dTUJYhhlptf9YS1hmfgVouw=="],
 
     "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 

--- a/docs/plans/milestone-2-context-and-embeddings.md
+++ b/docs/plans/milestone-2-context-and-embeddings.md
@@ -62,7 +62,6 @@ src/tools/
     exists.ts             ← file_exists tool
     count-lines.ts        ← file_count_lines tool
   search/
-    find.ts               ← search_find tool
     grep.ts               ← search_grep tool
     semantic.ts           ← search_semantic tool
 ```
@@ -152,7 +151,6 @@ Replace the stub with full implementation:
 
 | Tool | Input | Output | DB operation |
 |------|-------|--------|-------------|
-| `search_find` | `{ pattern, path?, max_results? }` | `{ matches: string[] }` | `context_path` glob match via SQLite `GLOB` |
 | `search_grep` | `{ pattern, path?, glob?, ignore_case?, context?, max_results? }` | `{ matches: {path, line, content, context_lines}[] }` | `LIKE` / application-level regex on `content` |
 | `search_semantic` | `{ query, top_k?, threshold? }` | `{ results: {path, title, score, snippet}[] }` | `embed([query])` → `hybridSearch()` |
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.88.0",
+    "@sqliteai/sqlite-vector": "^0.9.95",
     "ansis": "^4.2.0",
     "commander": "^14.0.0",
     "gray-matter": "^4.0.3",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,6 +18,7 @@ export const LOG_FILENAME = "daemon.log";
 export const CONFIG_FILENAME = "config.json";
 export const MCPX_DIR = "mcpx";
 export const MCPX_SERVERS_FILENAME = "servers.json";
+export const EMBEDDING_DIMENSION = 384;
 
 export function getBotholomewDir(projectDir: string): string {
   return join(projectDir, BOTHOLOMEW_DIR);

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -24,9 +24,14 @@ function ensureCustomSQLite(): void {
     "/usr/local/opt/sqlite/lib/libsqlite3.dylib",
   ];
   const sqlitePath = candidates.find((p) => existsSync(p));
-  if (sqlitePath) {
-    Database.setCustomSQLite(sqlitePath);
+  if (!sqlitePath) {
+    throw new Error(
+      "Homebrew SQLite not found. On macOS, Botholomew requires Homebrew's SQLite " +
+        "to load the sqlite-vector extension (Apple's build disables extension loading). " +
+        "Install it with: brew install sqlite",
+    );
   }
+  Database.setCustomSQLite(sqlitePath);
 }
 
 export function getConnection(dbPath: string): Database {

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -1,11 +1,36 @@
 import { Database } from "bun:sqlite";
+import { existsSync } from "node:fs";
+import { getExtensionPath } from "@sqliteai/sqlite-vector";
 
 export type DbConnection = Database;
 
+// On macOS, Bun's bundled SQLite doesn't support extensions.
+// We must call setCustomSQLite() exactly once, before any Database is created.
+let sqliteConfigured = false;
+
+function ensureCustomSQLite(): void {
+  if (sqliteConfigured) return;
+  sqliteConfigured = true;
+
+  if (process.platform !== "darwin") return;
+
+  // Homebrew sqlite paths (arm64 and x86_64)
+  const candidates = [
+    "/opt/homebrew/opt/sqlite/lib/libsqlite3.dylib",
+    "/usr/local/opt/sqlite/lib/libsqlite3.dylib",
+  ];
+  const sqlitePath = candidates.find((p) => existsSync(p));
+  if (sqlitePath) {
+    Database.setCustomSQLite(sqlitePath);
+  }
+}
+
 export function getConnection(dbPath: string): Database {
+  ensureCustomSQLite();
   const db = new Database(dbPath, { create: true });
   db.exec("PRAGMA journal_mode = WAL");
   db.exec("PRAGMA foreign_keys = ON");
+  db.loadExtension(getExtensionPath());
   return db;
 }
 

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -4,8 +4,12 @@ import { getExtensionPath } from "@sqliteai/sqlite-vector";
 
 export type DbConnection = Database;
 
-// On macOS, Bun's bundled SQLite doesn't support extensions.
-// We must call setCustomSQLite() exactly once, before any Database is created.
+// Bun bundles its own SQLite, but on macOS it uses Apple's proprietary build
+// which has sqlite3_load_extension() disabled for security. Since we need
+// loadable extensions (sqlite-vector), we swap in Homebrew's vanilla SQLite
+// via setCustomSQLite(). This must be called exactly once, before any
+// Database instance is created. On Linux, Bun's bundled SQLite supports
+// extensions natively, so no swap is needed.
 let sqliteConfigured = false;
 
 function ensureCustomSQLite(): void {

--- a/src/db/embeddings.ts
+++ b/src/db/embeddings.ts
@@ -1,4 +1,26 @@
 import type { DbConnection } from "./connection.ts";
+import { uuidv7 } from "./uuid.ts";
+
+const EMBEDDING_DIMENSION = 384;
+
+// Track which connections have been initialized for vector search
+const initializedConnections = new WeakSet<DbConnection>();
+
+/**
+ * Initialize sqlite-vector on the embeddings table for this connection.
+ * Must be called once per connection before vector operations.
+ * The dimension parameter allows overriding for tests.
+ */
+export function initVectorSearch(
+  conn: DbConnection,
+  dimension = EMBEDDING_DIMENSION,
+): void {
+  if (initializedConnections.has(conn)) return;
+  conn.exec(
+    `SELECT vector_init('embeddings', 'embedding', 'dimension=${dimension},type=FLOAT32,distance=COSINE')`,
+  );
+  initializedConnections.add(conn);
+}
 
 export interface Embedding {
   id: string;
@@ -12,11 +34,172 @@ export interface Embedding {
   created_at: Date;
 }
 
-// Stub — full implementation in a later milestone
-export async function searchEmbeddings(
-  _db: DbConnection,
-  _query: number[],
-  _limit?: number,
-): Promise<Embedding[]> {
-  return [];
+export interface EmbeddingSearchResult extends Embedding {
+  score: number;
+}
+
+interface EmbeddingRow {
+  id: string;
+  context_item_id: string;
+  chunk_index: number;
+  chunk_content: string | null;
+  title: string;
+  description: string;
+  source_path: string | null;
+  embedding: Uint8Array | null;
+  created_at: string;
+}
+
+function rowToEmbedding(row: EmbeddingRow): Embedding {
+  return {
+    id: row.id,
+    context_item_id: row.context_item_id,
+    chunk_index: row.chunk_index,
+    chunk_content: row.chunk_content,
+    title: row.title,
+    description: row.description,
+    source_path: row.source_path,
+    embedding: row.embedding
+      ? Array.from(new Float32Array(row.embedding.buffer))
+      : [],
+    created_at: new Date(row.created_at),
+  };
+}
+
+export function createEmbedding(
+  conn: DbConnection,
+  params: {
+    contextItemId: string;
+    chunkIndex: number;
+    chunkContent: string | null;
+    title: string;
+    description?: string;
+    sourcePath?: string | null;
+    embedding: number[];
+  },
+): Embedding {
+  const id = uuidv7();
+  conn
+    .query(
+      `INSERT INTO embeddings (id, context_item_id, chunk_index, chunk_content, title, description, source_path, embedding)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, vector_as_f32(?8))`,
+    )
+    .run(
+      id,
+      params.contextItemId,
+      params.chunkIndex,
+      params.chunkContent,
+      params.title,
+      params.description ?? "",
+      params.sourcePath ?? null,
+      JSON.stringify(params.embedding),
+    );
+
+  return {
+    id,
+    context_item_id: params.contextItemId,
+    chunk_index: params.chunkIndex,
+    chunk_content: params.chunkContent,
+    title: params.title,
+    description: params.description ?? "",
+    source_path: params.sourcePath ?? null,
+    embedding: params.embedding,
+    created_at: new Date(),
+  };
+}
+
+export function deleteEmbeddingsForItem(
+  conn: DbConnection,
+  contextItemId: string,
+): number {
+  const result = conn
+    .query("DELETE FROM embeddings WHERE context_item_id = ?1")
+    .run(contextItemId);
+  return result.changes;
+}
+
+interface VectorScanRow extends EmbeddingRow {
+  distance: number;
+}
+
+/**
+ * Vector similarity search using sqlite-vector's SIMD-accelerated
+ * cosine distance via vector_full_scan(). Returns results sorted by
+ * similarity (closest first), with score = 1 - distance.
+ */
+export function searchEmbeddings(
+  conn: DbConnection,
+  queryEmbedding: number[],
+  limit = 10,
+): EmbeddingSearchResult[] {
+  const queryJson = JSON.stringify(queryEmbedding);
+
+  const rows = conn
+    .query(
+      `SELECT e.*, v.distance
+       FROM embeddings e
+       JOIN vector_full_scan('embeddings', 'embedding', vector_as_f32(?1), ?2) v
+         ON e.rowid = v.rowid`,
+    )
+    .all(queryJson, limit) as VectorScanRow[];
+
+  return rows.map((row) => ({
+    ...rowToEmbedding(row),
+    score: 1 - row.distance,
+  }));
+}
+
+export function hybridSearch(
+  conn: DbConnection,
+  query: string,
+  queryEmbedding: number[],
+  limit = 10,
+): EmbeddingSearchResult[] {
+  const k = 60; // RRF constant
+
+  // Keyword search: match on chunk_content and title
+  const keywordRows = conn
+    .query(
+      `SELECT * FROM embeddings
+       WHERE chunk_content LIKE '%' || ?1 || '%'
+          OR title LIKE '%' || ?1 || '%'
+       LIMIT 100`,
+    )
+    .all(query) as EmbeddingRow[];
+
+  const keywordRanked = keywordRows.map(rowToEmbedding);
+
+  // Vector search via sqlite-vector
+  const vectorResults = searchEmbeddings(conn, queryEmbedding, 100);
+
+  // Reciprocal rank fusion
+  const scores = new Map<string, { embedding: Embedding; score: number }>();
+
+  for (const [i, emb] of keywordRanked.entries()) {
+    const rrfScore = 1 / (k + i + 1);
+    const existing = scores.get(emb.id);
+    if (existing) {
+      existing.score += rrfScore;
+    } else {
+      scores.set(emb.id, { embedding: emb, score: rrfScore });
+    }
+  }
+
+  for (const [i, emb] of vectorResults.entries()) {
+    const rrfScore = 1 / (k + i + 1);
+    const existing = scores.get(emb.id);
+    if (existing) {
+      existing.score += rrfScore;
+    } else {
+      scores.set(emb.id, { embedding: emb, score: rrfScore });
+    }
+  }
+
+  const merged = Array.from(scores.values());
+  merged.sort((a, b) => b.score - a.score);
+
+  return merged.slice(0, limit).map((entry) => ({
+    ...entry.embedding,
+    score: entry.score,
+  }));
 }

--- a/src/db/embeddings.ts
+++ b/src/db/embeddings.ts
@@ -1,7 +1,6 @@
+import { EMBEDDING_DIMENSION } from "../constants.ts";
 import type { DbConnection } from "./connection.ts";
 import { uuidv7 } from "./uuid.ts";
-
-const EMBEDDING_DIMENSION = 384;
 
 // Track which connections have been initialized for vector search
 const initializedConnections = new WeakSet<DbConnection>();

--- a/src/db/sql/1-core_tables.sql
+++ b/src/db/sql/1-core_tables.sql
@@ -47,7 +47,7 @@ CREATE TABLE embeddings (
   title TEXT NOT NULL,
   description TEXT NOT NULL DEFAULT '',
   source_path TEXT,
-  embedding TEXT,
+  embedding BLOB,
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
   UNIQUE(context_item_id, chunk_index)
 );

--- a/test/db/embeddings.test.ts
+++ b/test/db/embeddings.test.ts
@@ -1,0 +1,277 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { type DbConnection, getConnection } from "../../src/db/connection.ts";
+import { createContextItem } from "../../src/db/context.ts";
+import {
+  createEmbedding,
+  deleteEmbeddingsForItem,
+  hybridSearch,
+  initVectorSearch,
+  searchEmbeddings,
+} from "../../src/db/embeddings.ts";
+import { migrate } from "../../src/db/schema.ts";
+
+let conn: DbConnection;
+
+beforeEach(() => {
+  conn = getConnection(":memory:");
+  migrate(conn);
+  initVectorSearch(conn, 3); // 3-dim vectors for tests
+});
+
+async function makeContextItem(title: string) {
+  return await createContextItem(conn, {
+    title,
+    content: `Content for ${title}`,
+    contextPath: `/${title.toLowerCase().replace(/\s+/g, "-")}`,
+    mimeType: "text/plain",
+    isTextual: true,
+  });
+}
+
+// ── createEmbedding ────────────────────────────────────────
+
+describe("createEmbedding", () => {
+  test("inserts an embedding row", async () => {
+    const item = await makeContextItem("Test Item");
+    const emb = createEmbedding(conn, {
+      contextItemId: item.id,
+      chunkIndex: 0,
+      chunkContent: "some chunk text",
+      title: "Test Item chunk 0",
+      embedding: [0.1, 0.2, 0.3],
+    });
+
+    expect(emb.id).toBeTruthy();
+    expect(emb.context_item_id).toBe(item.id);
+    expect(emb.chunk_index).toBe(0);
+    expect(emb.chunk_content).toBe("some chunk text");
+    expect(emb.embedding).toEqual([0.1, 0.2, 0.3]);
+  });
+
+  test("stores embedding as BLOB in DB", async () => {
+    const item = await makeContextItem("Blob Check");
+    const emb = createEmbedding(conn, {
+      contextItemId: item.id,
+      chunkIndex: 0,
+      chunkContent: "chunk",
+      title: "chunk 0",
+      embedding: [1.0, 2.0, 3.0],
+    });
+
+    const row = conn
+      .query("SELECT typeof(embedding) as t FROM embeddings WHERE id = ?1")
+      .get(emb.id) as { t: string };
+    expect(row.t).toBe("blob");
+  });
+
+  test("enforces unique (context_item_id, chunk_index)", async () => {
+    const item = await makeContextItem("Unique Check");
+    createEmbedding(conn, {
+      contextItemId: item.id,
+      chunkIndex: 0,
+      chunkContent: "first",
+      title: "chunk 0",
+      embedding: [1, 0, 0],
+    });
+
+    expect(() =>
+      createEmbedding(conn, {
+        contextItemId: item.id,
+        chunkIndex: 0,
+        chunkContent: "duplicate",
+        title: "chunk 0 dup",
+        embedding: [0, 1, 0],
+      }),
+    ).toThrow();
+  });
+});
+
+// ── deleteEmbeddingsForItem ────────────────────────────────
+
+describe("deleteEmbeddingsForItem", () => {
+  test("deletes all embeddings for a context item", async () => {
+    const item = await makeContextItem("Delete Test");
+    createEmbedding(conn, {
+      contextItemId: item.id,
+      chunkIndex: 0,
+      chunkContent: "chunk 0",
+      title: "c0",
+      embedding: [1, 0, 0],
+    });
+    createEmbedding(conn, {
+      contextItemId: item.id,
+      chunkIndex: 1,
+      chunkContent: "chunk 1",
+      title: "c1",
+      embedding: [0, 1, 0],
+    });
+
+    const deleted = deleteEmbeddingsForItem(conn, item.id);
+    expect(deleted).toBe(2);
+
+    const remaining = conn
+      .query(
+        "SELECT COUNT(*) as cnt FROM embeddings WHERE context_item_id = ?1",
+      )
+      .get(item.id) as { cnt: number };
+    expect(remaining.cnt).toBe(0);
+  });
+
+  test("returns 0 when no embeddings exist", () => {
+    const deleted = deleteEmbeddingsForItem(conn, "nonexistent-id");
+    expect(deleted).toBe(0);
+  });
+
+  test("does not delete embeddings for other items", async () => {
+    const item1 = await makeContextItem("Item One");
+    const item2 = await makeContextItem("Item Two");
+    createEmbedding(conn, {
+      contextItemId: item1.id,
+      chunkIndex: 0,
+      chunkContent: "chunk",
+      title: "c",
+      embedding: [1, 0, 0],
+    });
+    createEmbedding(conn, {
+      contextItemId: item2.id,
+      chunkIndex: 0,
+      chunkContent: "chunk",
+      title: "c",
+      embedding: [0, 1, 0],
+    });
+
+    deleteEmbeddingsForItem(conn, item1.id);
+
+    const remaining = conn
+      .query("SELECT COUNT(*) as cnt FROM embeddings")
+      .get() as { cnt: number };
+    expect(remaining.cnt).toBe(1);
+  });
+});
+
+// ── searchEmbeddings ───────────────────────────────────────
+
+describe("searchEmbeddings", () => {
+  test("returns results ranked by cosine similarity", async () => {
+    const item = await makeContextItem("Search Test");
+    createEmbedding(conn, {
+      contextItemId: item.id,
+      chunkIndex: 0,
+      chunkContent: "close match",
+      title: "close",
+      embedding: [1, 0, 0],
+    });
+    createEmbedding(conn, {
+      contextItemId: item.id,
+      chunkIndex: 1,
+      chunkContent: "medium match",
+      title: "medium",
+      embedding: [0.7, 0.7, 0],
+    });
+    createEmbedding(conn, {
+      contextItemId: item.id,
+      chunkIndex: 2,
+      chunkContent: "far match",
+      title: "far",
+      embedding: [0, 0, 1],
+    });
+
+    const results = searchEmbeddings(conn, [1, 0, 0], 10);
+    expect(results.length).toBe(3);
+    expect(results[0]?.chunk_content).toBe("close match");
+    expect(results[0]?.score).toBeCloseTo(1.0);
+    expect(results[2]?.chunk_content).toBe("far match");
+    expect(results[2]?.score).toBeCloseTo(0.0);
+  });
+
+  test("respects limit", async () => {
+    const item = await makeContextItem("Limit Test");
+    for (let i = 0; i < 5; i++) {
+      createEmbedding(conn, {
+        contextItemId: item.id,
+        chunkIndex: i,
+        chunkContent: `chunk ${i}`,
+        title: `c${i}`,
+        embedding: [Math.random(), Math.random(), Math.random()],
+      });
+    }
+
+    const results = searchEmbeddings(conn, [1, 0, 0], 2);
+    expect(results.length).toBe(2);
+  });
+
+  test("returns empty array when no embeddings exist", () => {
+    const results = searchEmbeddings(conn, [1, 0, 0]);
+    expect(results).toEqual([]);
+  });
+});
+
+// ── hybridSearch ───────────────────────────────────────────
+
+describe("hybridSearch", () => {
+  test("combines keyword and vector results", async () => {
+    const item = await makeContextItem("Hybrid Test");
+    createEmbedding(conn, {
+      contextItemId: item.id,
+      chunkIndex: 0,
+      chunkContent: "quarterly revenue report",
+      title: "revenue",
+      embedding: [1, 0, 0],
+    });
+    createEmbedding(conn, {
+      contextItemId: item.id,
+      chunkIndex: 1,
+      chunkContent: "annual revenue summary",
+      title: "annual",
+      embedding: [0, 0, 1],
+    });
+    createEmbedding(conn, {
+      contextItemId: item.id,
+      chunkIndex: 2,
+      chunkContent: "financial overview",
+      title: "overview",
+      embedding: [0.9, 0.1, 0],
+    });
+
+    const results = hybridSearch(conn, "revenue", [1, 0, 0], 10);
+    expect(results.length).toBe(3);
+    expect(results[0]?.chunk_content).toBe("quarterly revenue report");
+    expect(results[0]?.score).toBeGreaterThan(results[1]?.score ?? 0);
+  });
+
+  test("returns keyword-only matches", async () => {
+    const item = await makeContextItem("Keyword Only");
+    createEmbedding(conn, {
+      contextItemId: item.id,
+      chunkIndex: 0,
+      chunkContent: "the special keyword here",
+      title: "special",
+      embedding: [0, 0, 1],
+    });
+
+    const results = hybridSearch(conn, "special", [1, 0, 0], 10);
+    expect(results.length).toBe(1);
+    expect(results[0]?.chunk_content).toContain("special");
+  });
+
+  test("respects limit", async () => {
+    const item = await makeContextItem("Limit Hybrid");
+    for (let i = 0; i < 5; i++) {
+      createEmbedding(conn, {
+        contextItemId: item.id,
+        chunkIndex: i,
+        chunkContent: `match chunk ${i}`,
+        title: `match ${i}`,
+        embedding: [1, 0, 0],
+      });
+    }
+
+    const results = hybridSearch(conn, "match", [1, 0, 0], 2);
+    expect(results.length).toBe(2);
+  });
+
+  test("returns empty when nothing matches", () => {
+    const results = hybridSearch(conn, "nonexistent", [1, 0, 0]);
+    expect(results).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Implements full embeddings CRUD (`createEmbedding`, `deleteEmbeddingsForItem`, `searchEmbeddings`, `hybridSearch`) replacing the previous stub
- Integrates `@sqliteai/sqlite-vector` for SIMD-accelerated cosine similarity via `vector_full_scan()` — embeddings stored as compact BLOBs instead of JSON text
- Adds `initVectorSearch()` for per-connection vector initialization with configurable dimensions
- On macOS, auto-detects homebrew SQLite to enable extension loading (Bun's bundled SQLite doesn't support extensions)
- Removes `search_find` tool from milestone plan (not needed); updates schema from `embedding TEXT` to `embedding BLOB`

## Test plan

- [x] 13 new embeddings tests covering CRUD, cosine similarity ranking, hybrid search with RRF, limits, and edge cases
- [x] All 149 existing tests continue to pass
- [x] `bun run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)