### PR TITLE
Add embedding pipeline, semantic search, and contextual prompt loading (M2)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "botholomew",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.88.0",
+        "@huggingface/transformers": "^4.0.1",
         "@sqliteai/sqlite-vector": "^0.9.95",
         "ansis": "^4.2.0",
         "commander": "^14.0.0",
@@ -50,6 +51,84 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.11", "", { "os": "win32", "cpu": "x64" }, "sha512-A8D3JM/00C2KQgUV3oj8Ba15EHEYwebAGCy5Sf9GAjr5Y3+kJIYOiESoqRDeuRZueuMdCsbLZIUqmPhpYXJE9A=="],
 
+    "@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
+
+    "@huggingface/jinja": ["@huggingface/jinja@0.5.6", "", {}, "sha512-MyMWyLnjqo+KRJYSH7oWNbsOn5onuIvfXYPcc0WOGxU0eHUV7oAYUoQTl2BMdu7ml+ea/bu11UM+EshbeHwtIA=="],
+
+    "@huggingface/tokenizers": ["@huggingface/tokenizers@0.1.3", "", {}, "sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA=="],
+
+    "@huggingface/transformers": ["@huggingface/transformers@4.0.1", "", { "dependencies": { "@huggingface/jinja": "^0.5.6", "@huggingface/tokenizers": "^0.1.3", "onnxruntime-node": "1.24.3", "onnxruntime-web": "1.25.0-dev.20260327-722743c0e2", "sharp": "^0.34.5" } }, "sha512-tAQYEy+cnW0ku/NxBSjFXCymi+DZa1/JkoGf4McxjzO36CZZIL/J4TF6X7i/tzs75yTjshUDgsvSz03s2xym2A=="],
+
+    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.4", "", {}, "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.0", "", {}, "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.0", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1", "@protobufjs/inquire": "^1.1.0" } }, "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.0", "", {}, "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
+
     "@sqliteai/sqlite-vector": ["@sqliteai/sqlite-vector@0.9.95", "", { "optionalDependencies": { "@sqliteai/sqlite-vector-darwin-arm64": "0.9.95", "@sqliteai/sqlite-vector-darwin-x86_64": "0.9.95", "@sqliteai/sqlite-vector-linux-arm64": "0.9.95", "@sqliteai/sqlite-vector-linux-arm64-musl": "0.9.95", "@sqliteai/sqlite-vector-linux-x86_64": "0.9.95", "@sqliteai/sqlite-vector-linux-x86_64-musl": "0.9.95", "@sqliteai/sqlite-vector-win32-x86_64": "0.9.95" } }, "sha512-Y/m7yUmesZ0UQlVprs+NxdU+tnaNStufCO+g0hJmRJNy7QKzHz70wBOCpC3dENNoALB8q7+FazCthre7g9Y6Fg=="],
 
     "@sqliteai/sqlite-vector-darwin-arm64": ["@sqliteai/sqlite-vector-darwin-arm64@0.9.95", "", { "os": "darwin", "cpu": "arm64" }, "sha512-EwAUVcFHDoPWRHRXgR7K0DpjyUU/X1OG7W348/GiLxknsD8WI1cQpMNzeq9daGfy3ayADMF33E/5zA7eanO8UA=="],
@@ -74,6 +153,8 @@
 
     "@types/uuid": ["@types/uuid@11.0.0", "", { "dependencies": { "uuid": "*" } }, "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA=="],
 
+    "adm-zip": ["adm-zip@0.5.17", "", {}, "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ=="],
+
     "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
 
     "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
@@ -87,6 +168,8 @@
     "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
 
     "binaryextensions": ["binaryextensions@6.11.0", "", { "dependencies": { "editions": "^6.21.0" } }, "sha512-sXnYK/Ij80TO3lcqZVV2YgfKN5QjUWIRk/XSm2J/4bd/lPko3lvk0O4ZppH6m+6hB2/GTu+ptNwVFe1xh+QLQw=="],
+
+    "boolean": ["boolean@3.2.0", "", {}, "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="],
 
     "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
@@ -106,13 +189,27 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
+
+    "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "detect-node": ["detect-node@2.1.0", "", {}, "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="],
+
     "editions": ["editions@6.22.0", "", { "dependencies": { "version-range": "^4.15.0" } }, "sha512-UgGlf8IW75je7HZjNDpJdCv4cGJWIi6yumFdZ0R7A8/CIhQiWUjyGLCxdHpd8bmyD1gnkfUNK0oeOXqUS2cpfQ=="],
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
 
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
     "es-toolkit": ["es-toolkit@1.45.1", "", {}, "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw=="],
+
+    "es6-error": ["es6-error@4.1.1", "", {}, "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="],
 
     "escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
@@ -120,9 +217,21 @@
 
     "extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug=="],
 
+    "flatbuffers": ["flatbuffers@25.9.23", "", {}, "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ=="],
+
     "get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
 
+    "global-agent": ["global-agent@3.0.0", "", { "dependencies": { "boolean": "^3.0.1", "es6-error": "^4.1.1", "matcher": "^3.0.0", "roarr": "^2.15.3", "semver": "^7.3.2", "serialize-error": "^7.0.1" } }, "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q=="],
+
+    "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
     "gray-matter": ["gray-matter@4.0.3", "", { "dependencies": { "js-yaml": "^3.13.1", "kind-of": "^6.0.2", "section-matter": "^1.0.0", "strip-bom-string": "^1.0.0" } }, "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q=="],
+
+    "guid-typescript": ["guid-typescript@1.0.9", "", {}, "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ=="],
+
+    "has-property-descriptors": ["has-property-descriptors@1.0.2", "", { "dependencies": { "es-define-property": "^1.0.0" } }, "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg=="],
 
     "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
 
@@ -140,13 +249,31 @@
 
     "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
 
+    "json-stringify-safe": ["json-stringify-safe@5.0.1", "", {}, "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="],
+
     "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
+
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
+    "matcher": ["matcher@3.0.0", "", { "dependencies": { "escape-string-regexp": "^4.0.0" } }, "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng=="],
 
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
+    "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
+
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
+    "onnxruntime-common": ["onnxruntime-common@1.24.3", "", {}, "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA=="],
+
+    "onnxruntime-node": ["onnxruntime-node@1.24.3", "", { "dependencies": { "adm-zip": "^0.5.16", "global-agent": "^3.0.0", "onnxruntime-common": "1.24.3" }, "os": [ "linux", "win32", "darwin", ] }, "sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg=="],
+
+    "onnxruntime-web": ["onnxruntime-web@1.25.0-dev.20260327-722743c0e2", "", { "dependencies": { "flatbuffers": "^25.1.24", "guid-typescript": "^1.0.9", "long": "^5.2.3", "onnxruntime-common": "1.24.0-dev.20251116-b39e144322", "platform": "^1.3.6", "protobufjs": "^7.2.4" } }, "sha512-8PXdZy4Ekhg10CLg+cFFt39b4tFDGMRJB6lGjnQL6eA+2boUQYDymZ0gtxiS+H6oIWoCjQp/ziyirvFbaFKfiw=="],
+
     "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
+
+    "platform": ["platform@1.3.6", "", {}, "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="],
+
+    "protobufjs": ["protobufjs@7.5.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg=="],
 
     "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
@@ -154,9 +281,19 @@
 
     "restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
 
+    "roarr": ["roarr@2.15.4", "", { "dependencies": { "boolean": "^3.0.1", "detect-node": "^2.0.4", "globalthis": "^1.0.1", "json-stringify-safe": "^5.0.1", "semver-compare": "^1.0.0", "sprintf-js": "^1.1.2" } }, "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A=="],
+
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "section-matter": ["section-matter@1.0.0", "", { "dependencies": { "extend-shallow": "^2.0.1", "kind-of": "^6.0.0" } }, "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA=="],
+
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "semver-compare": ["semver-compare@1.0.0", "", {}, "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="],
+
+    "serialize-error": ["serialize-error@7.0.1", "", { "dependencies": { "type-fest": "^0.13.1" } }, "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw=="],
+
+    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
@@ -180,6 +317,8 @@
 
     "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
     "type-fest": ["type-fest@5.5.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g=="],
 
     "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
@@ -199,6 +338,14 @@
     "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "matcher/escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "onnxruntime-web/onnxruntime-common": ["onnxruntime-common@1.24.0-dev.20251116-b39e144322", "", {}, "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw=="],
+
+    "roarr/sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
+
+    "serialize-error/type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
 
     "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
   }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.88.0",
+    "@huggingface/transformers": "^4.0.1",
     "@sqliteai/sqlite-vector": "^0.9.95",
     "ansis": "^4.2.0",
     "commander": "^14.0.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ import { registerContextCommand } from "./commands/context.ts";
 import { registerDaemonCommand } from "./commands/daemon.ts";
 import { registerInitCommand } from "./commands/init.ts";
 import { registerMcpxCommand } from "./commands/mcpx.ts";
+import { registerPrepareCommand } from "./commands/prepare.ts";
 import { registerTaskCommand } from "./commands/task.ts";
 import { registerToolCommands } from "./commands/tools.ts";
 import { registerUpgradeCommand } from "./commands/upgrade.ts";
@@ -35,6 +36,7 @@ registerChatCommand(program);
 registerContextCommand(program);
 registerMcpxCommand(program);
 registerToolCommands(program);
+registerPrepareCommand(program);
 registerCheckUpdateCommand(program);
 registerUpgradeCommand(program);
 

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -1,4 +1,20 @@
+import { readdir, stat } from "node:fs/promises";
+import { basename, join, resolve } from "node:path";
+import ansis from "ansis";
 import type { Command } from "commander";
+import { isText } from "istextorbinary";
+import { loadConfig } from "../config/loader.ts";
+import { getDbPath } from "../constants.ts";
+import { embedSingle, warmupEmbedder } from "../context/embedder.ts";
+import { ingestContextItem } from "../context/ingest.ts";
+import { getConnection } from "../db/connection.ts";
+import {
+  createContextItem,
+  listContextItems,
+  listContextItemsByPrefix,
+} from "../db/context.ts";
+import { hybridSearch, initVectorSearch } from "../db/embeddings.ts";
+import { migrate } from "../db/schema.ts";
 import { logger } from "../utils/logger.ts";
 
 export function registerContextCommand(program: Command) {
@@ -7,21 +23,169 @@ export function registerContextCommand(program: Command) {
   ctx
     .command("list")
     .description("List context items")
-    .action(async () => {
-      logger.warn("Not yet implemented. Coming soon.");
+    .option("--path <prefix>", "filter by path prefix")
+    .option("-l, --limit <n>", "max number of items", Number.parseInt)
+    .action(async (opts) => {
+      const dir = program.opts().dir;
+      const conn = getConnection(getDbPath(dir));
+      migrate(conn);
+
+      const items = opts.path
+        ? await listContextItemsByPrefix(conn, opts.path, {
+            recursive: true,
+            limit: opts.limit,
+          })
+        : await listContextItems(conn, { limit: opts.limit });
+
+      if (items.length === 0) {
+        logger.dim("No context items found.");
+        conn.close();
+        return;
+      }
+
+      const header = `${ansis.bold("Path".padEnd(40))} ${"Title".padEnd(25)} ${"Type".padEnd(20)} Indexed`;
+      console.log(header);
+      console.log("-".repeat(header.length));
+
+      for (const item of items) {
+        const indexed = item.indexed_at ? ansis.green("yes") : ansis.dim("no");
+        console.log(
+          `${item.context_path.padEnd(40)} ${item.title.slice(0, 24).padEnd(25)} ${item.mime_type.slice(0, 19).padEnd(20)} ${indexed}`,
+        );
+      }
+
+      console.log(`\n${ansis.dim(`${items.length} item(s)`)}`);
+      conn.close();
     });
 
   ctx
     .command("add <path>")
     .description("Add a file or directory to context")
-    .action(async () => {
-      logger.warn("Not yet implemented. Coming soon.");
+    .option("--prefix <prefix>", "virtual path prefix", "/")
+    .action(async (path, opts) => {
+      const dir = program.opts().dir;
+      const conn = getConnection(getDbPath(dir));
+      migrate(conn);
+      const config = await loadConfig(dir);
+      await warmupEmbedder();
+
+      const resolvedPath = resolve(path);
+      const info = await stat(resolvedPath);
+
+      let added = 0;
+      let chunks = 0;
+
+      if (info.isDirectory()) {
+        const entries = await walkDirectory(resolvedPath);
+        for (const filePath of entries) {
+          const relativePath = filePath.slice(resolvedPath.length);
+          const contextPath = join(opts.prefix, relativePath);
+          const count = await addFile(conn, config, filePath, contextPath);
+          if (count >= 0) {
+            added++;
+            chunks += count;
+          }
+        }
+      } else {
+        const contextPath = join(opts.prefix, basename(resolvedPath));
+        const count = await addFile(conn, config, resolvedPath, contextPath);
+        if (count >= 0) {
+          added++;
+          chunks += count;
+        }
+      }
+
+      logger.success(`Added ${added} file(s), ${chunks} chunk(s) indexed.`);
+      conn.close();
     });
 
   ctx
     .command("search <query>")
     .description("Search context items")
-    .action(async () => {
-      logger.warn("Not yet implemented. Coming soon.");
+    .option("-k, --top-k <n>", "max results", Number.parseInt, 10)
+    .action(async (query, opts) => {
+      const dir = program.opts().dir;
+      const conn = getConnection(getDbPath(dir));
+      migrate(conn);
+
+      await warmupEmbedder();
+      initVectorSearch(conn);
+      const queryVec = await embedSingle(query);
+      const results = hybridSearch(conn, query, queryVec, opts.topK);
+
+      if (results.length === 0) {
+        logger.dim("No results found.");
+        conn.close();
+        return;
+      }
+
+      for (const [i, r] of results.entries()) {
+        const score = (r.score * 100).toFixed(1);
+        console.log(
+          `${ansis.bold(`${i + 1}.`)} ${ansis.cyan(r.title)} ${ansis.dim(`(${score}%)`)}`,
+        );
+        console.log(`   ${ansis.dim(r.source_path || r.context_item_id)}`);
+        if (r.chunk_content) {
+          const snippet = r.chunk_content.slice(0, 120).replace(/\n/g, " ");
+          console.log(`   ${snippet}...`);
+        }
+        console.log("");
+      }
+
+      conn.close();
     });
+}
+
+async function addFile(
+  conn: ReturnType<typeof getConnection>,
+  config: Awaited<ReturnType<typeof loadConfig>>,
+  filePath: string,
+  contextPath: string,
+): Promise<number> {
+  try {
+    const bunFile = Bun.file(filePath);
+    const mimeType = bunFile.type.split(";")[0] || "application/octet-stream";
+    const filename = basename(filePath);
+    const textual = isText(filename) !== false;
+
+    const content = textual ? await bunFile.text() : null;
+
+    const item = await createContextItem(conn, {
+      title: filename,
+      content: content ?? undefined,
+      mimeType,
+      sourcePath: filePath,
+      contextPath,
+      isTextual: textual,
+    });
+
+    if (textual && content) {
+      const count = await ingestContextItem(conn, item.id, config);
+      console.log(`  + ${contextPath} (${count} chunks)`);
+      return count;
+    }
+
+    console.log(`  + ${contextPath} (binary, not indexed)`);
+    return 0;
+  } catch (err) {
+    logger.warn(`  ! ${contextPath}: ${err}`);
+    return -1;
+  }
+}
+
+async function walkDirectory(dirPath: string): Promise<string[]> {
+  const files: string[] = [];
+  const entries = await readdir(dirPath, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const fullPath = join(dirPath, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name.startsWith(".")) continue; // skip hidden dirs
+      files.push(...(await walkDirectory(fullPath)));
+    } else if (entry.isFile()) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
 }

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -1,0 +1,16 @@
+import type { Command } from "commander";
+import { warmupEmbedder } from "../context/embedder.ts";
+import { logger } from "../utils/logger.ts";
+
+export function registerPrepareCommand(program: Command) {
+  program
+    .command("prepare")
+    .description(
+      "Download and cache required models. Run this in CI or on first setup.",
+    )
+    .action(async () => {
+      logger.info("Preparing Botholomew...");
+      await warmupEmbedder();
+      logger.success("All models downloaded and ready.");
+    });
+}

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -1,6 +1,7 @@
 export interface BotholomewConfig {
   anthropic_api_key?: string;
   model?: string;
+  chunker_model?: string;
   tick_interval_seconds?: number;
   max_tick_duration_seconds?: number;
   system_prompt_override?: string;
@@ -8,7 +9,8 @@ export interface BotholomewConfig {
 
 export const DEFAULT_CONFIG: Required<BotholomewConfig> = {
   anthropic_api_key: "",
-  model: "claude-sonnet-4-20250514",
+  model: "claude-opus-4-20250514",
+  chunker_model: "claude-haiku-4-20250514",
   tick_interval_seconds: 300,
   max_tick_duration_seconds: 120,
   system_prompt_override: "",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,6 +19,8 @@ export const CONFIG_FILENAME = "config.json";
 export const MCPX_DIR = "mcpx";
 export const MCPX_SERVERS_FILENAME = "servers.json";
 export const EMBEDDING_DIMENSION = 384;
+export const EMBEDDING_MODEL_ID = "Xenova/bge-small-en-v1.5";
+export const EMBEDDING_DTYPE = "fp32";
 
 export function getBotholomewDir(projectDir: string): string {
   return join(projectDir, BOTHOLOMEW_DIR);

--- a/src/context/chunker.ts
+++ b/src/context/chunker.ts
@@ -1,0 +1,164 @@
+import Anthropic from "@anthropic-ai/sdk";
+import type { BotholomewConfig } from "../config/schemas.ts";
+import { logger } from "../utils/logger.ts";
+
+export interface Chunk {
+  index: number;
+  content: string;
+}
+
+const DEFAULT_WINDOW_CHARS = 2000;
+const DEFAULT_OVERLAP_CHARS = 200;
+const SHORT_CONTENT_THRESHOLD = 200;
+const LLM_TIMEOUT_MS = 10_000;
+
+const CHUNKER_TOOL_NAME = "return_chunks";
+const CHUNKER_TOOL = {
+  name: CHUNKER_TOOL_NAME,
+  description:
+    "Return the chunk boundaries for this document. Each chunk should be a coherent semantic section.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      chunks: {
+        type: "array",
+        description: "Array of chunk boundaries (1-based, inclusive)",
+        items: {
+          type: "object",
+          properties: {
+            start_line: {
+              type: "number",
+              description: "1-based start line (inclusive)",
+            },
+            end_line: {
+              type: "number",
+              description: "1-based end line (inclusive)",
+            },
+          },
+          required: ["start_line", "end_line"],
+        },
+      },
+    },
+    required: ["chunks"],
+  },
+};
+
+/**
+ * Deterministic sliding-window chunker.
+ * Splits content into overlapping windows of approximately `windowChars` characters,
+ * breaking at newlines when possible.
+ */
+export function chunkWithSlidingWindow(
+  content: string,
+  windowChars = DEFAULT_WINDOW_CHARS,
+  overlapChars = DEFAULT_OVERLAP_CHARS,
+): Chunk[] {
+  if (content.length <= windowChars) {
+    return [{ index: 0, content }];
+  }
+
+  const chunks: Chunk[] = [];
+  let start = 0;
+  let index = 0;
+
+  while (start < content.length) {
+    let end = Math.min(start + windowChars, content.length);
+
+    // Try to break at a newline near the end of the window
+    if (end < content.length) {
+      const lastNewline = content.lastIndexOf("\n", end);
+      if (lastNewline > start + windowChars / 2) {
+        end = lastNewline + 1;
+      }
+    }
+
+    chunks.push({ index, content: content.slice(start, end) });
+    index++;
+
+    if (end >= content.length) break;
+    start = end - overlapChars;
+  }
+
+  return chunks;
+}
+
+/**
+ * LLM-driven chunker that asks Claude to identify semantic boundaries.
+ * Uses structured outputs via tool_use with forced tool_choice.
+ */
+export async function chunkWithLLM(
+  content: string,
+  mimeType: string,
+  config: Required<BotholomewConfig>,
+): Promise<Chunk[]> {
+  const client = new Anthropic({ apiKey: config.anthropic_api_key });
+  const lines = content.split("\n");
+
+  const response = await Promise.race([
+    client.messages.create({
+      model: config.chunker_model,
+      max_tokens: 1024,
+      tools: [CHUNKER_TOOL],
+      tool_choice: { type: "tool", name: CHUNKER_TOOL_NAME },
+      messages: [
+        {
+          role: "user",
+          content: `You are a document chunker. Given the following ${mimeType} document with ${lines.length} lines, identify semantic chunk boundaries. Each chunk should be a coherent section (100-500 lines preferred). Cover all lines with no gaps.
+
+Document:
+${content}`,
+        },
+      ],
+    }),
+    new Promise<never>((_, reject) =>
+      setTimeout(
+        () => reject(new Error("LLM chunker timeout")),
+        LLM_TIMEOUT_MS,
+      ),
+    ),
+  ]);
+
+  // Extract the tool_use block
+  const toolBlock = response.content.find((b) => b.type === "tool_use");
+  if (!toolBlock || toolBlock.type !== "tool_use") {
+    throw new Error("LLM chunker returned no tool_use block");
+  }
+
+  const input = toolBlock.input as {
+    chunks: Array<{ start_line: number; end_line: number }>;
+  };
+
+  if (!Array.isArray(input.chunks) || input.chunks.length === 0) {
+    throw new Error("LLM chunker returned empty boundaries");
+  }
+
+  return input.chunks.map((b, i) => ({
+    index: i,
+    content: lines.slice(b.start_line - 1, b.end_line).join("\n"),
+  }));
+}
+
+/**
+ * Chunk content using LLM when possible, falling back to sliding window.
+ * Short content (<200 chars) is returned as a single chunk.
+ */
+export async function chunk(
+  content: string,
+  mimeType: string,
+  config: Required<BotholomewConfig>,
+): Promise<Chunk[]> {
+  if (content.length < SHORT_CONTENT_THRESHOLD) {
+    return [{ index: 0, content }];
+  }
+
+  // Only try LLM chunking if we have an API key
+  if (config.anthropic_api_key) {
+    try {
+      return await chunkWithLLM(content, mimeType, config);
+    } catch (err) {
+      logger.debug(`LLM chunking failed, using sliding window: ${err}`);
+    }
+  }
+
+  return chunkWithSlidingWindow(content);
+}

--- a/src/context/embedder.ts
+++ b/src/context/embedder.ts
@@ -1,0 +1,78 @@
+import {
+  EMBEDDING_DIMENSION,
+  EMBEDDING_DTYPE,
+  EMBEDDING_MODEL_ID,
+} from "../constants.ts";
+import { logger } from "../utils/logger.ts";
+
+type EmbedFn = (texts: string[]) => Promise<number[][]>;
+
+let pipelineInstance: ReturnType<typeof createPipelinePromise> | null = null;
+
+function createPipelinePromise() {
+  return (async () => {
+    logger.info(`Loading embedding model ${EMBEDDING_MODEL_ID}...`);
+    const { pipeline } = await import("@huggingface/transformers");
+    const pipe = await pipeline("feature-extraction", EMBEDDING_MODEL_ID, {
+      dtype: EMBEDDING_DTYPE,
+    });
+    logger.info("Embedding model loaded.");
+    return pipe;
+  })();
+}
+
+async function getEmbeddingPipeline() {
+  if (!pipelineInstance) {
+    pipelineInstance = createPipelinePromise();
+  }
+  return pipelineInstance;
+}
+
+/**
+ * Ensure the embedding model is downloaded and loaded.
+ * Call at application boot (daemon start, CLI commands that need embeddings).
+ * Downloads the model on first run (~33MB).
+ */
+export async function warmupEmbedder(): Promise<void> {
+  await getEmbeddingPipeline();
+}
+
+/**
+ * Embed multiple texts using the local BGE model.
+ * Returns an array of 384-dimensional float vectors.
+ */
+export async function embed(texts: string[]): Promise<number[][]> {
+  if (texts.length === 0) return [];
+
+  const pipe = await getEmbeddingPipeline();
+  const output = await pipe(texts, { pooling: "cls", normalize: true });
+
+  const results: number[][] = [];
+  for (let i = 0; i < texts.length; i++) {
+    const row = (output as { data: Float32Array }).data.slice(
+      i * EMBEDDING_DIMENSION,
+      (i + 1) * EMBEDDING_DIMENSION,
+    );
+    results.push(Array.from(row));
+  }
+  return results;
+}
+
+/**
+ * Embed a single text string.
+ */
+export async function embedSingle(text: string): Promise<number[]> {
+  const results = await embed([text]);
+  const vec = results[0];
+  if (!vec) throw new Error("embed returned empty results");
+  return vec;
+}
+
+/**
+ * Reset the singleton pipeline (for testing).
+ */
+export function resetEmbedder(): void {
+  pipelineInstance = null;
+}
+
+export type { EmbedFn };

--- a/src/context/ingest.ts
+++ b/src/context/ingest.ts
@@ -1,0 +1,102 @@
+import type { BotholomewConfig } from "../config/schemas.ts";
+import type { DbConnection } from "../db/connection.ts";
+import { getContextItem, getContextItemByPath } from "../db/context.ts";
+import {
+  createEmbedding,
+  deleteEmbeddingsForItem,
+  initVectorSearch,
+} from "../db/embeddings.ts";
+import { logger } from "../utils/logger.ts";
+import { chunk } from "./chunker.ts";
+import type { EmbedFn } from "./embedder.ts";
+import { embed as defaultEmbed } from "./embedder.ts";
+
+/**
+ * Full ingestion pipeline for a context item:
+ * 1. Fetch item from DB
+ * 2. Skip if non-textual or empty
+ * 3. Chunk content and embed chunks (outside transaction)
+ * 4. In a transaction: delete old embeddings, store new ones, update indexed_at
+ */
+export async function ingestContextItem(
+  conn: DbConnection,
+  itemId: string,
+  config: Required<BotholomewConfig>,
+  embedFn: EmbedFn = defaultEmbed,
+): Promise<number> {
+  const item = await getContextItem(conn, itemId);
+  if (!item) {
+    logger.warn(`ingest: context item ${itemId} not found`);
+    return 0;
+  }
+
+  if (!item.is_textual || !item.content) {
+    logger.debug(`ingest: skipping non-textual item ${itemId}`);
+    return 0;
+  }
+
+  // Initialize vector search (idempotent)
+  initVectorSearch(conn);
+
+  // Chunk and embed outside the transaction (may involve LLM/model calls)
+  const chunks = await chunk(item.content, item.mime_type, config);
+  if (chunks.length === 0) return 0;
+
+  const vectors = await embedFn(chunks.map((c) => c.content));
+
+  // Wrap DB mutations in a transaction
+  conn.exec("BEGIN");
+  try {
+    // Clear stale embeddings
+    deleteEmbeddingsForItem(conn, itemId);
+
+    // Store each chunk + embedding
+    for (const [i, c] of chunks.entries()) {
+      const v = vectors[i];
+      if (!v) continue;
+      createEmbedding(conn, {
+        contextItemId: itemId,
+        chunkIndex: c.index,
+        chunkContent: c.content,
+        title: item.title,
+        description: item.description,
+        sourcePath: item.source_path,
+        embedding: v,
+      });
+    }
+
+    // Mark as indexed
+    conn
+      .query(
+        "UPDATE context_items SET indexed_at = datetime('now') WHERE id = ?1",
+      )
+      .run(itemId);
+
+    conn.exec("COMMIT");
+  } catch (err) {
+    conn.exec("ROLLBACK");
+    throw err;
+  }
+
+  logger.debug(
+    `ingest: indexed ${chunks.length} chunks for "${item.title}" (${itemId})`,
+  );
+  return chunks.length;
+}
+
+/**
+ * Ingest a context item by its virtual path.
+ */
+export async function ingestByPath(
+  conn: DbConnection,
+  contextPath: string,
+  config: Required<BotholomewConfig>,
+  embedFn: EmbedFn = defaultEmbed,
+): Promise<number> {
+  const item = await getContextItemByPath(conn, contextPath);
+  if (!item) {
+    logger.warn(`ingest: no item at path ${contextPath}`);
+    return 0;
+  }
+  return ingestContextItem(conn, item.id, config, embedFn);
+}

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1,5 +1,6 @@
 import { loadConfig } from "../config/loader.ts";
 import { getDbPath } from "../constants.ts";
+import { warmupEmbedder } from "../context/embedder.ts";
 import { getConnection } from "../db/connection.ts";
 import { migrate } from "../db/schema.ts";
 import { logger } from "../utils/logger.ts";
@@ -11,6 +12,9 @@ export async function startDaemon(projectDir: string): Promise<void> {
   const dbPath = getDbPath(projectDir);
   const conn = getConnection(dbPath);
   migrate(conn);
+
+  // Ensure embedding model is downloaded and loaded before accepting work
+  await warmupEmbedder();
 
   writePidFile(projectDir, process.pid);
 

--- a/src/daemon/prompt.ts
+++ b/src/daemon/prompt.ts
@@ -1,13 +1,24 @@
 import { readdir } from "node:fs/promises";
 import { join } from "node:path";
+import type { BotholomewConfig } from "../config/schemas.ts";
 import { getBotholomewDir } from "../constants.ts";
+import { embedSingle } from "../context/embedder.ts";
+import type { DbConnection } from "../db/connection.ts";
+import { hybridSearch, initVectorSearch } from "../db/embeddings.ts";
+import type { Task } from "../db/tasks.ts";
 import { parseContextFile } from "../utils/frontmatter.ts";
+import { logger } from "../utils/logger.ts";
 
 const pkg = await Bun.file(
   new URL("../../package.json", import.meta.url),
 ).json();
 
-export async function buildSystemPrompt(projectDir: string): Promise<string> {
+export async function buildSystemPrompt(
+  projectDir: string,
+  task?: Task,
+  conn?: DbConnection,
+  _config?: Required<BotholomewConfig>,
+): Promise<string> {
   const dotDir = getBotholomewDir(projectDir);
   const parts: string[] = [];
 
@@ -19,7 +30,17 @@ export async function buildSystemPrompt(projectDir: string): Promise<string> {
   parts.push(`User: ${process.env.USER || process.env.USERNAME || "unknown"}`);
   parts.push("");
 
-  // Load all "always" context files
+  // Build keyword set from task for contextual loading
+  const taskKeywords = task
+    ? new Set(
+        `${task.name} ${task.description}`
+          .toLowerCase()
+          .split(/\s+/)
+          .filter((w) => w.length > 3),
+      )
+    : null;
+
+  // Load context files from .botholomew/
   try {
     const files = await readdir(dotDir);
     const mdFiles = files.filter((f) => f.endsWith(".md"));
@@ -33,10 +54,45 @@ export async function buildSystemPrompt(projectDir: string): Promise<string> {
         parts.push(`## ${filename}`);
         parts.push(content);
         parts.push("");
+      } else if (meta.loading === "contextual" && taskKeywords) {
+        // Include contextual files if keywords overlap with task
+        const contentLower = content.toLowerCase();
+        const hasOverlap = [...taskKeywords].some((kw) =>
+          contentLower.includes(kw),
+        );
+        if (hasOverlap) {
+          parts.push(`## ${filename} (contextual)`);
+          parts.push(content);
+          parts.push("");
+        }
       }
     }
   } catch {
     // .botholomew dir might not have md files yet
+  }
+
+  // Relevant context from embeddings search
+  if (task && conn) {
+    try {
+      const query = `${task.name} ${task.description}`;
+      const queryVec = await embedSingle(query);
+      initVectorSearch(conn);
+      const results = hybridSearch(conn, query, queryVec, 5);
+
+      if (results.length > 0) {
+        parts.push("## Relevant Context");
+        for (const r of results) {
+          const path = r.source_path || r.context_item_id;
+          parts.push(`### ${r.title} (${path})`);
+          if (r.chunk_content) {
+            parts.push(r.chunk_content.slice(0, 1000));
+          }
+          parts.push("");
+        }
+      }
+    } catch (err) {
+      logger.debug(`Failed to load contextual embeddings: ${err}`);
+    }
   }
 
   // Instructions

--- a/src/daemon/tick.ts
+++ b/src/daemon/tick.ts
@@ -30,8 +30,8 @@ export async function tick(
     `Working: ${task.name}`,
   );
 
-  // Build system prompt
-  const systemPrompt = await buildSystemPrompt(projectDir);
+  // Build system prompt (includes task-relevant context from embeddings)
+  const systemPrompt = await buildSystemPrompt(projectDir, task, conn, config);
 
   try {
     const result = await runAgentLoop({

--- a/src/tools/file/edit.ts
+++ b/src/tools/file/edit.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { ingestByPath } from "../../context/ingest.ts";
 import { applyPatchesToContextItem } from "../../db/context.ts";
 import type { ToolDefinition } from "../tool.ts";
 
@@ -35,6 +36,8 @@ export const fileEditTool = {
       input.path,
       input.patches,
     );
+
+    await ingestByPath(ctx.conn, input.path, ctx.config);
     return { applied, content: item.content ?? "" };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/file/move.ts
+++ b/src/tools/file/move.ts
@@ -24,6 +24,12 @@ export const fileMoveTool = {
     }
 
     await moveContextItem(ctx.conn, input.src, input.dst);
+
+    // Update embedding source_paths to match new location
+    ctx.conn
+      .query("UPDATE embeddings SET source_path = ?1 WHERE source_path = ?2")
+      .run(input.dst, input.src);
+
     return { path: input.dst };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/file/write.ts
+++ b/src/tools/file/write.ts
@@ -1,5 +1,6 @@
 import { isText } from "istextorbinary";
 import { z } from "zod";
+import { ingestByPath } from "../../context/ingest.ts";
 import {
   createContextItem,
   getContextItemByPath,
@@ -70,6 +71,7 @@ export const fileWriteTool = {
           description: input.description,
         });
       }
+      await ingestByPath(ctx.conn, input.path, ctx.config);
       return { id: existing.id, path: input.path };
     }
 
@@ -85,6 +87,7 @@ export const fileWriteTool = {
       isTextual,
     });
 
+    await ingestByPath(ctx.conn, input.path, ctx.config);
     return { id: item.id, path: item.context_path };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/search/semantic.ts
+++ b/src/tools/search/semantic.ts
@@ -1,4 +1,6 @@
 import { z } from "zod";
+import { embedSingle } from "../../context/embedder.ts";
+import { hybridSearch, initVectorSearch } from "../../db/embeddings.ts";
 import type { ToolDefinition } from "../tool.ts";
 
 const inputSchema = z.object({
@@ -32,9 +34,27 @@ export const searchSemanticTool = {
   group: "search",
   inputSchema,
   outputSchema,
-  execute: async () => {
-    throw new Error(
-      "Semantic search is not yet available — requires the embeddings pipeline (M2)",
-    );
+  execute: async (input, ctx) => {
+    initVectorSearch(ctx.conn);
+
+    const queryVec = await embedSingle(input.query);
+    const results = hybridSearch(ctx.conn, input.query, queryVec, input.top_k);
+
+    const threshold = input.threshold;
+    const filtered =
+      threshold !== undefined
+        ? results.filter((r) => r.score >= threshold)
+        : results;
+
+    return {
+      results: filtered
+        .map((r) => ({
+          path: r.source_path || r.context_item_id,
+          title: r.title,
+          score: Math.round(r.score * 1000) / 1000,
+          snippet: (r.chunk_content || "").slice(0, 300),
+        }))
+        .sort((a, b) => b.score - a.score),
+    };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/test/context/chunker.test.ts
+++ b/test/context/chunker.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_CONFIG } from "../../src/config/schemas.ts";
+import { chunk, chunkWithSlidingWindow } from "../../src/context/chunker.ts";
+
+describe("chunkWithSlidingWindow", () => {
+  test("returns single chunk for short content", () => {
+    const content = "Hello world, this is short.";
+    const chunks = chunkWithSlidingWindow(content, 2000);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]?.index).toBe(0);
+    expect(chunks[0]?.content).toBe(content);
+  });
+
+  test("splits long content into overlapping chunks", () => {
+    // Create content that's definitely longer than the window
+    const lines = Array.from(
+      { length: 100 },
+      (_, i) => `Line ${i + 1}: ${"x".repeat(30)}`,
+    );
+    const content = lines.join("\n");
+    const chunks = chunkWithSlidingWindow(content, 500, 100);
+
+    expect(chunks.length).toBeGreaterThan(1);
+
+    // Each chunk should be within the window size (roughly)
+    for (const c of chunks) {
+      expect(c?.content.length).toBeLessThanOrEqual(600); // some slack for newline breaking
+    }
+
+    // Indices should be sequential
+    for (let i = 0; i < chunks.length; i++) {
+      expect(chunks[i]?.index).toBe(i);
+    }
+  });
+
+  test("all content is covered", () => {
+    const content = "A\nB\nC\nD\nE\nF\nG\nH\nI\nJ";
+    const chunks = chunkWithSlidingWindow(content, 5, 2);
+
+    // Every character in the original should appear in at least one chunk
+    for (const char of ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"]) {
+      const found = chunks.some((c) => c.content.includes(char));
+      expect(found).toBe(true);
+    }
+  });
+
+  test("prefers breaking at newlines", () => {
+    const content = "First line\nSecond line\nThird line\nFourth line";
+    const chunks = chunkWithSlidingWindow(content, 25, 5);
+
+    // Chunks should end at newline boundaries when possible
+    for (const c of chunks.slice(0, -1)) {
+      // Non-last chunks should end with newline or be at a line boundary
+      expect(c.content.endsWith("\n") || c.content.endsWith("line")).toBe(true);
+    }
+  });
+});
+
+describe("chunk", () => {
+  test("returns single chunk for short content", async () => {
+    const config = { ...DEFAULT_CONFIG };
+    const chunks = await chunk("Hi", "text/plain", config);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]?.content).toBe("Hi");
+  });
+
+  test("falls back to sliding window without API key", async () => {
+    const config = { ...DEFAULT_CONFIG, anthropic_api_key: "" };
+    const content = "x".repeat(3000);
+    const chunks = await chunk(content, "text/plain", config);
+    expect(chunks.length).toBeGreaterThan(1);
+  });
+});

--- a/test/context/embedder.test.ts
+++ b/test/context/embedder.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { embed, embedSingle } from "../../src/context/embedder.ts";
+
+// These tests use the real model — they're slow on first run (~2s model load)
+// but fast on subsequent runs due to singleton caching.
+
+describe("embed", () => {
+  test("returns vectors of correct dimension", async () => {
+    const texts = ["hello world", "how are you"];
+    const vectors = await embed(texts);
+
+    expect(vectors).toHaveLength(2);
+    const [v0, v1] = vectors;
+    expect(v0).toHaveLength(384);
+    expect(v1).toHaveLength(384);
+  });
+
+  test("returns empty array for empty input", async () => {
+    const vectors = await embed([]);
+    expect(vectors).toHaveLength(0);
+  });
+
+  test("vectors are approximately normalized", async () => {
+    const results = await embed(["test normalization"]);
+    const [vec] = results;
+    expect(vec).toBeDefined();
+    const norm = Math.sqrt((vec ?? []).reduce((sum, v) => sum + v * v, 0));
+    expect(norm).toBeCloseTo(1.0, 1);
+  });
+});
+
+describe("embedSingle", () => {
+  test("returns a single vector of correct dimension", async () => {
+    const vec = await embedSingle("single text");
+    expect(vec).toHaveLength(384);
+  });
+
+  test("similar texts produce similar vectors", async () => {
+    const v1: number[] = await embedSingle("the cat sat on the mat");
+    const v2: number[] = await embedSingle("a cat was sitting on a mat");
+    const v3: number[] = await embedSingle("quantum physics equations");
+
+    // Cosine similarity between similar texts should be higher
+    const sim12 = cosineSimilarity(v1, v2);
+    const sim13 = cosineSimilarity(v1, v3);
+
+    expect(sim12).toBeGreaterThan(sim13);
+  });
+});
+
+function cosineSimilarity(a: number[], b: number[]): number {
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (const [i, aVal] of a.entries()) {
+    const bVal = b[i] ?? 0;
+    dot += aVal * bVal;
+    normA += aVal * aVal;
+    normB += bVal * bVal;
+  }
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}

--- a/test/context/ingest.test.ts
+++ b/test/context/ingest.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { DEFAULT_CONFIG } from "../../src/config/schemas.ts";
+import { EMBEDDING_DIMENSION } from "../../src/constants.ts";
+import { ingestByPath, ingestContextItem } from "../../src/context/ingest.ts";
+import { type DbConnection, getConnection } from "../../src/db/connection.ts";
+import { createContextItem, getContextItem } from "../../src/db/context.ts";
+import { initVectorSearch, searchEmbeddings } from "../../src/db/embeddings.ts";
+import { migrate } from "../../src/db/schema.ts";
+
+const config = { ...DEFAULT_CONFIG };
+
+/** Mock embedder that returns deterministic vectors without loading the real model. */
+function mockEmbed(texts: string[]): Promise<number[][]> {
+  return Promise.resolve(
+    texts.map((text) => {
+      // Simple hash-based vector for deterministic results
+      const vec = new Array(EMBEDDING_DIMENSION).fill(0);
+      for (let i = 0; i < text.length; i++) {
+        vec[i % EMBEDDING_DIMENSION] += text.charCodeAt(i) / 1000;
+      }
+      // Normalize
+      const norm = Math.sqrt(
+        vec.reduce((s: number, v: number) => s + v * v, 0),
+      );
+      return norm > 0 ? vec.map((v: number) => v / norm) : vec;
+    }),
+  );
+}
+
+let conn: DbConnection;
+
+beforeEach(() => {
+  conn = getConnection(":memory:");
+  migrate(conn);
+});
+
+describe("ingestContextItem", () => {
+  test("creates embeddings for textual content", async () => {
+    const item = await createContextItem(conn, {
+      title: "test doc",
+      content: "This is a test document with some content.",
+      contextPath: "/test/doc.md",
+      mimeType: "text/plain",
+      isTextual: true,
+    });
+
+    const count = await ingestContextItem(conn, item.id, config, mockEmbed);
+    expect(count).toBeGreaterThan(0);
+
+    // Verify embeddings are stored
+    initVectorSearch(conn);
+    const results = searchEmbeddings(
+      conn,
+      await mockEmbed(["test"]).then((r) => r[0] ?? []),
+      10,
+    );
+    expect(results.length).toBeGreaterThan(0);
+  });
+
+  test("updates indexed_at timestamp", async () => {
+    const item = await createContextItem(conn, {
+      title: "indexed check",
+      content: "Some content to index.",
+      contextPath: "/test/indexed.md",
+      mimeType: "text/plain",
+      isTextual: true,
+    });
+
+    expect(item.indexed_at).toBeNull();
+
+    await ingestContextItem(conn, item.id, config, mockEmbed);
+
+    const updated = await getContextItem(conn, item.id);
+    expect(updated?.indexed_at).not.toBeNull();
+  });
+
+  test("skips non-textual items", async () => {
+    const item = await createContextItem(conn, {
+      title: "binary file",
+      contextPath: "/test/image.png",
+      mimeType: "image/png",
+      isTextual: false,
+    });
+
+    const count = await ingestContextItem(conn, item.id, config, mockEmbed);
+    expect(count).toBe(0);
+  });
+
+  test("skips items with no content", async () => {
+    const item = await createContextItem(conn, {
+      title: "empty file",
+      contextPath: "/test/empty.md",
+      mimeType: "text/plain",
+      isTextual: true,
+    });
+
+    const count = await ingestContextItem(conn, item.id, config, mockEmbed);
+    expect(count).toBe(0);
+  });
+
+  test("re-ingest clears old embeddings", async () => {
+    const item = await createContextItem(conn, {
+      title: "re-index test",
+      content: "Original content for re-indexing.",
+      contextPath: "/test/reindex.md",
+      mimeType: "text/plain",
+      isTextual: true,
+    });
+
+    const count1 = await ingestContextItem(conn, item.id, config, mockEmbed);
+    expect(count1).toBeGreaterThan(0);
+
+    // Re-ingest should not double the embeddings
+    const count2 = await ingestContextItem(conn, item.id, config, mockEmbed);
+    expect(count2).toBe(count1);
+
+    // Total embeddings should match the latest ingest
+    initVectorSearch(conn);
+    const allResults = searchEmbeddings(
+      conn,
+      await mockEmbed(["test"]).then((r) => r[0] ?? []),
+      100,
+    );
+    expect(allResults.length).toBe(count2);
+  });
+
+  test("returns 0 for non-existent item", async () => {
+    const count = await ingestContextItem(
+      conn,
+      "non-existent-id",
+      config,
+      mockEmbed,
+    );
+    expect(count).toBe(0);
+  });
+});
+
+describe("ingestByPath", () => {
+  test("ingests by virtual path", async () => {
+    await createContextItem(conn, {
+      title: "path test",
+      content: "Content to find by path.",
+      contextPath: "/notes/find-me.md",
+      mimeType: "text/plain",
+      isTextual: true,
+    });
+
+    const count = await ingestByPath(
+      conn,
+      "/notes/find-me.md",
+      config,
+      mockEmbed,
+    );
+    expect(count).toBeGreaterThan(0);
+  });
+
+  test("returns 0 for non-existent path", async () => {
+    const count = await ingestByPath(
+      conn,
+      "/no/such/path.md",
+      config,
+      mockEmbed,
+    );
+    expect(count).toBe(0);
+  });
+});

--- a/test/daemon/tick.test.ts
+++ b/test/daemon/tick.test.ts
@@ -46,7 +46,8 @@ describe("daemon tick", () => {
 
     await tick("/tmp/test-project", conn, {
       anthropic_api_key: "test-key",
-      model: "claude-sonnet-4-20250514",
+      model: "claude-opus-4-20250514",
+      chunker_model: "claude-haiku-4-20250514",
       tick_interval_seconds: 300,
       max_tick_duration_seconds: 120,
       system_prompt_override: "",
@@ -65,7 +66,8 @@ describe("daemon tick", () => {
 
     await tick("/tmp/test-project", conn, {
       anthropic_api_key: "test-key",
-      model: "claude-sonnet-4-20250514",
+      model: "claude-opus-4-20250514",
+      chunker_model: "claude-haiku-4-20250514",
       tick_interval_seconds: 300,
       max_tick_duration_seconds: 120,
       system_prompt_override: "",
@@ -93,7 +95,8 @@ describe("daemon tick", () => {
   test("does nothing when no tasks available", async () => {
     await tick("/tmp/test-project", conn, {
       anthropic_api_key: "test-key",
-      model: "claude-sonnet-4-20250514",
+      model: "claude-opus-4-20250514",
+      chunker_model: "claude-haiku-4-20250514",
       tick_interval_seconds: 300,
       max_tick_duration_seconds: 120,
       system_prompt_override: "",

--- a/test/tools/search.test.ts
+++ b/test/tools/search.test.ts
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import { DEFAULT_CONFIG } from "../../src/config/schemas.ts";
+import { EMBEDDING_DIMENSION } from "../../src/constants.ts";
+import { ingestContextItem } from "../../src/context/ingest.ts";
 import { type DbConnection, getConnection } from "../../src/db/connection.ts";
 import { createContextItem } from "../../src/db/context.ts";
 import { migrate } from "../../src/db/schema.ts";
 import { searchGrepTool } from "../../src/tools/search/grep.ts";
 import { searchSemanticTool } from "../../src/tools/search/semantic.ts";
-import type { AnyToolDefinition, ToolContext } from "../../src/tools/tool.ts";
+import type { ToolContext } from "../../src/tools/tool.ts";
 
 let conn: DbConnection;
 let ctx: ToolContext;
@@ -118,10 +120,38 @@ describe("search_grep", () => {
 // ── search_semantic ─────────────────────────────────────────
 
 describe("search_semantic", () => {
-  test("throws not yet available", async () => {
-    const tool = searchSemanticTool as unknown as AnyToolDefinition;
-    expect(tool.execute({ query: "anything", top_k: 10 }, ctx)).rejects.toThrow(
-      "not yet available",
+  test("returns results for indexed content", async () => {
+    // Mock embedder for tests
+    function mockEmbed(texts: string[]): Promise<number[][]> {
+      return Promise.resolve(
+        texts.map((text) => {
+          const vec = new Array(EMBEDDING_DIMENSION).fill(0);
+          for (let i = 0; i < text.length; i++) {
+            vec[i % EMBEDDING_DIMENSION] += text.charCodeAt(i) / 1000;
+          }
+          const norm = Math.sqrt(
+            vec.reduce((s: number, v: number) => s + v * v, 0),
+          );
+          return norm > 0 ? vec.map((v: number) => v / norm) : vec;
+        }),
+      );
+    }
+
+    // Seed and ingest a file
+    const item = await seedFile(
+      "/search/doc.md",
+      "Meeting notes about quarterly revenue and projections.",
     );
+    await ingestContextItem(conn, item.id, ctx.config, mockEmbed);
+
+    // search_semantic uses the real embedder, so we test the grep-based path here
+    // by verifying the tool doesn't throw anymore
+    // Full integration test with real model is in embedder.test.ts
+    const result = await searchSemanticTool.execute(
+      { query: "quarterly revenue", top_k: 5 },
+      ctx,
+    );
+    expect(result.results).toBeDefined();
+    expect(Array.isArray(result.results)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Adds local embedding generation via `@huggingface/transformers` (`Xenova/bge-small-en-v1.5`, 384-dim vectors) with singleton warmup at daemon boot and a `botholomew prepare` CLI command for CI
- Implements LLM-driven content chunking (structured outputs via tool_use) with sliding-window fallback, and a transactional ingest pipeline (chunk → embed → store)
- Wires `search_semantic` tool with hybrid search (keyword + vector RRF), and adds embedding cascade to `file_write`, `file_edit`, and `file_move`
- Implements `context list`, `context add <path>`, and `context search <query>` CLI commands
- Extends `buildSystemPrompt` with task-aware contextual loading from embeddings and `loading: contextual` markdown files

## Test plan

- [x] `bun run lint` passes (0 errors)
- [x] `bun test` passes (168 tests, 0 failures)
- [x] New tests for embedder (5), chunker (6), ingest (8) cover core pipeline
- [ ] Manual: `botholomew prepare` downloads model, `context add ./file` ingests, `context search` returns ranked results

🤖 Generated with [Claude Code](https://claude.com/claude-code)