### PR TITLE
Add recurring schedules, cycle detection, and task hardening (M3)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import { registerDaemonCommand } from "./commands/daemon.ts";
 import { registerInitCommand } from "./commands/init.ts";
 import { registerMcpxCommand } from "./commands/mcpx.ts";
 import { registerPrepareCommand } from "./commands/prepare.ts";
+import { registerScheduleCommand } from "./commands/schedule.ts";
 import { registerTaskCommand } from "./commands/task.ts";
 import { registerToolCommands } from "./commands/tools.ts";
 import { registerUpgradeCommand } from "./commands/upgrade.ts";
@@ -32,6 +33,7 @@ program
 registerInitCommand(program);
 registerDaemonCommand(program);
 registerTaskCommand(program);
+registerScheduleCommand(program);
 registerChatCommand(program);
 registerContextCommand(program);
 registerMcpxCommand(program);

--- a/src/commands/schedule.ts
+++ b/src/commands/schedule.ts
@@ -1,0 +1,215 @@
+import ansis from "ansis";
+import type { Command } from "commander";
+import { getDbPath } from "../constants.ts";
+import { getConnection } from "../db/connection.ts";
+import type { Schedule } from "../db/schedules.ts";
+import {
+  createSchedule,
+  deleteSchedule,
+  getSchedule,
+  listSchedules,
+  updateSchedule,
+} from "../db/schedules.ts";
+import { migrate } from "../db/schema.ts";
+import { logger } from "../utils/logger.ts";
+
+export function registerScheduleCommand(program: Command) {
+  const schedule = program.command("schedule").description("Manage schedules");
+
+  schedule
+    .command("list")
+    .description("List all schedules")
+    .option("--enabled", "show only enabled schedules")
+    .option("--disabled", "show only disabled schedules")
+    .action(async (opts) => {
+      const dir = program.opts().dir;
+      const conn = getConnection(getDbPath(dir));
+      migrate(conn);
+
+      const filters: { enabled?: boolean } = {};
+      if (opts.enabled) filters.enabled = true;
+      if (opts.disabled) filters.enabled = false;
+
+      const schedules = await listSchedules(conn, filters);
+
+      if (schedules.length === 0) {
+        logger.dim("No schedules found.");
+        return;
+      }
+
+      for (const s of schedules) {
+        printSchedule(s);
+      }
+
+      conn.close();
+    });
+
+  schedule
+    .command("add <name>")
+    .description("Create a new schedule")
+    .requiredOption(
+      "-f, --frequency <text>",
+      "how often to run (e.g. 'every morning')",
+    )
+    .option("--description <text>", "schedule description", "")
+    .action(async (name, opts) => {
+      const dir = program.opts().dir;
+      const conn = getConnection(getDbPath(dir));
+      migrate(conn);
+
+      const s = await createSchedule(conn, {
+        name,
+        description: opts.description,
+        frequency: opts.frequency,
+      });
+
+      logger.success(`Created schedule: ${s.name} (${s.id})`);
+      conn.close();
+    });
+
+  schedule
+    .command("view <id>")
+    .description("View schedule details")
+    .action(async (id) => {
+      const dir = program.opts().dir;
+      const conn = getConnection(getDbPath(dir));
+      migrate(conn);
+
+      const s = await getSchedule(conn, id);
+      if (!s) {
+        logger.error(`Schedule not found: ${id}`);
+        process.exit(1);
+      }
+
+      printScheduleDetail(s);
+      conn.close();
+    });
+
+  schedule
+    .command("enable <id>")
+    .description("Enable a schedule")
+    .action(async (id) => {
+      const dir = program.opts().dir;
+      const conn = getConnection(getDbPath(dir));
+      migrate(conn);
+
+      const s = await updateSchedule(conn, id, { enabled: true });
+      if (!s) {
+        logger.error(`Schedule not found: ${id}`);
+        process.exit(1);
+      }
+
+      logger.success(`Enabled schedule: ${s.name}`);
+      conn.close();
+    });
+
+  schedule
+    .command("disable <id>")
+    .description("Disable a schedule")
+    .action(async (id) => {
+      const dir = program.opts().dir;
+      const conn = getConnection(getDbPath(dir));
+      migrate(conn);
+
+      const s = await updateSchedule(conn, id, { enabled: false });
+      if (!s) {
+        logger.error(`Schedule not found: ${id}`);
+        process.exit(1);
+      }
+
+      logger.success(`Disabled schedule: ${s.name}`);
+      conn.close();
+    });
+
+  schedule
+    .command("delete <id>")
+    .description("Delete a schedule")
+    .action(async (id) => {
+      const dir = program.opts().dir;
+      const conn = getConnection(getDbPath(dir));
+      migrate(conn);
+
+      const deleted = await deleteSchedule(conn, id);
+      if (!deleted) {
+        logger.error(`Schedule not found: ${id}`);
+        process.exit(1);
+      }
+
+      logger.success(`Deleted schedule: ${id}`);
+      conn.close();
+    });
+
+  schedule
+    .command("trigger <id>")
+    .description("Manually trigger a schedule (creates tasks immediately)")
+    .action(async (id) => {
+      const dir = program.opts().dir;
+      const conn = getConnection(getDbPath(dir));
+      migrate(conn);
+
+      const s = await getSchedule(conn, id);
+      if (!s) {
+        logger.error(`Schedule not found: ${id}`);
+        process.exit(1);
+      }
+
+      // Lazy import to avoid loading LLM deps for non-trigger commands
+      const { evaluateSchedule } = await import("../daemon/schedules.ts");
+      const { loadConfig } = await import("../config/loader.ts");
+      const { createTask } = await import("../db/tasks.ts");
+      const { markScheduleRun } = await import("../db/schedules.ts");
+
+      const config = await loadConfig(dir);
+      const evaluation = await evaluateSchedule(config, s);
+
+      if (evaluation.tasksToCreate.length === 0) {
+        logger.dim("Schedule evaluated but produced no tasks.");
+      } else {
+        const createdIds: string[] = [];
+        for (const taskDef of evaluation.tasksToCreate) {
+          const blockedBy = (taskDef.depends_on ?? [])
+            .map((i: number) => createdIds[i])
+            .filter(Boolean) as string[];
+          const t = await createTask(conn, {
+            name: taskDef.name,
+            description: taskDef.description,
+            priority: taskDef.priority,
+            blocked_by: blockedBy,
+          });
+          createdIds.push(t.id);
+          logger.success(`Created task: ${t.name} (${t.id})`);
+        }
+      }
+
+      await markScheduleRun(conn, s.id);
+      logger.info(`Marked schedule "${s.name}" as run.`);
+      conn.close();
+    });
+}
+
+function enabledColor(enabled: boolean): string {
+  return enabled ? ansis.green("enabled") : ansis.dim("disabled");
+}
+
+function printSchedule(s: Schedule) {
+  const id = ansis.dim(s.id.slice(0, 8));
+  const lastRun = s.last_run_at
+    ? s.last_run_at.toISOString()
+    : ansis.dim("never");
+  console.log(
+    `  ${id}  ${enabledColor(s.enabled)}  ${s.frequency}  ${s.name}  (last: ${lastRun})`,
+  );
+}
+
+function printScheduleDetail(s: Schedule) {
+  console.log(ansis.bold(s.name));
+  console.log(`  ID:          ${s.id}`);
+  console.log(`  Status:      ${enabledColor(s.enabled)}`);
+  console.log(`  Frequency:   ${s.frequency}`);
+  if (s.description) console.log(`  Description: ${s.description}`);
+  console.log(
+    `  Last run:    ${s.last_run_at ? s.last_run_at.toISOString() : ansis.dim("never")}`,
+  );
+  console.log(`  Created:     ${s.created_at.toISOString()}`);
+  console.log(`  Updated:     ${s.updated_at.toISOString()}`);
+}

--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -4,7 +4,14 @@ import { getDbPath } from "../constants.ts";
 import { getConnection } from "../db/connection.ts";
 import { migrate } from "../db/schema.ts";
 import type { Task } from "../db/tasks.ts";
-import { createTask, getTask, listTasks } from "../db/tasks.ts";
+import {
+  createTask,
+  deleteTask,
+  getTask,
+  listTasks,
+  resetTask,
+  updateTask,
+} from "../db/tasks.ts";
 import { logger } from "../utils/logger.ts";
 
 export function registerTaskCommand(program: Command) {
@@ -74,6 +81,75 @@ export function registerTaskCommand(program: Command) {
       }
 
       printTaskDetail(t);
+      conn.close();
+    });
+
+  task
+    .command("update <id>")
+    .description("Update a task")
+    .option("--name <text>", "new task name")
+    .option("--description <text>", "new description")
+    .option("-p, --priority <priority>", "low, medium, or high")
+    .option("-s, --status <status>", "new status")
+    .action(async (id, opts) => {
+      const dir = program.opts().dir;
+      const conn = getConnection(getDbPath(dir));
+      migrate(conn);
+
+      const updates: Parameters<typeof updateTask>[2] = {};
+      if (opts.name) updates.name = opts.name;
+      if (opts.description) updates.description = opts.description;
+      if (opts.priority) updates.priority = opts.priority;
+      if (opts.status) updates.status = opts.status;
+
+      try {
+        const t = await updateTask(conn, id, updates);
+        if (!t) {
+          logger.error(`Task not found: ${id}`);
+          process.exit(1);
+        }
+        printTaskDetail(t);
+      } catch (err) {
+        logger.error(String(err));
+        process.exit(1);
+      }
+
+      conn.close();
+    });
+
+  task
+    .command("delete <id>")
+    .description("Delete a task")
+    .action(async (id) => {
+      const dir = program.opts().dir;
+      const conn = getConnection(getDbPath(dir));
+      migrate(conn);
+
+      const deleted = await deleteTask(conn, id);
+      if (!deleted) {
+        logger.error(`Task not found: ${id}`);
+        process.exit(1);
+      }
+
+      logger.success(`Deleted task: ${id}`);
+      conn.close();
+    });
+
+  task
+    .command("reset <id>")
+    .description("Reset a stuck task back to pending")
+    .action(async (id) => {
+      const dir = program.opts().dir;
+      const conn = getConnection(getDbPath(dir));
+      migrate(conn);
+
+      const t = await resetTask(conn, id);
+      if (!t) {
+        logger.error(`Task not found: ${id}`);
+        process.exit(1);
+      }
+
+      logger.success(`Reset task: ${t.name} (${t.id})`);
       conn.close();
     });
 }

--- a/src/daemon/schedules.ts
+++ b/src/daemon/schedules.ts
@@ -1,0 +1,142 @@
+import Anthropic from "@anthropic-ai/sdk";
+import type { BotholomewConfig } from "../config/schemas.ts";
+import type { DbConnection } from "../db/connection.ts";
+import {
+  listSchedules,
+  markScheduleRun,
+  type Schedule,
+} from "../db/schedules.ts";
+import { createTask } from "../db/tasks.ts";
+import { logger } from "../utils/logger.ts";
+
+interface ScheduleTaskDef {
+  name: string;
+  description: string;
+  priority: "low" | "medium" | "high";
+  depends_on?: number[];
+}
+
+export interface ScheduleEvaluation {
+  isDue: boolean;
+  reasoning: string;
+  tasksToCreate: ScheduleTaskDef[];
+}
+
+export async function evaluateSchedule(
+  config: Required<BotholomewConfig>,
+  schedule: Schedule,
+): Promise<ScheduleEvaluation> {
+  const client = new Anthropic({
+    apiKey: config.anthropic_api_key || undefined,
+  });
+
+  const systemPrompt = `You are a schedule evaluator. Given a recurring schedule, the current time, and when the schedule last ran, determine:
+1. Whether the schedule is currently due to run
+2. If due, what task(s) should be created
+
+Respond with JSON only, no other text. Use this exact schema:
+{
+  "isDue": boolean,
+  "reasoning": "brief explanation of why it is or is not due",
+  "tasks": [
+    {
+      "name": "task name",
+      "description": "what to do",
+      "priority": "low" | "medium" | "high",
+      "depends_on": []
+    }
+  ]
+}
+
+The "depends_on" array contains indices of other tasks in the array that must complete first. For example, if task at index 1 depends on task at index 0, set depends_on to [0].`;
+
+  const userMessage = `Schedule: "${schedule.name}"
+Description: ${schedule.description || "(none)"}
+Frequency: ${schedule.frequency}
+Last run: ${schedule.last_run_at?.toISOString() ?? "never"}
+Current time: ${new Date().toISOString()}
+
+Is this schedule due to run? If yes, what tasks should be created?`;
+
+  try {
+    const response = await client.messages.create({
+      model: config.chunker_model,
+      max_tokens: 1024,
+      system: systemPrompt,
+      messages: [{ role: "user", content: userMessage }],
+    });
+
+    const text = response.content
+      .filter((b) => b.type === "text")
+      .map((b) => b.text)
+      .join("");
+
+    const parsed = JSON.parse(text);
+
+    return {
+      isDue: Boolean(parsed.isDue),
+      reasoning: String(parsed.reasoning ?? ""),
+      tasksToCreate: Array.isArray(parsed.tasks)
+        ? parsed.tasks.map((t: Record<string, unknown>) => ({
+            name: String(t.name ?? "Untitled"),
+            description: String(t.description ?? ""),
+            priority:
+              t.priority === "low" || t.priority === "high"
+                ? t.priority
+                : "medium",
+            depends_on: Array.isArray(t.depends_on) ? t.depends_on : [],
+          }))
+        : [],
+    };
+  } catch (err) {
+    logger.warn(`Failed to evaluate schedule "${schedule.name}": ${err}`);
+    return {
+      isDue: false,
+      reasoning: `Evaluation failed: ${err}`,
+      tasksToCreate: [],
+    };
+  }
+}
+
+export async function processSchedules(
+  conn: DbConnection,
+  config: Required<BotholomewConfig>,
+): Promise<void> {
+  const schedules = await listSchedules(conn, { enabled: true });
+  if (schedules.length === 0) return;
+
+  for (const schedule of schedules) {
+    try {
+      const evaluation = await evaluateSchedule(config, schedule);
+
+      if (!evaluation.isDue) {
+        logger.debug(
+          `Schedule "${schedule.name}" not due: ${evaluation.reasoning}`,
+        );
+        continue;
+      }
+
+      const createdIds: string[] = [];
+      for (const taskDef of evaluation.tasksToCreate) {
+        const blockedBy = (taskDef.depends_on ?? [])
+          .map((i: number) => createdIds[i])
+          .filter(Boolean) as string[];
+
+        const task = await createTask(conn, {
+          name: taskDef.name,
+          description: taskDef.description,
+          priority: taskDef.priority,
+          blocked_by: blockedBy,
+        });
+        createdIds.push(task.id);
+      }
+
+      await markScheduleRun(conn, schedule.id);
+      logger.info(
+        `Schedule "${schedule.name}" fired, created ${createdIds.length} task(s)`,
+      );
+    } catch (err) {
+      logger.error(`Error processing schedule "${schedule.name}": ${err}`);
+    }
+  }
+}

--- a/src/daemon/tick.ts
+++ b/src/daemon/tick.ts
@@ -1,10 +1,15 @@
 import type { BotholomewConfig } from "../config/schemas.ts";
 import type { DbConnection } from "../db/connection.ts";
-import { claimNextTask, updateTaskStatus } from "../db/tasks.ts";
+import {
+  claimNextTask,
+  resetStaleTasks,
+  updateTaskStatus,
+} from "../db/tasks.ts";
 import { createThread, endThread, logInteraction } from "../db/threads.ts";
 import { logger } from "../utils/logger.ts";
 import { runAgentLoop } from "./llm.ts";
 import { buildSystemPrompt } from "./prompt.ts";
+import { processSchedules } from "./schedules.ts";
 
 export async function tick(
   projectDir: string,
@@ -12,6 +17,24 @@ export async function tick(
   config: Required<BotholomewConfig>,
 ): Promise<void> {
   logger.debug("Tick starting...");
+
+  // Reset stale tasks stuck in in_progress
+  const resetIds = await resetStaleTasks(
+    conn,
+    config.max_tick_duration_seconds * 3,
+  );
+  if (resetIds.length > 0) {
+    logger.warn(
+      `Reset ${resetIds.length} stale task(s): ${resetIds.join(", ")}`,
+    );
+  }
+
+  // Process schedules (may create new tasks)
+  try {
+    await processSchedules(conn, config);
+  } catch (err) {
+    logger.error(`Schedule processing failed: ${err}`);
+  }
 
   // Claim a task
   const task = await claimNextTask(conn);

--- a/src/db/schedules.ts
+++ b/src/db/schedules.ts
@@ -1,4 +1,5 @@
 import type { DbConnection } from "./connection.ts";
+import { uuidv7 } from "./uuid.ts";
 
 export interface Schedule {
   id: string;
@@ -11,7 +12,141 @@ export interface Schedule {
   updated_at: Date;
 }
 
-// Stub — full implementation in a later milestone
-export async function listSchedules(_db: DbConnection): Promise<Schedule[]> {
-  return [];
+interface ScheduleRow {
+  id: string;
+  name: string;
+  description: string;
+  frequency: string;
+  last_run_at: string | null;
+  enabled: number;
+  created_at: string;
+  updated_at: string;
+}
+
+function rowToSchedule(row: ScheduleRow): Schedule {
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    frequency: row.frequency,
+    last_run_at: row.last_run_at ? new Date(row.last_run_at) : null,
+    enabled: row.enabled === 1,
+    created_at: new Date(row.created_at),
+    updated_at: new Date(row.updated_at),
+  };
+}
+
+export async function createSchedule(
+  db: DbConnection,
+  params: {
+    name: string;
+    description?: string;
+    frequency: string;
+  },
+): Promise<Schedule> {
+  const id = uuidv7();
+  const row = db
+    .query(
+      `INSERT INTO schedules (id, name, description, frequency)
+     VALUES (?1, ?2, ?3, ?4)
+     RETURNING *`,
+    )
+    .get(
+      id,
+      params.name,
+      params.description ?? "",
+      params.frequency,
+    ) as ScheduleRow | null;
+  if (!row) throw new Error("INSERT did not return a row");
+  return rowToSchedule(row);
+}
+
+export async function getSchedule(
+  db: DbConnection,
+  id: string,
+): Promise<Schedule | null> {
+  const row = db
+    .query("SELECT * FROM schedules WHERE id = ?1")
+    .get(id) as ScheduleRow | null;
+  return row ? rowToSchedule(row) : null;
+}
+
+export async function listSchedules(
+  db: DbConnection,
+  filters?: { enabled?: boolean },
+): Promise<Schedule[]> {
+  const conditions: string[] = [];
+  const params: (string | number)[] = [];
+
+  if (filters?.enabled !== undefined) {
+    params.push(filters.enabled ? 1 : 0);
+    conditions.push(`enabled = ?${params.length}`);
+  }
+
+  const where =
+    conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+
+  const rows = db
+    .query(`SELECT * FROM schedules ${where} ORDER BY created_at ASC`)
+    .all(...params) as ScheduleRow[];
+  return rows.map(rowToSchedule);
+}
+
+export async function updateSchedule(
+  db: DbConnection,
+  id: string,
+  updates: Partial<
+    Pick<Schedule, "name" | "description" | "frequency" | "enabled">
+  >,
+): Promise<Schedule | null> {
+  const setClauses: string[] = [];
+  const params: (string | number)[] = [];
+
+  if (updates.name !== undefined) {
+    params.push(updates.name);
+    setClauses.push(`name = ?${params.length}`);
+  }
+  if (updates.description !== undefined) {
+    params.push(updates.description);
+    setClauses.push(`description = ?${params.length}`);
+  }
+  if (updates.frequency !== undefined) {
+    params.push(updates.frequency);
+    setClauses.push(`frequency = ?${params.length}`);
+  }
+  if (updates.enabled !== undefined) {
+    params.push(updates.enabled ? 1 : 0);
+    setClauses.push(`enabled = ?${params.length}`);
+  }
+
+  if (setClauses.length === 0) {
+    return getSchedule(db, id);
+  }
+
+  setClauses.push("updated_at = datetime('now')");
+  params.push(id);
+
+  const row = db
+    .query(
+      `UPDATE schedules SET ${setClauses.join(", ")} WHERE id = ?${params.length} RETURNING *`,
+    )
+    .get(...params) as ScheduleRow | null;
+  return row ? rowToSchedule(row) : null;
+}
+
+export async function deleteSchedule(
+  db: DbConnection,
+  id: string,
+): Promise<boolean> {
+  const result = db.query("DELETE FROM schedules WHERE id = ?1").run(id);
+  return result.changes > 0;
+}
+
+export async function markScheduleRun(
+  db: DbConnection,
+  id: string,
+): Promise<void> {
+  db.query(
+    `UPDATE schedules SET last_run_at = datetime('now'), updated_at = datetime('now') WHERE id = ?1`,
+  ).run(id);
 }

--- a/src/db/tasks.ts
+++ b/src/db/tasks.ts
@@ -68,7 +68,9 @@ export async function createTask(
   },
 ): Promise<Task> {
   const id = uuidv7();
-  const blockedBy = JSON.stringify(params.blocked_by ?? []);
+  const blockedByArr = params.blocked_by ?? [];
+  await validateBlockedBy(db, id, blockedByArr);
+  const blockedBy = JSON.stringify(blockedByArr);
   const contextIds = JSON.stringify(params.context_ids ?? []);
 
   const row = db
@@ -146,6 +148,137 @@ export async function updateTaskStatus(
      SET status = ?1, waiting_reason = ?2, updated_at = datetime('now')
      WHERE id = ?3`,
   ).run(status, reason ?? null, id);
+}
+
+export async function validateBlockedBy(
+  db: DbConnection,
+  taskId: string,
+  blockedBy: string[],
+): Promise<void> {
+  if (blockedBy.length === 0) return;
+
+  // Check for direct self-reference
+  if (blockedBy.includes(taskId)) {
+    throw new Error(`Circular dependency: task ${taskId} cannot block itself`);
+  }
+
+  // DFS through transitive blocked_by chains
+  const visited = new Set<string>();
+
+  async function dfs(currentId: string): Promise<void> {
+    if (visited.has(currentId)) return;
+    visited.add(currentId);
+
+    const task = await getTask(db, currentId);
+    if (!task) return;
+
+    for (const dep of task.blocked_by) {
+      if (dep === taskId) {
+        throw new Error(
+          `Circular dependency: adding blocked_by would create cycle involving task ${taskId}`,
+        );
+      }
+      await dfs(dep);
+    }
+  }
+
+  for (const blockerId of blockedBy) {
+    await dfs(blockerId);
+  }
+}
+
+export async function updateTask(
+  db: DbConnection,
+  id: string,
+  updates: Partial<
+    Pick<Task, "name" | "description" | "priority" | "status" | "blocked_by">
+  >,
+): Promise<Task | null> {
+  if (updates.blocked_by !== undefined) {
+    await validateBlockedBy(db, id, updates.blocked_by);
+  }
+
+  const setClauses: string[] = [];
+  const params: (string | number | null)[] = [];
+
+  if (updates.name !== undefined) {
+    params.push(updates.name);
+    setClauses.push(`name = ?${params.length}`);
+  }
+  if (updates.description !== undefined) {
+    params.push(updates.description);
+    setClauses.push(`description = ?${params.length}`);
+  }
+  if (updates.priority !== undefined) {
+    params.push(updates.priority);
+    setClauses.push(`priority = ?${params.length}`);
+  }
+  if (updates.status !== undefined) {
+    params.push(updates.status);
+    setClauses.push(`status = ?${params.length}`);
+  }
+  if (updates.blocked_by !== undefined) {
+    params.push(JSON.stringify(updates.blocked_by));
+    setClauses.push(`blocked_by = ?${params.length}`);
+  }
+
+  if (setClauses.length === 0) {
+    return getTask(db, id);
+  }
+
+  setClauses.push("updated_at = datetime('now')");
+  params.push(id);
+
+  const row = db
+    .query(
+      `UPDATE tasks SET ${setClauses.join(", ")} WHERE id = ?${params.length} RETURNING *`,
+    )
+    .get(...params) as TaskRow | null;
+  return row ? rowToTask(row) : null;
+}
+
+export async function deleteTask(
+  db: DbConnection,
+  id: string,
+): Promise<boolean> {
+  const result = db.query("DELETE FROM tasks WHERE id = ?1").run(id);
+  return result.changes > 0;
+}
+
+export async function resetTask(
+  db: DbConnection,
+  id: string,
+): Promise<Task | null> {
+  const row = db
+    .query(
+      `UPDATE tasks
+     SET status = 'pending', claimed_by = NULL, claimed_at = NULL,
+         waiting_reason = NULL, updated_at = datetime('now')
+     WHERE id = ?1
+     RETURNING *`,
+    )
+    .get(id) as TaskRow | null;
+  return row ? rowToTask(row) : null;
+}
+
+export async function resetStaleTasks(
+  db: DbConnection,
+  timeoutSeconds: number,
+): Promise<string[]> {
+  const rows = db
+    .query(
+      `UPDATE tasks
+     SET status = 'pending',
+         claimed_by = NULL,
+         claimed_at = NULL,
+         updated_at = datetime('now')
+     WHERE status = 'in_progress'
+       AND claimed_at IS NOT NULL
+       AND claimed_at < datetime('now', '-' || ?1 || ' seconds')
+     RETURNING id`,
+    )
+    .all(timeoutSeconds) as { id: string }[];
+  return rows.map((r) => r.id);
 }
 
 export async function claimNextTask(

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -13,6 +13,9 @@ import { fileMoveTool } from "./file/move.ts";
 // File tools
 import { fileReadTool } from "./file/read.ts";
 import { fileWriteTool } from "./file/write.ts";
+// Schedule tools
+import { createScheduleTool } from "./schedule/create.ts";
+import { listSchedulesTool } from "./schedule/list.ts";
 // Search tools
 import { searchGrepTool } from "./search/grep.ts";
 import { searchSemanticTool } from "./search/semantic.ts";
@@ -46,6 +49,10 @@ export function registerAllTools(): void {
   registerTool(fileInfoTool);
   registerTool(fileExistsTool);
   registerTool(fileCountLinesTool);
+
+  // Schedule
+  registerTool(createScheduleTool);
+  registerTool(listSchedulesTool);
 
   // Search
   registerTool(searchGrepTool);

--- a/src/tools/schedule/create.ts
+++ b/src/tools/schedule/create.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+import { createSchedule } from "../../db/schedules.ts";
+import { logger } from "../../utils/logger.ts";
+import type { ToolDefinition } from "../tool.ts";
+
+const inputSchema = z.object({
+  name: z.string().describe("Schedule name"),
+  description: z.string().optional().describe("What should happen on each run"),
+  frequency: z
+    .string()
+    .describe(
+      "How often to run, e.g. 'every morning', 'weekly on Mondays', 'every 2 hours'",
+    ),
+});
+
+const outputSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  message: z.string(),
+});
+
+export const createScheduleTool = {
+  name: "create_schedule",
+  description:
+    "Create a new recurring schedule that will automatically generate tasks.",
+  group: "schedule",
+  inputSchema,
+  outputSchema,
+  execute: async (input, ctx) => {
+    const schedule = await createSchedule(ctx.conn, {
+      name: input.name,
+      description: input.description,
+      frequency: input.frequency,
+    });
+    logger.info(`Created schedule: ${schedule.name} (${schedule.id})`);
+    return {
+      id: schedule.id,
+      name: schedule.name,
+      message: `Created schedule "${schedule.name}" with frequency "${schedule.frequency}"`,
+    };
+  },
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/schedule/list.ts
+++ b/src/tools/schedule/list.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+import { listSchedules } from "../../db/schedules.ts";
+import type { ToolDefinition } from "../tool.ts";
+
+const inputSchema = z.object({
+  enabled: z.boolean().optional().describe("Filter by enabled status"),
+});
+
+const outputSchema = z.object({
+  schedules: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+      frequency: z.string(),
+      enabled: z.boolean(),
+      last_run_at: z.string().nullable(),
+    }),
+  ),
+  count: z.number(),
+});
+
+export const listSchedulesTool = {
+  name: "list_schedules",
+  description: "List existing recurring schedules.",
+  group: "schedule",
+  inputSchema,
+  outputSchema,
+  execute: async (input, ctx) => {
+    const schedules = await listSchedules(ctx.conn, {
+      enabled: input.enabled,
+    });
+    return {
+      schedules: schedules.map((s) => ({
+        id: s.id,
+        name: s.name,
+        frequency: s.frequency,
+        enabled: s.enabled,
+        last_run_at: s.last_run_at?.toISOString() ?? null,
+      })),
+      count: schedules.length,
+    };
+  },
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/test/daemon/schedules.test.ts
+++ b/test/daemon/schedules.test.ts
@@ -1,0 +1,270 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { type DbConnection, getConnection } from "../../src/db/connection.ts";
+import { createSchedule, getSchedule } from "../../src/db/schedules.ts";
+import { migrate } from "../../src/db/schema.ts";
+import { listTasks } from "../../src/db/tasks.ts";
+
+let mockResponse: Record<string, unknown> = {};
+
+// Mock the Anthropic SDK before importing schedules module
+mock.module("@anthropic-ai/sdk", () => {
+  return {
+    default: class MockAnthropic {
+      messages = {
+        create: async () => ({
+          content: [{ type: "text", text: JSON.stringify(mockResponse) }],
+          stop_reason: "end_turn",
+          usage: { input_tokens: 50, output_tokens: 50 },
+        }),
+      };
+    },
+  };
+});
+
+const { evaluateSchedule, processSchedules } = await import(
+  "../../src/daemon/schedules.ts"
+);
+
+let conn: DbConnection;
+
+const testConfig = {
+  anthropic_api_key: "test-key",
+  model: "claude-opus-4-20250514",
+  chunker_model: "claude-haiku-4-20250514",
+  tick_interval_seconds: 300,
+  max_tick_duration_seconds: 120,
+  system_prompt_override: "",
+};
+
+beforeEach(() => {
+  conn = getConnection(":memory:");
+  migrate(conn);
+  mockResponse = {};
+});
+
+describe("evaluateSchedule", () => {
+  test("returns isDue with tasks when schedule is due", async () => {
+    mockResponse = {
+      isDue: true,
+      reasoning: "Last run was over 24 hours ago",
+      tasks: [
+        { name: "Check email", description: "Read inbox", priority: "medium" },
+      ],
+    };
+
+    const schedule = await createSchedule(conn, {
+      name: "Morning email",
+      frequency: "every morning",
+    });
+
+    const result = await evaluateSchedule(testConfig, schedule);
+    expect(result.isDue).toBe(true);
+    expect(result.tasksToCreate).toHaveLength(1);
+    expect(result.tasksToCreate[0]?.name).toBe("Check email");
+  });
+
+  test("returns not due when schedule is not due", async () => {
+    mockResponse = {
+      isDue: false,
+      reasoning: "Last run was 1 hour ago, too soon",
+      tasks: [],
+    };
+
+    const schedule = await createSchedule(conn, {
+      name: "Hourly check",
+      frequency: "every 4 hours",
+    });
+
+    const result = await evaluateSchedule(testConfig, schedule);
+    expect(result.isDue).toBe(false);
+    expect(result.tasksToCreate).toHaveLength(0);
+  });
+
+  test("handles malformed LLM response gracefully", async () => {
+    // Override mock to return invalid JSON
+    mock.module("@anthropic-ai/sdk", () => ({
+      default: class MockAnthropic {
+        messages = {
+          create: async () => ({
+            content: [{ type: "text", text: "not valid json {{{" }],
+            stop_reason: "end_turn",
+            usage: { input_tokens: 50, output_tokens: 50 },
+          }),
+        };
+      },
+    }));
+
+    // Re-import to get the new mock
+    const { evaluateSchedule: evalFresh } = await import(
+      "../../src/daemon/schedules.ts"
+    );
+
+    const schedule = await createSchedule(conn, {
+      name: "Test",
+      frequency: "daily",
+    });
+
+    const result = await evalFresh(testConfig, schedule);
+    expect(result.isDue).toBe(false);
+    expect(result.reasoning).toContain("failed");
+
+    // Restore original mock
+    mock.module("@anthropic-ai/sdk", () => ({
+      default: class MockAnthropic {
+        messages = {
+          create: async () => ({
+            content: [{ type: "text", text: JSON.stringify(mockResponse) }],
+            stop_reason: "end_turn",
+            usage: { input_tokens: 50, output_tokens: 50 },
+          }),
+        };
+      },
+    }));
+  });
+
+  test("handles tasks with depends_on", async () => {
+    mockResponse = {
+      isDue: true,
+      reasoning: "Due now",
+      tasks: [
+        { name: "Step 1", description: "First", priority: "high" },
+        {
+          name: "Step 2",
+          description: "Second",
+          priority: "medium",
+          depends_on: [0],
+        },
+      ],
+    };
+
+    const schedule = await createSchedule(conn, {
+      name: "Multi-step",
+      frequency: "daily",
+    });
+
+    const result = await evaluateSchedule(testConfig, schedule);
+    expect(result.tasksToCreate).toHaveLength(2);
+    expect(result.tasksToCreate[1]?.depends_on).toEqual([0]);
+  });
+});
+
+describe("processSchedules", () => {
+  test("creates tasks for due schedules", async () => {
+    mockResponse = {
+      isDue: true,
+      reasoning: "Due now",
+      tasks: [
+        { name: "Read email", description: "Check inbox", priority: "medium" },
+      ],
+    };
+
+    await createSchedule(conn, {
+      name: "Morning email",
+      frequency: "every morning",
+    });
+
+    await processSchedules(conn, testConfig);
+
+    const tasks = await listTasks(conn);
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]?.name).toBe("Read email");
+  });
+
+  test("updates last_run_at for due schedules", async () => {
+    mockResponse = {
+      isDue: true,
+      reasoning: "Due",
+      tasks: [{ name: "Task", description: "", priority: "low" }],
+    };
+
+    const schedule = await createSchedule(conn, {
+      name: "Test",
+      frequency: "daily",
+    });
+
+    await processSchedules(conn, testConfig);
+
+    const updated = await getSchedule(conn, schedule.id);
+    expect(updated?.last_run_at).not.toBeNull();
+  });
+
+  test("does not create tasks for not-due schedules", async () => {
+    mockResponse = {
+      isDue: false,
+      reasoning: "Not due yet",
+      tasks: [],
+    };
+
+    await createSchedule(conn, {
+      name: "Future",
+      frequency: "weekly",
+    });
+
+    await processSchedules(conn, testConfig);
+
+    const tasks = await listTasks(conn);
+    expect(tasks).toHaveLength(0);
+  });
+
+  test("skips disabled schedules", async () => {
+    mockResponse = {
+      isDue: true,
+      reasoning: "Due",
+      tasks: [{ name: "Task", description: "", priority: "low" }],
+    };
+
+    const schedule = await createSchedule(conn, {
+      name: "Disabled",
+      frequency: "daily",
+    });
+
+    const { updateSchedule } = await import("../../src/db/schedules.ts");
+    await updateSchedule(conn, schedule.id, { enabled: false });
+
+    await processSchedules(conn, testConfig);
+
+    const tasks = await listTasks(conn);
+    expect(tasks).toHaveLength(0);
+  });
+
+  test("wires depends_on to blocked_by", async () => {
+    mockResponse = {
+      isDue: true,
+      reasoning: "Due",
+      tasks: [
+        { name: "Step 1", description: "First", priority: "high" },
+        {
+          name: "Step 2",
+          description: "Second",
+          priority: "medium",
+          depends_on: [0],
+        },
+      ],
+    };
+
+    await createSchedule(conn, {
+      name: "Multi-step",
+      frequency: "daily",
+    });
+
+    await processSchedules(conn, testConfig);
+
+    const tasks = await listTasks(conn);
+    expect(tasks).toHaveLength(2);
+
+    // Step 2 should be blocked by Step 1
+    const step1 = tasks.find((t) => t.name === "Step 1");
+    const step2 = tasks.find((t) => t.name === "Step 2");
+    expect(step1).toBeDefined();
+    expect(step2).toBeDefined();
+    expect(step2?.blocked_by).toContain(step1?.id);
+  });
+
+  test("does nothing with no enabled schedules", async () => {
+    // No schedules at all — should return immediately
+    await processSchedules(conn, testConfig);
+
+    const tasks = await listTasks(conn);
+    expect(tasks).toHaveLength(0);
+  });
+});

--- a/test/db/schedules.test.ts
+++ b/test/db/schedules.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { type DbConnection, getConnection } from "../../src/db/connection.ts";
+import {
+  createSchedule,
+  deleteSchedule,
+  getSchedule,
+  listSchedules,
+  markScheduleRun,
+  updateSchedule,
+} from "../../src/db/schedules.ts";
+import { migrate } from "../../src/db/schema.ts";
+
+let conn: DbConnection;
+
+beforeEach(() => {
+  conn = getConnection(":memory:");
+  migrate(conn);
+});
+
+describe("schedule CRUD", () => {
+  test("create and get a schedule", async () => {
+    const schedule = await createSchedule(conn, {
+      name: "Morning email",
+      description: "Check email and summarize",
+      frequency: "every morning",
+    });
+
+    expect(schedule.name).toBe("Morning email");
+    expect(schedule.description).toBe("Check email and summarize");
+    expect(schedule.frequency).toBe("every morning");
+    expect(schedule.enabled).toBe(true);
+    expect(schedule.last_run_at).toBeNull();
+    expect(schedule.id).toBeTruthy();
+
+    const fetched = await getSchedule(conn, schedule.id);
+    expect(fetched).not.toBeNull();
+    expect(fetched?.name).toBe("Morning email");
+  });
+
+  test("create schedule with default description", async () => {
+    const schedule = await createSchedule(conn, {
+      name: "Test",
+      frequency: "daily",
+    });
+    expect(schedule.description).toBe("");
+  });
+
+  test("get nonexistent schedule returns null", async () => {
+    const schedule = await getSchedule(conn, "nonexistent");
+    expect(schedule).toBeNull();
+  });
+
+  test("list all schedules", async () => {
+    await createSchedule(conn, { name: "A", frequency: "daily" });
+    await createSchedule(conn, { name: "B", frequency: "weekly" });
+
+    const schedules = await listSchedules(conn);
+    expect(schedules.length).toBe(2);
+    expect(schedules[0]?.name).toBe("A");
+    expect(schedules[1]?.name).toBe("B");
+  });
+
+  test("list schedules filtered by enabled", async () => {
+    const s = await createSchedule(conn, {
+      name: "Active",
+      frequency: "daily",
+    });
+    await createSchedule(conn, { name: "Inactive", frequency: "daily" });
+    await updateSchedule(conn, s.id, { enabled: false });
+
+    const enabled = await listSchedules(conn, { enabled: true });
+    expect(enabled.length).toBe(1);
+    expect(enabled[0]?.name).toBe("Inactive");
+
+    const disabled = await listSchedules(conn, { enabled: false });
+    expect(disabled.length).toBe(1);
+    expect(disabled[0]?.name).toBe("Active");
+  });
+
+  test("update schedule fields", async () => {
+    const schedule = await createSchedule(conn, {
+      name: "Original",
+      frequency: "daily",
+    });
+
+    const updated = await updateSchedule(conn, schedule.id, {
+      name: "Updated",
+      frequency: "weekly",
+      description: "New description",
+    });
+
+    expect(updated?.name).toBe("Updated");
+    expect(updated?.frequency).toBe("weekly");
+    expect(updated?.description).toBe("New description");
+  });
+
+  test("update with empty updates returns current", async () => {
+    const schedule = await createSchedule(conn, {
+      name: "Test",
+      frequency: "daily",
+    });
+
+    const same = await updateSchedule(conn, schedule.id, {});
+    expect(same?.name).toBe("Test");
+  });
+
+  test("update nonexistent schedule returns null", async () => {
+    const result = await updateSchedule(conn, "nonexistent", { name: "X" });
+    expect(result).toBeNull();
+  });
+
+  test("delete schedule", async () => {
+    const schedule = await createSchedule(conn, {
+      name: "To delete",
+      frequency: "daily",
+    });
+
+    const deleted = await deleteSchedule(conn, schedule.id);
+    expect(deleted).toBe(true);
+
+    const fetched = await getSchedule(conn, schedule.id);
+    expect(fetched).toBeNull();
+  });
+
+  test("delete nonexistent schedule returns false", async () => {
+    const deleted = await deleteSchedule(conn, "nonexistent");
+    expect(deleted).toBe(false);
+  });
+
+  test("markScheduleRun updates last_run_at", async () => {
+    const schedule = await createSchedule(conn, {
+      name: "Test",
+      frequency: "daily",
+    });
+    expect(schedule.last_run_at).toBeNull();
+
+    await markScheduleRun(conn, schedule.id);
+
+    const updated = await getSchedule(conn, schedule.id);
+    expect(updated?.last_run_at).not.toBeNull();
+    expect(updated?.last_run_at).toBeInstanceOf(Date);
+  });
+});

--- a/test/db/tasks-validation.test.ts
+++ b/test/db/tasks-validation.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { type DbConnection, getConnection } from "../../src/db/connection.ts";
+import { migrate } from "../../src/db/schema.ts";
+import {
+  createTask,
+  deleteTask,
+  getTask,
+  resetStaleTasks,
+  resetTask,
+  updateTask,
+  updateTaskStatus,
+} from "../../src/db/tasks.ts";
+
+let conn: DbConnection;
+
+beforeEach(() => {
+  conn = getConnection(":memory:");
+  migrate(conn);
+});
+
+describe("cycle detection", () => {
+  test("rejects direct self-reference", async () => {
+    const a = await createTask(conn, { name: "A" });
+    await expect(
+      updateTask(conn, a.id, { blocked_by: [a.id] }),
+    ).rejects.toThrow("cannot block itself");
+  });
+
+  test("rejects simple A↔B cycle", async () => {
+    const a = await createTask(conn, { name: "A" });
+    const b = await createTask(conn, { name: "B", blocked_by: [a.id] });
+
+    await expect(
+      updateTask(conn, a.id, { blocked_by: [b.id] }),
+    ).rejects.toThrow("Circular dependency");
+  });
+
+  test("rejects deep A→B→C→A cycle", async () => {
+    const a = await createTask(conn, { name: "A" });
+    const b = await createTask(conn, { name: "B", blocked_by: [a.id] });
+    const c = await createTask(conn, { name: "C", blocked_by: [b.id] });
+
+    await expect(
+      updateTask(conn, a.id, { blocked_by: [c.id] }),
+    ).rejects.toThrow("Circular dependency");
+  });
+
+  test("allows valid chain (no cycle)", async () => {
+    const a = await createTask(conn, { name: "A" });
+    const b = await createTask(conn, { name: "B", blocked_by: [a.id] });
+    const c = await createTask(conn, { name: "C", blocked_by: [b.id] });
+
+    // This is fine — no cycle
+    expect(c.blocked_by).toEqual([b.id]);
+  });
+
+  test("allows diamond dependency (not a cycle)", async () => {
+    const d = await createTask(conn, { name: "D" });
+    const b = await createTask(conn, { name: "B", blocked_by: [d.id] });
+    const c = await createTask(conn, { name: "C", blocked_by: [d.id] });
+    const a = await createTask(conn, {
+      name: "A",
+      blocked_by: [b.id, c.id],
+    });
+
+    expect(a.blocked_by).toEqual([b.id, c.id]);
+  });
+});
+
+describe("updateTask", () => {
+  test("updates name and priority", async () => {
+    const task = await createTask(conn, { name: "Original" });
+
+    const updated = await updateTask(conn, task.id, {
+      name: "New name",
+      priority: "high",
+    });
+
+    expect(updated?.name).toBe("New name");
+    expect(updated?.priority).toBe("high");
+  });
+
+  test("updates status", async () => {
+    const task = await createTask(conn, { name: "Task" });
+    const updated = await updateTask(conn, task.id, { status: "complete" });
+    expect(updated?.status).toBe("complete");
+  });
+
+  test("empty updates returns current task", async () => {
+    const task = await createTask(conn, { name: "Task" });
+    const same = await updateTask(conn, task.id, {});
+    expect(same?.name).toBe("Task");
+  });
+
+  test("update nonexistent task returns null", async () => {
+    const result = await updateTask(conn, "nonexistent", { name: "X" });
+    expect(result).toBeNull();
+  });
+});
+
+describe("deleteTask", () => {
+  test("deletes existing task", async () => {
+    const task = await createTask(conn, { name: "To delete" });
+    const deleted = await deleteTask(conn, task.id);
+    expect(deleted).toBe(true);
+
+    const fetched = await getTask(conn, task.id);
+    expect(fetched).toBeNull();
+  });
+
+  test("delete nonexistent returns false", async () => {
+    const deleted = await deleteTask(conn, "nonexistent");
+    expect(deleted).toBe(false);
+  });
+});
+
+describe("resetTask", () => {
+  test("resets in_progress task to pending", async () => {
+    const task = await createTask(conn, { name: "Stuck" });
+    await updateTaskStatus(conn, task.id, "in_progress");
+
+    const reset = await resetTask(conn, task.id);
+    expect(reset?.status).toBe("pending");
+    expect(reset?.claimed_by).toBeNull();
+    expect(reset?.claimed_at).toBeNull();
+    expect(reset?.waiting_reason).toBeNull();
+  });
+
+  test("reset nonexistent returns null", async () => {
+    const result = await resetTask(conn, "nonexistent");
+    expect(result).toBeNull();
+  });
+});
+
+describe("resetStaleTasks", () => {
+  test("resets tasks with old claimed_at", async () => {
+    const task = await createTask(conn, { name: "Stale" });
+
+    // Manually set to in_progress with old claimed_at
+    conn
+      .query(
+        `UPDATE tasks
+       SET status = 'in_progress', claimed_by = 'daemon',
+           claimed_at = datetime('now', '-1 hour')
+       WHERE id = ?1`,
+      )
+      .run(task.id);
+
+    const resetIds = await resetStaleTasks(conn, 60); // 60s timeout
+    expect(resetIds).toContain(task.id);
+
+    const fetched = await getTask(conn, task.id);
+    expect(fetched?.status).toBe("pending");
+    expect(fetched?.claimed_by).toBeNull();
+  });
+
+  test("does not reset recent in_progress tasks", async () => {
+    const task = await createTask(conn, { name: "Active" });
+
+    conn
+      .query(
+        `UPDATE tasks
+       SET status = 'in_progress', claimed_by = 'daemon',
+           claimed_at = datetime('now')
+       WHERE id = ?1`,
+      )
+      .run(task.id);
+
+    const resetIds = await resetStaleTasks(conn, 60);
+    expect(resetIds).not.toContain(task.id);
+  });
+
+  test("does not reset non-in_progress tasks", async () => {
+    const task = await createTask(conn, { name: "Pending" });
+
+    const resetIds = await resetStaleTasks(conn, 60);
+    expect(resetIds).not.toContain(task.id);
+  });
+});

--- a/test/tools/schedule.test.ts
+++ b/test/tools/schedule.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { DEFAULT_CONFIG } from "../../src/config/schemas.ts";
+import { type DbConnection, getConnection } from "../../src/db/connection.ts";
+import { migrate } from "../../src/db/schema.ts";
+import { createScheduleTool } from "../../src/tools/schedule/create.ts";
+import { listSchedulesTool } from "../../src/tools/schedule/list.ts";
+import type { ToolContext } from "../../src/tools/tool.ts";
+
+let conn: DbConnection;
+let ctx: ToolContext;
+
+beforeEach(() => {
+  conn = getConnection(":memory:");
+  migrate(conn);
+  ctx = { conn, projectDir: "/tmp/test", config: { ...DEFAULT_CONFIG } };
+});
+
+describe("create_schedule", () => {
+  test("creates a schedule", async () => {
+    const result = await createScheduleTool.execute(
+      { name: "Morning email", frequency: "every morning" },
+      ctx,
+    );
+    expect(result.id).toBeTruthy();
+    expect(result.name).toBe("Morning email");
+    expect(result.message).toContain("every morning");
+  });
+
+  test("creates a schedule with description", async () => {
+    const result = await createScheduleTool.execute(
+      {
+        name: "Weekly report",
+        frequency: "weekly on Mondays",
+        description: "Generate summary",
+      },
+      ctx,
+    );
+    expect(result.name).toBe("Weekly report");
+  });
+
+  test("validates input: missing frequency", () => {
+    const parsed = createScheduleTool.inputSchema.safeParse({ name: "Test" });
+    expect(parsed.success).toBe(false);
+  });
+});
+
+describe("list_schedules", () => {
+  test("returns empty array initially", async () => {
+    const result = await listSchedulesTool.execute({}, ctx);
+    expect(result.schedules).toEqual([]);
+    expect(result.count).toBe(0);
+  });
+
+  test("returns created schedules", async () => {
+    await createScheduleTool.execute({ name: "A", frequency: "daily" }, ctx);
+    await createScheduleTool.execute({ name: "B", frequency: "weekly" }, ctx);
+
+    const result = await listSchedulesTool.execute({}, ctx);
+    expect(result.count).toBe(2);
+    expect(result.schedules[0]?.name).toBe("A");
+    expect(result.schedules[1]?.name).toBe("B");
+  });
+
+  test("filters by enabled", async () => {
+    const { id } = await createScheduleTool.execute(
+      { name: "Active", frequency: "daily" },
+      ctx,
+    );
+    await createScheduleTool.execute(
+      { name: "Also active", frequency: "weekly" },
+      ctx,
+    );
+
+    // Disable one via direct DB update
+    const { updateSchedule } = await import("../../src/db/schedules.ts");
+    await updateSchedule(conn, id, { enabled: false });
+
+    const enabled = await listSchedulesTool.execute({ enabled: true }, ctx);
+    expect(enabled.count).toBe(1);
+    expect(enabled.schedules[0]?.name).toBe("Also active");
+  });
+});


### PR DESCRIPTION
## Summary

- **Schedule system**: Full CRUD for recurring schedules with LLM-based evaluation (uses chunker_model/Haiku) to determine when schedules are due and what tasks to create
- **Cycle detection**: DFS-based `validateBlockedBy` prevents circular dependencies in `blocked_by` chains, enforced on both create and update
- **Task hardening**: Stale task recovery (`resetStaleTasks`), plus `updateTask`, `deleteTask`, and `resetTask` helpers
- **CLI**: New `schedule` command (list/add/view/enable/disable/delete/trigger) and task subcommands (update/delete/reset)
- **Agent tools**: `create_schedule` and `list_schedules` registered in the daemon tool registry

## Test plan

- [x] `bun run lint` passes (0 errors)
- [x] `bun test` passes (211 tests, 0 failures)
- [x] New tests: schedule CRUD, cycle detection, stale reset, schedule evaluation (mocked LLM), schedule tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)