### PR TITLE
Refactor: reduce duplication across commands, db, and tests

### DIFF
--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -4,18 +4,17 @@ import ansis from "ansis";
 import type { Command } from "commander";
 import { isText } from "istextorbinary";
 import { loadConfig } from "../config/loader.ts";
-import { getDbPath } from "../constants.ts";
 import { embedSingle, warmupEmbedder } from "../context/embedder.ts";
 import { ingestContextItem } from "../context/ingest.ts";
-import { getConnection } from "../db/connection.ts";
+import type { DbConnection } from "../db/connection.ts";
 import {
   createContextItem,
   listContextItems,
   listContextItemsByPrefix,
 } from "../db/context.ts";
 import { hybridSearch, initVectorSearch } from "../db/embeddings.ts";
-import { migrate } from "../db/schema.ts";
 import { logger } from "../utils/logger.ts";
+import { withDb } from "./with-db.ts";
 
 export function registerContextCommand(program: Command) {
   const ctx = program.command("context").description("Manage context items");
@@ -25,119 +24,110 @@ export function registerContextCommand(program: Command) {
     .description("List context items")
     .option("--path <prefix>", "filter by path prefix")
     .option("-l, --limit <n>", "max number of items", Number.parseInt)
-    .action(async (opts) => {
-      const dir = program.opts().dir;
-      const conn = getConnection(getDbPath(dir));
-      migrate(conn);
+    .action((opts) =>
+      withDb(program, async (conn) => {
+        const items = opts.path
+          ? await listContextItemsByPrefix(conn, opts.path, {
+              recursive: true,
+              limit: opts.limit,
+            })
+          : await listContextItems(conn, { limit: opts.limit });
 
-      const items = opts.path
-        ? await listContextItemsByPrefix(conn, opts.path, {
-            recursive: true,
-            limit: opts.limit,
-          })
-        : await listContextItems(conn, { limit: opts.limit });
+        if (items.length === 0) {
+          logger.dim("No context items found.");
+          return;
+        }
 
-      if (items.length === 0) {
-        logger.dim("No context items found.");
-        conn.close();
-        return;
-      }
+        const header = `${ansis.bold("Path".padEnd(40))} ${"Title".padEnd(25)} ${"Type".padEnd(20)} Indexed`;
+        console.log(header);
+        console.log("-".repeat(header.length));
 
-      const header = `${ansis.bold("Path".padEnd(40))} ${"Title".padEnd(25)} ${"Type".padEnd(20)} Indexed`;
-      console.log(header);
-      console.log("-".repeat(header.length));
+        for (const item of items) {
+          const indexed = item.indexed_at
+            ? ansis.green("yes")
+            : ansis.dim("no");
+          console.log(
+            `${item.context_path.padEnd(40)} ${item.title.slice(0, 24).padEnd(25)} ${item.mime_type.slice(0, 19).padEnd(20)} ${indexed}`,
+          );
+        }
 
-      for (const item of items) {
-        const indexed = item.indexed_at ? ansis.green("yes") : ansis.dim("no");
-        console.log(
-          `${item.context_path.padEnd(40)} ${item.title.slice(0, 24).padEnd(25)} ${item.mime_type.slice(0, 19).padEnd(20)} ${indexed}`,
-        );
-      }
-
-      console.log(`\n${ansis.dim(`${items.length} item(s)`)}`);
-      conn.close();
-    });
+        console.log(`\n${ansis.dim(`${items.length} item(s)`)}`);
+      }),
+    );
 
   ctx
     .command("add <path>")
     .description("Add a file or directory to context")
     .option("--prefix <prefix>", "virtual path prefix", "/")
-    .action(async (path, opts) => {
-      const dir = program.opts().dir;
-      const conn = getConnection(getDbPath(dir));
-      migrate(conn);
-      const config = await loadConfig(dir);
-      await warmupEmbedder();
+    .action((path, opts) =>
+      withDb(program, async (conn, dir) => {
+        const config = await loadConfig(dir);
+        await warmupEmbedder();
 
-      const resolvedPath = resolve(path);
-      const info = await stat(resolvedPath);
+        const resolvedPath = resolve(path);
+        const info = await stat(resolvedPath);
 
-      let added = 0;
-      let chunks = 0;
+        let added = 0;
+        let chunks = 0;
 
-      if (info.isDirectory()) {
-        const entries = await walkDirectory(resolvedPath);
-        for (const filePath of entries) {
-          const relativePath = filePath.slice(resolvedPath.length);
-          const contextPath = join(opts.prefix, relativePath);
-          const count = await addFile(conn, config, filePath, contextPath);
+        if (info.isDirectory()) {
+          const entries = await walkDirectory(resolvedPath);
+          for (const filePath of entries) {
+            const relativePath = filePath.slice(resolvedPath.length);
+            const contextPath = join(opts.prefix, relativePath);
+            const count = await addFile(conn, config, filePath, contextPath);
+            if (count >= 0) {
+              added++;
+              chunks += count;
+            }
+          }
+        } else {
+          const contextPath = join(opts.prefix, basename(resolvedPath));
+          const count = await addFile(conn, config, resolvedPath, contextPath);
           if (count >= 0) {
             added++;
             chunks += count;
           }
         }
-      } else {
-        const contextPath = join(opts.prefix, basename(resolvedPath));
-        const count = await addFile(conn, config, resolvedPath, contextPath);
-        if (count >= 0) {
-          added++;
-          chunks += count;
-        }
-      }
 
-      logger.success(`Added ${added} file(s), ${chunks} chunk(s) indexed.`);
-      conn.close();
-    });
+        logger.success(`Added ${added} file(s), ${chunks} chunk(s) indexed.`);
+      }),
+    );
 
   ctx
     .command("search <query>")
     .description("Search context items")
     .option("-k, --top-k <n>", "max results", Number.parseInt, 10)
-    .action(async (query, opts) => {
-      const dir = program.opts().dir;
-      const conn = getConnection(getDbPath(dir));
-      migrate(conn);
+    .action((query, opts) =>
+      withDb(program, async (conn) => {
+        await warmupEmbedder();
+        initVectorSearch(conn);
+        const queryVec = await embedSingle(query);
+        const results = hybridSearch(conn, query, queryVec, opts.topK);
 
-      await warmupEmbedder();
-      initVectorSearch(conn);
-      const queryVec = await embedSingle(query);
-      const results = hybridSearch(conn, query, queryVec, opts.topK);
-
-      if (results.length === 0) {
-        logger.dim("No results found.");
-        conn.close();
-        return;
-      }
-
-      for (const [i, r] of results.entries()) {
-        const score = (r.score * 100).toFixed(1);
-        console.log(
-          `${ansis.bold(`${i + 1}.`)} ${ansis.cyan(r.title)} ${ansis.dim(`(${score}%)`)}`,
-        );
-        console.log(`   ${ansis.dim(r.source_path || r.context_item_id)}`);
-        if (r.chunk_content) {
-          const snippet = r.chunk_content.slice(0, 120).replace(/\n/g, " ");
-          console.log(`   ${snippet}...`);
+        if (results.length === 0) {
+          logger.dim("No results found.");
+          return;
         }
-        console.log("");
-      }
 
-      conn.close();
-    });
+        for (const [i, r] of results.entries()) {
+          const score = (r.score * 100).toFixed(1);
+          console.log(
+            `${ansis.bold(`${i + 1}.`)} ${ansis.cyan(r.title)} ${ansis.dim(`(${score}%)`)}`,
+          );
+          console.log(`   ${ansis.dim(r.source_path || r.context_item_id)}`);
+          if (r.chunk_content) {
+            const snippet = r.chunk_content.slice(0, 120).replace(/\n/g, " ");
+            console.log(`   ${snippet}...`);
+          }
+          console.log("");
+        }
+      }),
+    );
 }
 
 async function addFile(
-  conn: ReturnType<typeof getConnection>,
+  conn: DbConnection,
   config: Awaited<ReturnType<typeof loadConfig>>,
   filePath: string,
   contextPath: string,

--- a/src/commands/schedule.ts
+++ b/src/commands/schedule.ts
@@ -1,7 +1,5 @@
 import ansis from "ansis";
 import type { Command } from "commander";
-import { getDbPath } from "../constants.ts";
-import { getConnection } from "../db/connection.ts";
 import type { Schedule } from "../db/schedules.ts";
 import {
   createSchedule,
@@ -10,8 +8,8 @@ import {
   listSchedules,
   updateSchedule,
 } from "../db/schedules.ts";
-import { migrate } from "../db/schema.ts";
 import { logger } from "../utils/logger.ts";
+import { withDb } from "./with-db.ts";
 
 export function registerScheduleCommand(program: Command) {
   const schedule = program.command("schedule").description("Manage schedules");
@@ -21,28 +19,24 @@ export function registerScheduleCommand(program: Command) {
     .description("List all schedules")
     .option("--enabled", "show only enabled schedules")
     .option("--disabled", "show only disabled schedules")
-    .action(async (opts) => {
-      const dir = program.opts().dir;
-      const conn = getConnection(getDbPath(dir));
-      migrate(conn);
+    .action((opts) =>
+      withDb(program, async (conn) => {
+        const filters: { enabled?: boolean } = {};
+        if (opts.enabled) filters.enabled = true;
+        if (opts.disabled) filters.enabled = false;
 
-      const filters: { enabled?: boolean } = {};
-      if (opts.enabled) filters.enabled = true;
-      if (opts.disabled) filters.enabled = false;
+        const schedules = await listSchedules(conn, filters);
 
-      const schedules = await listSchedules(conn, filters);
+        if (schedules.length === 0) {
+          logger.dim("No schedules found.");
+          return;
+        }
 
-      if (schedules.length === 0) {
-        logger.dim("No schedules found.");
-        return;
-      }
-
-      for (const s of schedules) {
-        printSchedule(s);
-      }
-
-      conn.close();
-    });
+        for (const s of schedules) {
+          printSchedule(s);
+        }
+      }),
+    );
 
   schedule
     .command("add <name>")
@@ -52,139 +46,116 @@ export function registerScheduleCommand(program: Command) {
       "how often to run (e.g. 'every morning')",
     )
     .option("--description <text>", "schedule description", "")
-    .action(async (name, opts) => {
-      const dir = program.opts().dir;
-      const conn = getConnection(getDbPath(dir));
-      migrate(conn);
-
-      const s = await createSchedule(conn, {
-        name,
-        description: opts.description,
-        frequency: opts.frequency,
-      });
-
-      logger.success(`Created schedule: ${s.name} (${s.id})`);
-      conn.close();
-    });
+    .action((name, opts) =>
+      withDb(program, async (conn) => {
+        const s = await createSchedule(conn, {
+          name,
+          description: opts.description,
+          frequency: opts.frequency,
+        });
+        logger.success(`Created schedule: ${s.name} (${s.id})`);
+      }),
+    );
 
   schedule
     .command("view <id>")
     .description("View schedule details")
-    .action(async (id) => {
-      const dir = program.opts().dir;
-      const conn = getConnection(getDbPath(dir));
-      migrate(conn);
-
-      const s = await getSchedule(conn, id);
-      if (!s) {
-        logger.error(`Schedule not found: ${id}`);
-        process.exit(1);
-      }
-
-      printScheduleDetail(s);
-      conn.close();
-    });
+    .action((id) =>
+      withDb(program, async (conn) => {
+        const s = await getSchedule(conn, id);
+        if (!s) {
+          logger.error(`Schedule not found: ${id}`);
+          process.exit(1);
+        }
+        printScheduleDetail(s);
+      }),
+    );
 
   schedule
     .command("enable <id>")
     .description("Enable a schedule")
-    .action(async (id) => {
-      const dir = program.opts().dir;
-      const conn = getConnection(getDbPath(dir));
-      migrate(conn);
-
-      const s = await updateSchedule(conn, id, { enabled: true });
-      if (!s) {
-        logger.error(`Schedule not found: ${id}`);
-        process.exit(1);
-      }
-
-      logger.success(`Enabled schedule: ${s.name}`);
-      conn.close();
-    });
+    .action((id) =>
+      withDb(program, async (conn) => {
+        const s = await updateSchedule(conn, id, { enabled: true });
+        if (!s) {
+          logger.error(`Schedule not found: ${id}`);
+          process.exit(1);
+        }
+        logger.success(`Enabled schedule: ${s.name}`);
+      }),
+    );
 
   schedule
     .command("disable <id>")
     .description("Disable a schedule")
-    .action(async (id) => {
-      const dir = program.opts().dir;
-      const conn = getConnection(getDbPath(dir));
-      migrate(conn);
-
-      const s = await updateSchedule(conn, id, { enabled: false });
-      if (!s) {
-        logger.error(`Schedule not found: ${id}`);
-        process.exit(1);
-      }
-
-      logger.success(`Disabled schedule: ${s.name}`);
-      conn.close();
-    });
+    .action((id) =>
+      withDb(program, async (conn) => {
+        const s = await updateSchedule(conn, id, { enabled: false });
+        if (!s) {
+          logger.error(`Schedule not found: ${id}`);
+          process.exit(1);
+        }
+        logger.success(`Disabled schedule: ${s.name}`);
+      }),
+    );
 
   schedule
     .command("delete <id>")
     .description("Delete a schedule")
-    .action(async (id) => {
-      const dir = program.opts().dir;
-      const conn = getConnection(getDbPath(dir));
-      migrate(conn);
-
-      const deleted = await deleteSchedule(conn, id);
-      if (!deleted) {
-        logger.error(`Schedule not found: ${id}`);
-        process.exit(1);
-      }
-
-      logger.success(`Deleted schedule: ${id}`);
-      conn.close();
-    });
+    .action((id) =>
+      withDb(program, async (conn) => {
+        const deleted = await deleteSchedule(conn, id);
+        if (!deleted) {
+          logger.error(`Schedule not found: ${id}`);
+          process.exit(1);
+        }
+        logger.success(`Deleted schedule: ${id}`);
+      }),
+    );
 
   schedule
     .command("trigger <id>")
     .description("Manually trigger a schedule (creates tasks immediately)")
-    .action(async (id) => {
-      const dir = program.opts().dir;
-      const conn = getConnection(getDbPath(dir));
-      migrate(conn);
-
-      const s = await getSchedule(conn, id);
-      if (!s) {
-        logger.error(`Schedule not found: ${id}`);
-        process.exit(1);
-      }
-
-      // Lazy import to avoid loading LLM deps for non-trigger commands
-      const { evaluateSchedule } = await import("../daemon/schedules.ts");
-      const { loadConfig } = await import("../config/loader.ts");
-      const { createTask } = await import("../db/tasks.ts");
-      const { markScheduleRun } = await import("../db/schedules.ts");
-
-      const config = await loadConfig(dir);
-      const evaluation = await evaluateSchedule(config, s);
-
-      if (evaluation.tasksToCreate.length === 0) {
-        logger.dim("Schedule evaluated but produced no tasks.");
-      } else {
-        const createdIds: string[] = [];
-        for (const taskDef of evaluation.tasksToCreate) {
-          const blockedBy = (taskDef.depends_on ?? [])
-            .map((i: number) => createdIds[i])
-            .filter(Boolean) as string[];
-          const t = await createTask(conn, {
-            name: taskDef.name,
-            description: taskDef.description,
-            priority: taskDef.priority,
-            blocked_by: blockedBy,
-          });
-          createdIds.push(t.id);
-          logger.success(`Created task: ${t.name} (${t.id})`);
+    .action((id) =>
+      withDb(program, async (conn, dir) => {
+        const s = await getSchedule(conn, id);
+        if (!s) {
+          logger.error(`Schedule not found: ${id}`);
+          process.exit(1);
         }
-      }
 
-      await markScheduleRun(conn, s.id);
-      logger.info(`Marked schedule "${s.name}" as run.`);
-      conn.close();
-    });
+        // Lazy import to avoid loading LLM deps for non-trigger commands
+        const { evaluateSchedule } = await import("../daemon/schedules.ts");
+        const { loadConfig } = await import("../config/loader.ts");
+        const { createTask } = await import("../db/tasks.ts");
+        const { markScheduleRun } = await import("../db/schedules.ts");
+
+        const config = await loadConfig(dir);
+        const evaluation = await evaluateSchedule(config, s);
+
+        if (evaluation.tasksToCreate.length === 0) {
+          logger.dim("Schedule evaluated but produced no tasks.");
+        } else {
+          const createdIds: string[] = [];
+          for (const taskDef of evaluation.tasksToCreate) {
+            const blockedBy = (taskDef.depends_on ?? [])
+              .map((i: number) => createdIds[i])
+              .filter(Boolean) as string[];
+            const t = await createTask(conn, {
+              name: taskDef.name,
+              description: taskDef.description,
+              priority: taskDef.priority,
+              blocked_by: blockedBy,
+            });
+            createdIds.push(t.id);
+            logger.success(`Created task: ${t.name} (${t.id})`);
+          }
+        }
+
+        await markScheduleRun(conn, s.id);
+        logger.info(`Marked schedule "${s.name}" as run.`);
+      }),
+    );
 }
 
 function enabledColor(enabled: boolean): string {

--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -1,8 +1,5 @@
 import ansis from "ansis";
 import type { Command } from "commander";
-import { getDbPath } from "../constants.ts";
-import { getConnection } from "../db/connection.ts";
-import { migrate } from "../db/schema.ts";
 import type { Task } from "../db/tasks.ts";
 import {
   createTask,
@@ -13,6 +10,7 @@ import {
   updateTask,
 } from "../db/tasks.ts";
 import { logger } from "../utils/logger.ts";
+import { withDb } from "./with-db.ts";
 
 export function registerTaskCommand(program: Command) {
   const task = program.command("task").description("Manage tasks");
@@ -23,66 +21,54 @@ export function registerTaskCommand(program: Command) {
     .option("-s, --status <status>", "filter by status")
     .option("-p, --priority <priority>", "filter by priority")
     .option("-l, --limit <n>", "max number of tasks", parseInt)
-    .action(async (opts) => {
-      const dir = program.opts().dir;
-      const conn = getConnection(getDbPath(dir));
-      migrate(conn);
+    .action((opts) =>
+      withDb(program, async (conn) => {
+        const tasks = await listTasks(conn, {
+          status: opts.status,
+          priority: opts.priority,
+          limit: opts.limit,
+        });
 
-      const tasks = await listTasks(conn, {
-        status: opts.status,
-        priority: opts.priority,
-        limit: opts.limit,
-      });
+        if (tasks.length === 0) {
+          logger.dim("No tasks found.");
+          return;
+        }
 
-      if (tasks.length === 0) {
-        logger.dim("No tasks found.");
-        return;
-      }
-
-      for (const t of tasks) {
-        printTask(t);
-      }
-
-      conn.close();
-    });
+        for (const t of tasks) {
+          printTask(t);
+        }
+      }),
+    );
 
   task
     .command("add <name>")
     .description("Create a new task")
     .option("--description <text>", "task description", "")
     .option("-p, --priority <priority>", "low, medium, or high", "medium")
-    .action(async (name, opts) => {
-      const dir = program.opts().dir;
-      const conn = getConnection(getDbPath(dir));
-      migrate(conn);
-
-      const t = await createTask(conn, {
-        name,
-        description: opts.description,
-        priority: opts.priority,
-      });
-
-      logger.success(`Created task: ${t.name} (${t.id})`);
-      conn.close();
-    });
+    .action((name, opts) =>
+      withDb(program, async (conn) => {
+        const t = await createTask(conn, {
+          name,
+          description: opts.description,
+          priority: opts.priority,
+        });
+        logger.success(`Created task: ${t.name} (${t.id})`);
+      }),
+    );
 
   task
     .command("view <id>")
     .description("View task details")
-    .action(async (id) => {
-      const dir = program.opts().dir;
-      const conn = getConnection(getDbPath(dir));
-      migrate(conn);
-
-      const t = await getTask(conn, id);
-      if (!t) {
-        logger.error(`Task not found: ${id}`);
-        process.exit(1);
-      }
-
-      printTaskDetail(t);
-      conn.close();
-    });
+    .action((id) =>
+      withDb(program, async (conn) => {
+        const t = await getTask(conn, id);
+        if (!t) {
+          logger.error(`Task not found: ${id}`);
+          process.exit(1);
+        }
+        printTaskDetail(t);
+      }),
+    );
 
   task
     .command("update <id>")
@@ -91,67 +77,55 @@ export function registerTaskCommand(program: Command) {
     .option("--description <text>", "new description")
     .option("-p, --priority <priority>", "low, medium, or high")
     .option("-s, --status <status>", "new status")
-    .action(async (id, opts) => {
-      const dir = program.opts().dir;
-      const conn = getConnection(getDbPath(dir));
-      migrate(conn);
+    .action((id, opts) =>
+      withDb(program, async (conn) => {
+        const updates: Parameters<typeof updateTask>[2] = {};
+        if (opts.name) updates.name = opts.name;
+        if (opts.description) updates.description = opts.description;
+        if (opts.priority) updates.priority = opts.priority;
+        if (opts.status) updates.status = opts.status;
 
-      const updates: Parameters<typeof updateTask>[2] = {};
-      if (opts.name) updates.name = opts.name;
-      if (opts.description) updates.description = opts.description;
-      if (opts.priority) updates.priority = opts.priority;
-      if (opts.status) updates.status = opts.status;
-
-      try {
-        const t = await updateTask(conn, id, updates);
-        if (!t) {
-          logger.error(`Task not found: ${id}`);
+        try {
+          const t = await updateTask(conn, id, updates);
+          if (!t) {
+            logger.error(`Task not found: ${id}`);
+            process.exit(1);
+          }
+          printTaskDetail(t);
+        } catch (err) {
+          logger.error(String(err));
           process.exit(1);
         }
-        printTaskDetail(t);
-      } catch (err) {
-        logger.error(String(err));
-        process.exit(1);
-      }
-
-      conn.close();
-    });
+      }),
+    );
 
   task
     .command("delete <id>")
     .description("Delete a task")
-    .action(async (id) => {
-      const dir = program.opts().dir;
-      const conn = getConnection(getDbPath(dir));
-      migrate(conn);
-
-      const deleted = await deleteTask(conn, id);
-      if (!deleted) {
-        logger.error(`Task not found: ${id}`);
-        process.exit(1);
-      }
-
-      logger.success(`Deleted task: ${id}`);
-      conn.close();
-    });
+    .action((id) =>
+      withDb(program, async (conn) => {
+        const deleted = await deleteTask(conn, id);
+        if (!deleted) {
+          logger.error(`Task not found: ${id}`);
+          process.exit(1);
+        }
+        logger.success(`Deleted task: ${id}`);
+      }),
+    );
 
   task
     .command("reset <id>")
     .description("Reset a stuck task back to pending")
-    .action(async (id) => {
-      const dir = program.opts().dir;
-      const conn = getConnection(getDbPath(dir));
-      migrate(conn);
-
-      const t = await resetTask(conn, id);
-      if (!t) {
-        logger.error(`Task not found: ${id}`);
-        process.exit(1);
-      }
-
-      logger.success(`Reset task: ${t.name} (${t.id})`);
-      conn.close();
-    });
+    .action((id) =>
+      withDb(program, async (conn) => {
+        const t = await resetTask(conn, id);
+        if (!t) {
+          logger.error(`Task not found: ${id}`);
+          process.exit(1);
+        }
+        logger.success(`Reset task: ${t.name} (${t.id})`);
+      }),
+    );
 }
 
 function statusColor(status: Task["status"]): string {

--- a/src/commands/tools.ts
+++ b/src/commands/tools.ts
@@ -2,9 +2,6 @@ import type { Command } from "commander";
 import { z } from "zod";
 import type { BotholomewConfig } from "../config/schemas.ts";
 import { DEFAULT_CONFIG } from "../config/schemas.ts";
-import { getDbPath } from "../constants.ts";
-import { getConnection } from "../db/connection.ts";
-import { migrate } from "../db/schema.ts";
 import { registerAllTools } from "../tools/registry.ts";
 import {
   type AnyToolDefinition,
@@ -12,6 +9,7 @@ import {
   type ToolContext,
 } from "../tools/tool.ts";
 import { logger } from "../utils/logger.ts";
+import { withDb } from "./with-db.ts";
 
 registerAllTools();
 
@@ -94,29 +92,25 @@ function registerToolAsCLI(
     }
   }
 
-  cmd.action(async (...args: unknown[]) => {
-    const dir = program.opts().dir;
-    const conn = getConnection(getDbPath(dir));
-    migrate(conn);
+  cmd.action((...args: unknown[]) =>
+    withDb(program, async (conn, dir) => {
+      try {
+        const input = buildInput(tool, positionals, options, shape, args);
 
-    try {
-      const input = buildInput(tool, positionals, options, shape, args);
+        const ctx: ToolContext = {
+          conn,
+          projectDir: dir,
+          config: DEFAULT_CONFIG as Required<BotholomewConfig>,
+        };
 
-      const ctx: ToolContext = {
-        conn,
-        projectDir: dir,
-        config: DEFAULT_CONFIG as Required<BotholomewConfig>,
-      };
-
-      const result = await tool.execute(input, ctx);
-      formatOutput(result, tool.name);
-    } catch (err) {
-      logger.error(String(err));
-      process.exit(1);
-    } finally {
-      conn.close();
-    }
-  });
+        const result = await tool.execute(input, ctx);
+        formatOutput(result, tool.name);
+      } catch (err) {
+        logger.error(String(err));
+        process.exit(1);
+      }
+    }),
+  );
 }
 
 function buildInput(

--- a/src/commands/with-db.ts
+++ b/src/commands/with-db.ts
@@ -1,0 +1,23 @@
+import type { Command } from "commander";
+import { getDbPath } from "../constants.ts";
+import type { DbConnection } from "../db/connection.ts";
+import { getConnection } from "../db/connection.ts";
+import { migrate } from "../db/schema.ts";
+
+/**
+ * Open a migrated DB connection from the CLI --dir flag, run the callback,
+ * and guarantee the connection is closed afterward.
+ */
+export async function withDb<T>(
+  program: Command,
+  fn: (conn: DbConnection, dir: string) => Promise<T>,
+): Promise<T> {
+  const dir = program.opts().dir;
+  const conn = getConnection(getDbPath(dir));
+  migrate(conn);
+  try {
+    return await fn(conn, dir);
+  } finally {
+    conn.close();
+  }
+}

--- a/src/db/context.ts
+++ b/src/db/context.ts
@@ -1,4 +1,5 @@
 import type { DbConnection } from "./connection.ts";
+import { buildSetClauses, buildWhereClause } from "./query.ts";
 import { uuidv7 } from "./uuid.ts";
 
 export interface ContextItem {
@@ -115,20 +116,10 @@ export async function listContextItems(
     limit?: number;
   },
 ): Promise<ContextItem[]> {
-  const conditions: string[] = [];
-  const params: (string | null)[] = [];
-
-  if (filters?.contextPath) {
-    params.push(filters.contextPath);
-    conditions.push(`context_path = ?${params.length}`);
-  }
-  if (filters?.mimeType) {
-    params.push(filters.mimeType);
-    conditions.push(`mime_type = ?${params.length}`);
-  }
-
-  const where =
-    conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+  const { where, params } = buildWhereClause([
+    ["context_path", filters?.contextPath],
+    ["mime_type", filters?.mimeType],
+  ]);
   const limit = filters?.limit ? `LIMIT ${filters.limit}` : "";
 
   const rows = db
@@ -224,27 +215,16 @@ export async function updateContextItem(
     Pick<ContextItem, "title" | "description" | "content" | "mime_type">
   >,
 ): Promise<ContextItem | null> {
-  const setClauses: string[] = ["updated_at = datetime('now')"];
-  const params: (string | null)[] = [];
+  const { setClauses, params } = buildSetClauses([
+    ["title", updates.title],
+    ["description", updates.description],
+    ["content", updates.content],
+    ["mime_type", updates.mime_type],
+  ]);
 
-  if (updates.title !== undefined) {
-    params.push(updates.title);
-    setClauses.push(`title = ?${params.length}`);
-  }
-  if (updates.description !== undefined) {
-    params.push(updates.description);
-    setClauses.push(`description = ?${params.length}`);
-  }
-  if (updates.content !== undefined) {
-    params.push(updates.content);
-    setClauses.push(`content = ?${params.length}`);
-  }
-  if (updates.mime_type !== undefined) {
-    params.push(updates.mime_type);
-    setClauses.push(`mime_type = ?${params.length}`);
-  }
-
+  setClauses.push("updated_at = datetime('now')");
   params.push(id);
+
   const row = db
     .query(
       `UPDATE context_items

--- a/src/db/query.ts
+++ b/src/db/query.ts
@@ -1,0 +1,45 @@
+type SqlParam = string | number | null;
+
+/**
+ * Build a WHERE clause from column-value pairs.
+ * Entries with `undefined` values are skipped.
+ */
+export function buildWhereClause(filters: [string, SqlParam | undefined][]): {
+  where: string;
+  params: SqlParam[];
+} {
+  const conditions: string[] = [];
+  const params: SqlParam[] = [];
+
+  for (const [col, val] of filters) {
+    if (val !== undefined) {
+      params.push(val);
+      conditions.push(`${col} = ?${params.length}`);
+    }
+  }
+
+  const where =
+    conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+  return { where, params };
+}
+
+/**
+ * Build SET clauses for an UPDATE from column-value pairs.
+ * Entries with `undefined` values are skipped.
+ */
+export function buildSetClauses(fields: [string, SqlParam | undefined][]): {
+  setClauses: string[];
+  params: SqlParam[];
+} {
+  const setClauses: string[] = [];
+  const params: SqlParam[] = [];
+
+  for (const [col, val] of fields) {
+    if (val !== undefined) {
+      params.push(val);
+      setClauses.push(`${col} = ?${params.length}`);
+    }
+  }
+
+  return { setClauses, params };
+}

--- a/src/db/schedules.ts
+++ b/src/db/schedules.ts
@@ -1,4 +1,5 @@
 import type { DbConnection } from "./connection.ts";
+import { buildSetClauses, buildWhereClause } from "./query.ts";
 import { uuidv7 } from "./uuid.ts";
 
 export interface Schedule {
@@ -75,16 +76,12 @@ export async function listSchedules(
   db: DbConnection,
   filters?: { enabled?: boolean },
 ): Promise<Schedule[]> {
-  const conditions: string[] = [];
-  const params: (string | number)[] = [];
-
-  if (filters?.enabled !== undefined) {
-    params.push(filters.enabled ? 1 : 0);
-    conditions.push(`enabled = ?${params.length}`);
-  }
-
-  const where =
-    conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+  const { where, params } = buildWhereClause([
+    [
+      "enabled",
+      filters?.enabled !== undefined ? (filters.enabled ? 1 : 0) : undefined,
+    ],
+  ]);
 
   const rows = db
     .query(`SELECT * FROM schedules ${where} ORDER BY created_at ASC`)
@@ -99,25 +96,15 @@ export async function updateSchedule(
     Pick<Schedule, "name" | "description" | "frequency" | "enabled">
   >,
 ): Promise<Schedule | null> {
-  const setClauses: string[] = [];
-  const params: (string | number)[] = [];
-
-  if (updates.name !== undefined) {
-    params.push(updates.name);
-    setClauses.push(`name = ?${params.length}`);
-  }
-  if (updates.description !== undefined) {
-    params.push(updates.description);
-    setClauses.push(`description = ?${params.length}`);
-  }
-  if (updates.frequency !== undefined) {
-    params.push(updates.frequency);
-    setClauses.push(`frequency = ?${params.length}`);
-  }
-  if (updates.enabled !== undefined) {
-    params.push(updates.enabled ? 1 : 0);
-    setClauses.push(`enabled = ?${params.length}`);
-  }
+  const { setClauses, params } = buildSetClauses([
+    ["name", updates.name],
+    ["description", updates.description],
+    ["frequency", updates.frequency],
+    [
+      "enabled",
+      updates.enabled !== undefined ? (updates.enabled ? 1 : 0) : undefined,
+    ],
+  ]);
 
   if (setClauses.length === 0) {
     return getSchedule(db, id);

--- a/src/db/tasks.ts
+++ b/src/db/tasks.ts
@@ -1,4 +1,5 @@
 import type { DbConnection } from "./connection.ts";
+import { buildSetClauses, buildWhereClause } from "./query.ts";
 import { uuidv7 } from "./uuid.ts";
 
 export const TASK_PRIORITIES = ["low", "medium", "high"] as const;
@@ -109,20 +110,10 @@ export async function listTasks(
     limit?: number;
   },
 ): Promise<Task[]> {
-  const conditions: string[] = [];
-  const params: string[] = [];
-
-  if (filters?.status) {
-    params.push(filters.status);
-    conditions.push(`status = ?${params.length}`);
-  }
-  if (filters?.priority) {
-    params.push(filters.priority);
-    conditions.push(`priority = ?${params.length}`);
-  }
-
-  const where =
-    conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+  const { where, params } = buildWhereClause([
+    ["status", filters?.status],
+    ["priority", filters?.priority],
+  ]);
   const limit = filters?.limit ? `LIMIT ${filters.limit}` : "";
 
   const rows = db
@@ -198,29 +189,18 @@ export async function updateTask(
     await validateBlockedBy(db, id, updates.blocked_by);
   }
 
-  const setClauses: string[] = [];
-  const params: (string | number | null)[] = [];
-
-  if (updates.name !== undefined) {
-    params.push(updates.name);
-    setClauses.push(`name = ?${params.length}`);
-  }
-  if (updates.description !== undefined) {
-    params.push(updates.description);
-    setClauses.push(`description = ?${params.length}`);
-  }
-  if (updates.priority !== undefined) {
-    params.push(updates.priority);
-    setClauses.push(`priority = ?${params.length}`);
-  }
-  if (updates.status !== undefined) {
-    params.push(updates.status);
-    setClauses.push(`status = ?${params.length}`);
-  }
-  if (updates.blocked_by !== undefined) {
-    params.push(JSON.stringify(updates.blocked_by));
-    setClauses.push(`blocked_by = ?${params.length}`);
-  }
+  const { setClauses, params } = buildSetClauses([
+    ["name", updates.name],
+    ["description", updates.description],
+    ["priority", updates.priority],
+    ["status", updates.status],
+    [
+      "blocked_by",
+      updates.blocked_by !== undefined
+        ? JSON.stringify(updates.blocked_by)
+        : undefined,
+    ],
+  ]);
 
   if (setClauses.length === 0) {
     return getTask(db, id);

--- a/src/db/threads.ts
+++ b/src/db/threads.ts
@@ -1,4 +1,5 @@
 import type { DbConnection } from "./connection.ts";
+import { buildWhereClause } from "./query.ts";
 import { uuidv7 } from "./uuid.ts";
 
 export interface Thread {
@@ -175,20 +176,10 @@ export async function listThreads(
     limit?: number;
   },
 ): Promise<Thread[]> {
-  const conditions: string[] = [];
-  const params: string[] = [];
-
-  if (filters?.type) {
-    params.push(filters.type);
-    conditions.push(`type = ?${params.length}`);
-  }
-  if (filters?.taskId) {
-    params.push(filters.taskId);
-    conditions.push(`task_id = ?${params.length}`);
-  }
-
-  const where =
-    conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+  const { where, params } = buildWhereClause([
+    ["type", filters?.type],
+    ["task_id", filters?.taskId],
+  ]);
   const limit = filters?.limit ? `LIMIT ${filters.limit}` : "";
 
   const rows = db

--- a/test/context/ingest.test.ts
+++ b/test/context/ingest.test.ts
@@ -2,10 +2,10 @@ import { beforeEach, describe, expect, test } from "bun:test";
 import { DEFAULT_CONFIG } from "../../src/config/schemas.ts";
 import { EMBEDDING_DIMENSION } from "../../src/constants.ts";
 import { ingestByPath, ingestContextItem } from "../../src/context/ingest.ts";
-import { type DbConnection, getConnection } from "../../src/db/connection.ts";
+import type { DbConnection } from "../../src/db/connection.ts";
 import { createContextItem, getContextItem } from "../../src/db/context.ts";
 import { initVectorSearch, searchEmbeddings } from "../../src/db/embeddings.ts";
-import { migrate } from "../../src/db/schema.ts";
+import { setupTestDb } from "../helpers.ts";
 
 const config = { ...DEFAULT_CONFIG };
 
@@ -30,8 +30,7 @@ function mockEmbed(texts: string[]): Promise<number[][]> {
 let conn: DbConnection;
 
 beforeEach(() => {
-  conn = getConnection(":memory:");
-  migrate(conn);
+  conn = setupTestDb();
 });
 
 describe("ingestContextItem", () => {

--- a/test/daemon/schedules.test.ts
+++ b/test/daemon/schedules.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
-import { type DbConnection, getConnection } from "../../src/db/connection.ts";
+import type { DbConnection } from "../../src/db/connection.ts";
 import { createSchedule, getSchedule } from "../../src/db/schedules.ts";
-import { migrate } from "../../src/db/schema.ts";
 import { listTasks } from "../../src/db/tasks.ts";
+import { setupTestDb } from "../helpers.ts";
 
 let mockResponse: Record<string, unknown> = {};
 
@@ -37,8 +37,7 @@ const testConfig = {
 };
 
 beforeEach(() => {
-  conn = getConnection(":memory:");
-  migrate(conn);
+  conn = setupTestDb();
   mockResponse = {};
 });
 

--- a/test/daemon/tick.test.ts
+++ b/test/daemon/tick.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
-import { type DbConnection, getConnection } from "../../src/db/connection.ts";
-import { migrate } from "../../src/db/schema.ts";
+import type { DbConnection } from "../../src/db/connection.ts";
 import { createTask, getTask } from "../../src/db/tasks.ts";
 import { getThread, listThreads } from "../../src/db/threads.ts";
+import { setupTestDb } from "../helpers.ts";
 
 // Mock the Anthropic SDK before importing tick
 mock.module("@anthropic-ai/sdk", () => {
@@ -33,8 +33,7 @@ const { tick } = await import("../../src/daemon/tick.ts");
 let conn: DbConnection;
 
 beforeEach(() => {
-  conn = getConnection(":memory:");
-  migrate(conn);
+  conn = setupTestDb();
 });
 
 describe("daemon tick", () => {

--- a/test/db/context.test.ts
+++ b/test/db/context.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test } from "bun:test";
-import { type DbConnection, getConnection } from "../../src/db/connection.ts";
+import type { DbConnection } from "../../src/db/connection.ts";
 import {
   applyPatchesToContextItem,
   contextPathExists,
@@ -18,13 +18,12 @@ import {
   updateContextItem,
   updateContextItemContent,
 } from "../../src/db/context.ts";
-import { migrate } from "../../src/db/schema.ts";
+import { setupTestDb } from "../helpers.ts";
 
 let conn: DbConnection;
 
 beforeEach(() => {
-  conn = getConnection(":memory:");
-  migrate(conn);
+  conn = setupTestDb();
 });
 
 describe("context CRUD", () => {

--- a/test/db/embeddings.test.ts
+++ b/test/db/embeddings.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test } from "bun:test";
-import { type DbConnection, getConnection } from "../../src/db/connection.ts";
+import type { DbConnection } from "../../src/db/connection.ts";
 import { createContextItem } from "../../src/db/context.ts";
 import {
   createEmbedding,
@@ -8,13 +8,12 @@ import {
   initVectorSearch,
   searchEmbeddings,
 } from "../../src/db/embeddings.ts";
-import { migrate } from "../../src/db/schema.ts";
+import { setupTestDb } from "../helpers.ts";
 
 let conn: DbConnection;
 
 beforeEach(() => {
-  conn = getConnection(":memory:");
-  migrate(conn);
+  conn = setupTestDb();
   initVectorSearch(conn, 3); // 3-dim vectors for tests
 });
 

--- a/test/db/schedules.test.ts
+++ b/test/db/schedules.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test } from "bun:test";
-import { type DbConnection, getConnection } from "../../src/db/connection.ts";
+import type { DbConnection } from "../../src/db/connection.ts";
 import {
   createSchedule,
   deleteSchedule,
@@ -8,13 +8,12 @@ import {
   markScheduleRun,
   updateSchedule,
 } from "../../src/db/schedules.ts";
-import { migrate } from "../../src/db/schema.ts";
+import { setupTestDb } from "../helpers.ts";
 
 let conn: DbConnection;
 
 beforeEach(() => {
-  conn = getConnection(":memory:");
-  migrate(conn);
+  conn = setupTestDb();
 });
 
 describe("schedule CRUD", () => {

--- a/test/db/tasks-validation.test.ts
+++ b/test/db/tasks-validation.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, test } from "bun:test";
-import { type DbConnection, getConnection } from "../../src/db/connection.ts";
-import { migrate } from "../../src/db/schema.ts";
+import type { DbConnection } from "../../src/db/connection.ts";
 import {
   createTask,
   deleteTask,
@@ -10,12 +9,12 @@ import {
   updateTask,
   updateTaskStatus,
 } from "../../src/db/tasks.ts";
+import { setupTestDb } from "../helpers.ts";
 
 let conn: DbConnection;
 
 beforeEach(() => {
-  conn = getConnection(":memory:");
-  migrate(conn);
+  conn = setupTestDb();
 });
 
 describe("cycle detection", () => {

--- a/test/db/tasks.test.ts
+++ b/test/db/tasks.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, test } from "bun:test";
-import { type DbConnection, getConnection } from "../../src/db/connection.ts";
-import { migrate } from "../../src/db/schema.ts";
+import type { DbConnection } from "../../src/db/connection.ts";
 import {
   claimNextTask,
   createTask,
@@ -8,12 +7,12 @@ import {
   listTasks,
   updateTaskStatus,
 } from "../../src/db/tasks.ts";
+import { setupTestDb } from "../helpers.ts";
 
 let conn: DbConnection;
 
 beforeEach(() => {
-  conn = getConnection(":memory:");
-  migrate(conn);
+  conn = setupTestDb();
 });
 
 describe("task CRUD", () => {

--- a/test/db/threads.test.ts
+++ b/test/db/threads.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, test } from "bun:test";
-import { type DbConnection, getConnection } from "../../src/db/connection.ts";
-import { migrate } from "../../src/db/schema.ts";
+import type { DbConnection } from "../../src/db/connection.ts";
 import {
   createThread,
   endThread,
@@ -8,12 +7,12 @@ import {
   listThreads,
   logInteraction,
 } from "../../src/db/threads.ts";
+import { setupTestDb } from "../helpers.ts";
 
 let conn: DbConnection;
 
 beforeEach(() => {
-  conn = getConnection(":memory:");
-  migrate(conn);
+  conn = setupTestDb();
 });
 
 describe("thread CRUD", () => {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,0 +1,61 @@
+import { DEFAULT_CONFIG } from "../src/config/schemas.ts";
+import { type DbConnection, getConnection } from "../src/db/connection.ts";
+import { createContextItem } from "../src/db/context.ts";
+import { migrate } from "../src/db/schema.ts";
+import type { ToolContext } from "../src/tools/tool.ts";
+
+/** Create a fresh in-memory database with migrations applied. */
+export function setupTestDb(): DbConnection {
+  const conn = getConnection(":memory:");
+  migrate(conn);
+  return conn;
+}
+
+/** Create a ToolContext backed by a fresh in-memory database. */
+export function setupToolContext(): { conn: DbConnection; ctx: ToolContext } {
+  const conn = setupTestDb();
+  const ctx: ToolContext = {
+    conn,
+    projectDir: "/tmp/test",
+    config: { ...DEFAULT_CONFIG },
+  };
+  return { conn, ctx };
+}
+
+/** Seed a text file into the virtual filesystem. */
+export async function seedFile(
+  conn: DbConnection,
+  path: string,
+  content: string,
+  opts?: { title?: string; description?: string },
+) {
+  return createContextItem(conn, {
+    title: opts?.title ?? path.split("/").pop() ?? path,
+    description: opts?.description,
+    content,
+    contextPath: path,
+    mimeType: "text/plain",
+    isTextual: true,
+  });
+}
+
+/** Seed a binary (non-textual) file into the virtual filesystem. */
+export async function seedBinaryFile(conn: DbConnection, path: string) {
+  return createContextItem(conn, {
+    title: path.split("/").pop() ?? path,
+    content: undefined,
+    contextPath: path,
+    mimeType: "application/octet-stream",
+    isTextual: false,
+  });
+}
+
+/** Seed a directory entry into the virtual filesystem. */
+export async function seedDir(conn: DbConnection, path: string) {
+  return createContextItem(conn, {
+    title: path.split("/").pop() ?? path,
+    contextPath: path,
+    mimeType: "inode/directory",
+    isTextual: false,
+  });
+}

--- a/test/tools/dir.test.ts
+++ b/test/tools/dir.test.ts
@@ -1,41 +1,18 @@
 import { beforeEach, describe, expect, test } from "bun:test";
-import { DEFAULT_CONFIG } from "../../src/config/schemas.ts";
-import { type DbConnection, getConnection } from "../../src/db/connection.ts";
-import { createContextItem } from "../../src/db/context.ts";
-import { migrate } from "../../src/db/schema.ts";
+import type { DbConnection } from "../../src/db/connection.ts";
 import { dirCreateTool } from "../../src/tools/dir/create.ts";
 import { dirListTool } from "../../src/tools/dir/list.ts";
 import { dirSizeTool } from "../../src/tools/dir/size.ts";
 import { dirTreeTool } from "../../src/tools/dir/tree.ts";
 import type { ToolContext } from "../../src/tools/tool.ts";
+import { seedDir, seedFile, setupToolContext } from "../helpers.ts";
 
 let conn: DbConnection;
 let ctx: ToolContext;
 
 beforeEach(() => {
-  conn = getConnection(":memory:");
-  migrate(conn);
-  ctx = { conn, projectDir: "/tmp/test", config: { ...DEFAULT_CONFIG } };
+  ({ conn, ctx } = setupToolContext());
 });
-
-async function seedFile(path: string, content: string) {
-  return createContextItem(conn, {
-    title: path.split("/").pop() ?? path,
-    content,
-    contextPath: path,
-    mimeType: "text/plain",
-    isTextual: true,
-  });
-}
-
-async function seedDir(path: string) {
-  return createContextItem(conn, {
-    title: path.split("/").pop() ?? path,
-    contextPath: path,
-    mimeType: "inode/directory",
-    isTextual: false,
-  });
-}
 
 // ── dir_create ──────────────────────────────────────────────
 
@@ -47,7 +24,7 @@ describe("dir_create", () => {
   });
 
   test("returns created=false if directory already exists", async () => {
-    await seedDir("/existing");
+    await seedDir(conn, "/existing");
     const result = await dirCreateTool.execute({ path: "/existing" }, ctx);
     expect(result.created).toBe(false);
     expect(result.path).toBe("/existing");
@@ -58,8 +35,8 @@ describe("dir_create", () => {
 
 describe("dir_list", () => {
   test("lists files at root", async () => {
-    await seedFile("/a.txt", "aaa");
-    await seedFile("/b.txt", "bbb");
+    await seedFile(conn, "/a.txt", "aaa");
+    await seedFile(conn, "/b.txt", "bbb");
     const result = await dirListTool.execute(
       { path: "/", recursive: true, limit: 100, offset: 0 },
       ctx,
@@ -71,9 +48,9 @@ describe("dir_list", () => {
   });
 
   test("lists with pagination", async () => {
-    await seedFile("/p1.txt", "1");
-    await seedFile("/p2.txt", "2");
-    await seedFile("/p3.txt", "3");
+    await seedFile(conn, "/p1.txt", "1");
+    await seedFile(conn, "/p2.txt", "2");
+    await seedFile(conn, "/p3.txt", "3");
 
     const page1 = await dirListTool.execute(
       { path: "/", recursive: true, limit: 2, offset: 0 },
@@ -99,8 +76,8 @@ describe("dir_list", () => {
   });
 
   test("non-recursive lists only immediate children", async () => {
-    await seedFile("/top/child.txt", "child");
-    await seedFile("/top/sub/deep.txt", "deep");
+    await seedFile(conn, "/top/child.txt", "child");
+    await seedFile(conn, "/top/sub/deep.txt", "deep");
     const result = await dirListTool.execute(
       { path: "/top", recursive: false, limit: 100, offset: 0 },
       ctx,
@@ -110,7 +87,7 @@ describe("dir_list", () => {
   });
 
   test("entries include type and size", async () => {
-    await seedFile("/typed.txt", "content");
+    await seedFile(conn, "/typed.txt", "content");
     const result = await dirListTool.execute(
       { path: "/", recursive: true, limit: 100, offset: 0 },
       ctx,
@@ -126,8 +103,8 @@ describe("dir_list", () => {
 
 describe("dir_size", () => {
   test("returns total size of files", async () => {
-    await seedFile("/size/a.txt", "hello"); // 5 bytes
-    await seedFile("/size/b.txt", "world!"); // 6 bytes
+    await seedFile(conn, "/size/a.txt", "hello"); // 5 bytes
+    await seedFile(conn, "/size/b.txt", "world!"); // 6 bytes
     const result = await dirSizeTool.execute({ path: "/size" }, ctx);
     expect(result.bytes).toBe(11);
     expect(result.formatted).toBeTruthy();
@@ -140,8 +117,8 @@ describe("dir_size", () => {
   });
 
   test("includes subdirectories by default", async () => {
-    await seedFile("/deep/a.txt", "aaa");
-    await seedFile("/deep/sub/b.txt", "bbb");
+    await seedFile(conn, "/deep/a.txt", "aaa");
+    await seedFile(conn, "/deep/sub/b.txt", "bbb");
     const result = await dirSizeTool.execute({ path: "/deep" }, ctx);
     expect(result.bytes).toBe(6);
   });
@@ -151,8 +128,8 @@ describe("dir_size", () => {
 
 describe("dir_tree", () => {
   test("renders a tree with files", async () => {
-    await seedFile("/tree/a.txt", "a");
-    await seedFile("/tree/sub/b.txt", "b");
+    await seedFile(conn, "/tree/a.txt", "a");
+    await seedFile(conn, "/tree/sub/b.txt", "b");
     const result = await dirTreeTool.execute(
       { path: "/tree", max_items: 200 },
       ctx,
@@ -173,7 +150,7 @@ describe("dir_tree", () => {
   test("respects max_items", async () => {
     // Seed more items than max_items
     for (let i = 0; i < 5; i++) {
-      await seedFile(`/many/file${i}.txt`, `content ${i}`);
+      await seedFile(conn, `/many/file${i}.txt`, `content ${i}`);
     }
     const result = await dirTreeTool.execute(
       { path: "/many", max_items: 3 },

--- a/test/tools/file.test.ts
+++ b/test/tools/file.test.ts
@@ -1,8 +1,5 @@
 import { beforeEach, describe, expect, test } from "bun:test";
-import { DEFAULT_CONFIG } from "../../src/config/schemas.ts";
-import { type DbConnection, getConnection } from "../../src/db/connection.ts";
-import { createContextItem } from "../../src/db/context.ts";
-import { migrate } from "../../src/db/schema.ts";
+import type { DbConnection } from "../../src/db/connection.ts";
 import { fileCopyTool } from "../../src/tools/file/copy.ts";
 import { fileCountLinesTool } from "../../src/tools/file/count-lines.ts";
 import { fileDeleteTool } from "../../src/tools/file/delete.ts";
@@ -13,40 +10,14 @@ import { fileMoveTool } from "../../src/tools/file/move.ts";
 import { fileReadTool } from "../../src/tools/file/read.ts";
 import { fileWriteTool } from "../../src/tools/file/write.ts";
 import type { ToolContext } from "../../src/tools/tool.ts";
+import { seedBinaryFile, seedFile, setupToolContext } from "../helpers.ts";
 
 let conn: DbConnection;
 let ctx: ToolContext;
 
 beforeEach(() => {
-  conn = getConnection(":memory:");
-  migrate(conn);
-  ctx = { conn, projectDir: "/tmp/test", config: { ...DEFAULT_CONFIG } };
+  ({ conn, ctx } = setupToolContext());
 });
-
-async function seedFile(
-  path: string,
-  content: string,
-  opts?: { title?: string; description?: string },
-) {
-  return createContextItem(conn, {
-    title: opts?.title ?? path.split("/").pop() ?? path,
-    description: opts?.description,
-    content,
-    contextPath: path,
-    mimeType: "text/plain",
-    isTextual: true,
-  });
-}
-
-async function seedBinaryFile(path: string) {
-  return createContextItem(conn, {
-    title: path.split("/").pop() ?? path,
-    content: undefined,
-    contextPath: path,
-    mimeType: "application/octet-stream",
-    isTextual: false,
-  });
-}
 
 // ── file_write ──────────────────────────────────────────────
 
@@ -64,7 +35,7 @@ describe("file_write", () => {
   });
 
   test("overwrites existing file", async () => {
-    await seedFile("/overwrite.txt", "original");
+    await seedFile(conn, "/overwrite.txt", "original");
     const result = await fileWriteTool.execute(
       { path: "/overwrite.txt", content: "updated" },
       ctx,
@@ -104,13 +75,13 @@ describe("file_write", () => {
 
 describe("file_read", () => {
   test("reads existing file", async () => {
-    await seedFile("/readme.md", "line1\nline2\nline3");
+    await seedFile(conn, "/readme.md", "line1\nline2\nline3");
     const result = await fileReadTool.execute({ path: "/readme.md" }, ctx);
     expect(result.content).toBe("line1\nline2\nline3");
   });
 
   test("reads with offset and limit", async () => {
-    await seedFile("/lines.txt", "a\nb\nc\nd\ne");
+    await seedFile(conn, "/lines.txt", "a\nb\nc\nd\ne");
     const result = await fileReadTool.execute(
       { path: "/lines.txt", offset: 2, limit: 2 },
       ctx,
@@ -125,7 +96,7 @@ describe("file_read", () => {
   });
 
   test("throws for file with no text content", async () => {
-    await seedBinaryFile("/image.png");
+    await seedBinaryFile(conn, "/image.png");
     expect(fileReadTool.execute({ path: "/image.png" }, ctx)).rejects.toThrow(
       "No text content",
     );
@@ -136,7 +107,7 @@ describe("file_read", () => {
 
 describe("file_edit", () => {
   test("replaces lines with a patch", async () => {
-    await seedFile("/edit.txt", "line1\nline2\nline3");
+    await seedFile(conn, "/edit.txt", "line1\nline2\nline3");
     const result = await fileEditTool.execute(
       {
         path: "/edit.txt",
@@ -150,7 +121,7 @@ describe("file_edit", () => {
   });
 
   test("inserts lines when end_line is 0", async () => {
-    await seedFile("/insert.txt", "line1\nline2");
+    await seedFile(conn, "/insert.txt", "line1\nline2");
     const result = await fileEditTool.execute(
       {
         path: "/insert.txt",
@@ -165,7 +136,7 @@ describe("file_edit", () => {
   });
 
   test("deletes lines with empty content", async () => {
-    await seedFile("/delete.txt", "line1\nline2\nline3");
+    await seedFile(conn, "/delete.txt", "line1\nline2\nline3");
     const result = await fileEditTool.execute(
       {
         path: "/delete.txt",
@@ -194,7 +165,7 @@ describe("file_edit", () => {
 
 describe("file_delete", () => {
   test("deletes an existing file", async () => {
-    await seedFile("/remove.txt", "bye");
+    await seedFile(conn, "/remove.txt", "bye");
     const result = await fileDeleteTool.execute({ path: "/remove.txt" }, ctx);
     expect(result.deleted).toBe(1);
 
@@ -217,8 +188,8 @@ describe("file_delete", () => {
   });
 
   test("recursive delete removes children", async () => {
-    await seedFile("/dir/a.txt", "a");
-    await seedFile("/dir/b.txt", "b");
+    await seedFile(conn, "/dir/a.txt", "a");
+    await seedFile(conn, "/dir/b.txt", "b");
     const result = await fileDeleteTool.execute(
       { path: "/dir", recursive: true },
       ctx,
@@ -231,7 +202,7 @@ describe("file_delete", () => {
 
 describe("file_copy", () => {
   test("copies a file", async () => {
-    await seedFile("/orig.txt", "content");
+    await seedFile(conn, "/orig.txt", "content");
     const result = await fileCopyTool.execute(
       { src: "/orig.txt", dst: "/copy.txt" },
       ctx,
@@ -243,16 +214,16 @@ describe("file_copy", () => {
   });
 
   test("throws when destination exists without overwrite", async () => {
-    await seedFile("/src.txt", "a");
-    await seedFile("/dst.txt", "b");
+    await seedFile(conn, "/src.txt", "a");
+    await seedFile(conn, "/dst.txt", "b");
     expect(
       fileCopyTool.execute({ src: "/src.txt", dst: "/dst.txt" }, ctx),
     ).rejects.toThrow("Destination already exists");
   });
 
   test("overwrites when overwrite is true", async () => {
-    await seedFile("/src.txt", "new");
-    await seedFile("/dst.txt", "old");
+    await seedFile(conn, "/src.txt", "new");
+    await seedFile(conn, "/dst.txt", "old");
     const result = await fileCopyTool.execute(
       { src: "/src.txt", dst: "/dst.txt", overwrite: true },
       ctx,
@@ -271,7 +242,7 @@ describe("file_copy", () => {
 
 describe("file_move", () => {
   test("moves a file", async () => {
-    await seedFile("/old.txt", "data");
+    await seedFile(conn, "/old.txt", "data");
     const result = await fileMoveTool.execute(
       { src: "/old.txt", dst: "/new.txt" },
       ctx,
@@ -286,16 +257,16 @@ describe("file_move", () => {
   });
 
   test("throws when destination exists without overwrite", async () => {
-    await seedFile("/a.txt", "a");
-    await seedFile("/b.txt", "b");
+    await seedFile(conn, "/a.txt", "a");
+    await seedFile(conn, "/b.txt", "b");
     expect(
       fileMoveTool.execute({ src: "/a.txt", dst: "/b.txt" }, ctx),
     ).rejects.toThrow("Destination already exists");
   });
 
   test("overwrites when overwrite is true", async () => {
-    await seedFile("/a.txt", "a");
-    await seedFile("/b.txt", "b");
+    await seedFile(conn, "/a.txt", "a");
+    await seedFile(conn, "/b.txt", "b");
     const result = await fileMoveTool.execute(
       { src: "/a.txt", dst: "/b.txt", overwrite: true },
       ctx,
@@ -314,7 +285,7 @@ describe("file_move", () => {
 
 describe("file_info", () => {
   test("returns metadata for existing file", async () => {
-    await seedFile("/meta.txt", "hello\nworld", {
+    await seedFile(conn, "/meta.txt", "hello\nworld", {
       title: "Meta",
       description: "A test file",
     });
@@ -341,7 +312,7 @@ describe("file_info", () => {
 
 describe("file_exists", () => {
   test("returns true for existing file", async () => {
-    await seedFile("/there.txt", "hi");
+    await seedFile(conn, "/there.txt", "hi");
     const result = await fileExistsTool.execute({ path: "/there.txt" }, ctx);
     expect(result.exists).toBe(true);
   });
@@ -356,7 +327,7 @@ describe("file_exists", () => {
 
 describe("file_count_lines", () => {
   test("counts lines in a file", async () => {
-    await seedFile("/lines.txt", "a\nb\nc");
+    await seedFile(conn, "/lines.txt", "a\nb\nc");
     const result = await fileCountLinesTool.execute(
       { path: "/lines.txt" },
       ctx,
@@ -365,7 +336,7 @@ describe("file_count_lines", () => {
   });
 
   test("single line file returns 1", async () => {
-    await seedFile("/single.txt", "only one line");
+    await seedFile(conn, "/single.txt", "only one line");
     const result = await fileCountLinesTool.execute(
       { path: "/single.txt" },
       ctx,
@@ -380,7 +351,7 @@ describe("file_count_lines", () => {
   });
 
   test("throws for non-textual file", async () => {
-    await seedBinaryFile("/bin.dat");
+    await seedBinaryFile(conn, "/bin.dat");
     expect(
       fileCountLinesTool.execute({ path: "/bin.dat" }, ctx),
     ).rejects.toThrow("No text content");

--- a/test/tools/schedule.test.ts
+++ b/test/tools/schedule.test.ts
@@ -1,18 +1,15 @@
 import { beforeEach, describe, expect, test } from "bun:test";
-import { DEFAULT_CONFIG } from "../../src/config/schemas.ts";
-import { type DbConnection, getConnection } from "../../src/db/connection.ts";
-import { migrate } from "../../src/db/schema.ts";
+import type { DbConnection } from "../../src/db/connection.ts";
 import { createScheduleTool } from "../../src/tools/schedule/create.ts";
 import { listSchedulesTool } from "../../src/tools/schedule/list.ts";
 import type { ToolContext } from "../../src/tools/tool.ts";
+import { setupToolContext } from "../helpers.ts";
 
 let conn: DbConnection;
 let ctx: ToolContext;
 
 beforeEach(() => {
-  conn = getConnection(":memory:");
-  migrate(conn);
-  ctx = { conn, projectDir: "/tmp/test", config: { ...DEFAULT_CONFIG } };
+  ({ conn, ctx } = setupToolContext());
 });
 
 describe("create_schedule", () => {

--- a/test/tools/search.test.ts
+++ b/test/tools/search.test.ts
@@ -1,38 +1,24 @@
 import { beforeEach, describe, expect, test } from "bun:test";
-import { DEFAULT_CONFIG } from "../../src/config/schemas.ts";
 import { EMBEDDING_DIMENSION } from "../../src/constants.ts";
 import { ingestContextItem } from "../../src/context/ingest.ts";
-import { type DbConnection, getConnection } from "../../src/db/connection.ts";
-import { createContextItem } from "../../src/db/context.ts";
-import { migrate } from "../../src/db/schema.ts";
+import type { DbConnection } from "../../src/db/connection.ts";
 import { searchGrepTool } from "../../src/tools/search/grep.ts";
 import { searchSemanticTool } from "../../src/tools/search/semantic.ts";
 import type { ToolContext } from "../../src/tools/tool.ts";
+import { seedFile, setupToolContext } from "../helpers.ts";
 
 let conn: DbConnection;
 let ctx: ToolContext;
 
 beforeEach(() => {
-  conn = getConnection(":memory:");
-  migrate(conn);
-  ctx = { conn, projectDir: "/tmp/test", config: { ...DEFAULT_CONFIG } };
+  ({ conn, ctx } = setupToolContext());
 });
-
-async function seedFile(path: string, content: string) {
-  return createContextItem(conn, {
-    title: path.split("/").pop() ?? path,
-    content,
-    contextPath: path,
-    mimeType: "text/plain",
-    isTextual: true,
-  });
-}
 
 // ── search_grep ─────────────────────────────────────────────
 
 describe("search_grep", () => {
   test("finds a simple string match", async () => {
-    await seedFile("/grep/hello.txt", "hello world\ngoodbye world");
+    await seedFile(conn, "/grep/hello.txt", "hello world\ngoodbye world");
     const result = await searchGrepTool.execute({ pattern: "hello" }, ctx);
     expect(result.matches.length).toBe(1);
     expect(result.matches[0]?.content).toContain("hello");
@@ -41,13 +27,13 @@ describe("search_grep", () => {
   });
 
   test("supports regex patterns", async () => {
-    await seedFile("/grep/regex.txt", "foo123\nbar456\nfoo789");
+    await seedFile(conn, "/grep/regex.txt", "foo123\nbar456\nfoo789");
     const result = await searchGrepTool.execute({ pattern: "foo\\d+" }, ctx);
     expect(result.matches.length).toBe(2);
   });
 
   test("case-insensitive search", async () => {
-    await seedFile("/grep/case.txt", "Hello\nhello\nHELLO");
+    await seedFile(conn, "/grep/case.txt", "Hello\nhello\nHELLO");
     const result = await searchGrepTool.execute(
       { pattern: "hello", ignore_case: true },
       ctx,
@@ -56,13 +42,13 @@ describe("search_grep", () => {
   });
 
   test("case-sensitive by default", async () => {
-    await seedFile("/grep/case2.txt", "Hello\nhello\nHELLO");
+    await seedFile(conn, "/grep/case2.txt", "Hello\nhello\nHELLO");
     const result = await searchGrepTool.execute({ pattern: "hello" }, ctx);
     expect(result.matches.length).toBe(1);
   });
 
   test("returns context lines", async () => {
-    await seedFile("/grep/ctx.txt", "a\nb\nc\nd\ne");
+    await seedFile(conn, "/grep/ctx.txt", "a\nb\nc\nd\ne");
     const result = await searchGrepTool.execute(
       { pattern: "c", context: 1 },
       ctx,
@@ -73,7 +59,7 @@ describe("search_grep", () => {
   });
 
   test("respects max_results", async () => {
-    await seedFile("/grep/many.txt", "match\nmatch\nmatch\nmatch\nmatch");
+    await seedFile(conn, "/grep/many.txt", "match\nmatch\nmatch\nmatch\nmatch");
     const result = await searchGrepTool.execute(
       { pattern: "match", max_results: 2 },
       ctx,
@@ -82,8 +68,8 @@ describe("search_grep", () => {
   });
 
   test("filters by glob pattern", async () => {
-    await seedFile("/grep/code.ts", "function hello() {}");
-    await seedFile("/grep/notes.md", "hello notes");
+    await seedFile(conn, "/grep/code.ts", "function hello() {}");
+    await seedFile(conn, "/grep/notes.md", "hello notes");
     const result = await searchGrepTool.execute(
       { pattern: "hello", glob: "*.ts" },
       ctx,
@@ -93,14 +79,14 @@ describe("search_grep", () => {
   });
 
   test("returns empty matches when nothing found", async () => {
-    await seedFile("/grep/empty.txt", "no match here");
+    await seedFile(conn, "/grep/empty.txt", "no match here");
     const result = await searchGrepTool.execute({ pattern: "zzzzz" }, ctx);
     expect(result.matches).toHaveLength(0);
   });
 
   test("searches only within specified path", async () => {
-    await seedFile("/a/file.txt", "target");
-    await seedFile("/b/file.txt", "target");
+    await seedFile(conn, "/a/file.txt", "target");
+    await seedFile(conn, "/b/file.txt", "target");
     const result = await searchGrepTool.execute(
       { pattern: "target", path: "/a" },
       ctx,
@@ -110,7 +96,7 @@ describe("search_grep", () => {
   });
 
   test("throws on invalid regex", async () => {
-    await seedFile("/grep/test.txt", "test");
+    await seedFile(conn, "/grep/test.txt", "test");
     expect(
       searchGrepTool.execute({ pattern: "[invalid" }, ctx),
     ).rejects.toThrow();
@@ -139,6 +125,7 @@ describe("search_semantic", () => {
 
     // Seed and ingest a file
     const item = await seedFile(
+      conn,
       "/search/doc.md",
       "Meeting notes about quarterly revenue and projections.",
     );

--- a/test/tools/task.test.ts
+++ b/test/tools/task.test.ts
@@ -1,20 +1,15 @@
 import { beforeEach, describe, expect, test } from "bun:test";
-import { DEFAULT_CONFIG } from "../../src/config/schemas.ts";
-import { type DbConnection, getConnection } from "../../src/db/connection.ts";
-import { migrate } from "../../src/db/schema.ts";
 import { completeTaskTool } from "../../src/tools/task/complete.ts";
 import { createTaskTool } from "../../src/tools/task/create.ts";
 import { failTaskTool } from "../../src/tools/task/fail.ts";
 import { waitTaskTool } from "../../src/tools/task/wait.ts";
 import type { ToolContext } from "../../src/tools/tool.ts";
+import { setupToolContext } from "../helpers.ts";
 
-let conn: DbConnection;
 let ctx: ToolContext;
 
 beforeEach(() => {
-  conn = getConnection(":memory:");
-  migrate(conn);
-  ctx = { conn, projectDir: "/tmp/test", config: { ...DEFAULT_CONFIG } };
+  ({ ctx } = setupToolContext());
 });
 
 // ── create_task ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **`src/commands/with-db.ts`** — `withDb()` wraps command actions with DB connection setup/teardown, eliminating 4 repeated lines (`opts().dir`, `getConnection`, `migrate`, `conn.close()`) from 18+ command handlers. Also fixes resource leaks where `conn.close()` was skipped on early returns (e.g. empty list results).
- **`src/db/query.ts`** — `buildWhereClause()` and `buildSetClauses()` extract the dynamic SQL filter/update pattern that was duplicated across tasks, schedules, threads, and context modules.
- **`test/helpers.ts`** — `setupTestDb()`, `setupToolContext()`, and seed helpers (`seedFile`, `seedBinaryFile`, `seedDir`) consolidate identical setup code from 13 test files.

Net result: **-215 lines** across 25 files with no behavior changes.

## Test plan

- [x] `bun run lint` passes (tsc + biome)
- [x] `bun test` passes — all 211 tests, 0 failures

https://claude.ai/code/session_01RxKQfTXZKpJoHxNBFsPds8