### PR TITLE
Mark Milestone 2 as done in roadmap

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -3,7 +3,7 @@
 | # | Milestone | Status | Summary |
 |---|-----------|--------|---------|
 | 1 | [Foundation](milestone-1-foundation.md) | **Done** | Scaffolding, SQLite schema, CLI skeleton, daemon tick loop |
-| 2 | [Context & Embeddings](milestone-2-context-and-embeddings.md) | Planned | Ingest, chunk, embed, and search content with hybrid vector search |
+| 2 | [Context & Embeddings](milestone-2-context-and-embeddings.md) | **Done** | Ingest, chunk, embed, and search content with hybrid vector search |
 | 3 | [Schedules & Task Hardening](milestone-3-schedules-and-task-hardening.md) | Planned | Recurring schedules, cycle detection, timeouts, full task/schedule CLI |
 | 4 | [MCPX Integration](milestone-4-mcpx-integration.md) | Planned | External tools via MCP servers (Gmail, Slack, web, etc.) |
 | 5 | [Chat TUI](milestone-5-chat-tui.md) | Planned | Interactive Ink/React terminal UI for conversational interaction |


### PR DESCRIPTION
## Summary
- Updates the milestone roadmap to mark M2 (Context & Embeddings) as **Done**
- All M2 components — tool base class, 18 tools, context/embeddings CRUD, embedding pipeline, CLI integration, daemon integration, contextual prompt loading, and tests — are fully implemented

## Test plan
- [ ] Verify `docs/plans/README.md` renders correctly with M2 marked as Done

🤖 Generated with [Claude Code](https://claude.com/claude-code)