### PR TITLE
Add MCPX integration with meta-tools and full CLI (M4)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "botholomew",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.88.0",
+        "@evantahler/mcpx": "0.18.3",
         "@huggingface/transformers": "^4.0.1",
         "@sqliteai/sqlite-vector": "^0.9.95",
         "ansis": "^4.2.0",
@@ -52,6 +53,10 @@
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.11", "", { "os": "win32", "cpu": "x64" }, "sha512-A8D3JM/00C2KQgUV3oj8Ba15EHEYwebAGCy5Sf9GAjr5Y3+kJIYOiESoqRDeuRZueuMdCsbLZIUqmPhpYXJE9A=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
+
+    "@evantahler/mcpx": ["@evantahler/mcpx@0.18.3", "", { "dependencies": { "@huggingface/transformers": "^3.8.1", "@modelcontextprotocol/sdk": "^1.27.1", "@types/picomatch": "^4.0.2", "ajv": "^8.18.0", "ansis": "^4.2.0", "commander": "^14.0.3", "nanospinner": "^1.2.2", "picomatch": "^4.0.3" }, "peerDependencies": { "typescript": "^5" }, "bin": { "mcpx": "src/cli.ts" } }, "sha512-Wi5RUShAf5oaNxDrx34BLJAHQ4/K8VV7XezxfRf6Fn5xR3Cy5LUK9wnP1Aifv/UwqYS+R0sGLDPvj7EVefql5Q=="],
+
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
     "@huggingface/jinja": ["@huggingface/jinja@0.5.6", "", {}, "sha512-MyMWyLnjqo+KRJYSH7oWNbsOn5onuIvfXYPcc0WOGxU0eHUV7oAYUoQTl2BMdu7ml+ea/bu11UM+EshbeHwtIA=="],
 
@@ -109,6 +114,10 @@
 
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
+    "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 
     "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
@@ -149,11 +158,19 @@
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
+    "@types/picomatch": ["@types/picomatch@4.0.3", "", {}, "sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ=="],
+
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/uuid": ["@types/uuid@11.0.0", "", { "dependencies": { "uuid": "*" } }, "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
     "adm-zip": ["adm-zip@0.5.17", "", {}, "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ=="],
+
+    "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
     "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
 
@@ -169,11 +186,21 @@
 
     "binaryextensions": ["binaryextensions@6.11.0", "", { "dependencies": { "editions": "^6.21.0" } }, "sha512-sXnYK/Ij80TO3lcqZVV2YgfKN5QjUWIRk/XSm2J/4bd/lPko3lvk0O4ZppH6m+6hB2/GTu+ptNwVFe1xh+QLQw=="],
 
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
     "boolean": ["boolean@3.2.0", "", {}, "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="],
 
     "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
 
     "cli-boxes": ["cli-boxes@3.0.0", "", {}, "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g=="],
 
@@ -185,21 +212,43 @@
 
     "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
     "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
 
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
 
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
 
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "detect-node": ["detect-node@2.1.0", "", {}, "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="],
 
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
     "editions": ["editions@6.22.0", "", { "dependencies": { "version-range": "^4.15.0" } }, "sha512-UgGlf8IW75je7HZjNDpJdCv4cGJWIi6yumFdZ0R7A8/CIhQiWUjyGLCxdHpd8bmyD1gnkfUNK0oeOXqUS2cpfQ=="],
 
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
 
@@ -207,19 +256,49 @@
 
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
     "es-toolkit": ["es-toolkit@1.45.1", "", {}, "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw=="],
 
     "es6-error": ["es6-error@4.1.1", "", {}, "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
     "escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
 
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.3.2", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg=="],
+
     "extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
     "flatbuffers": ["flatbuffers@25.9.23", "", {}, "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ=="],
 
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
     "get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "global-agent": ["global-agent@3.0.0", "", { "dependencies": { "boolean": "^3.0.1", "es6-error": "^4.1.1", "matcher": "^3.0.0", "roarr": "^2.15.3", "semver": "^7.3.2", "serialize-error": "^7.0.1" } }, "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q=="],
 
@@ -233,9 +312,25 @@
 
     "has-property-descriptors": ["has-property-descriptors@1.0.2", "", { "dependencies": { "es-define-property": "^1.0.0" } }, "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg=="],
 
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "hono": ["hono@4.12.12", "", {}, "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
     "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
 
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
     "ink": ["ink@6.8.0", "", { "dependencies": { "@alcalzone/ansi-tokenize": "^0.2.4", "ansi-escapes": "^7.3.0", "ansi-styles": "^6.2.1", "auto-bind": "^5.0.1", "chalk": "^5.6.0", "cli-boxes": "^3.0.0", "cli-cursor": "^4.0.0", "cli-truncate": "^5.1.1", "code-excerpt": "^4.0.0", "es-toolkit": "^1.39.10", "indent-string": "^5.0.0", "is-in-ci": "^2.0.0", "patch-console": "^2.0.0", "react-reconciler": "^0.33.0", "scheduler": "^0.27.0", "signal-exit": "^3.0.7", "slice-ansi": "^8.0.0", "stack-utils": "^2.0.6", "string-width": "^8.1.1", "terminal-size": "^4.0.1", "type-fest": "^5.4.1", "widest-line": "^6.0.0", "wrap-ansi": "^9.0.0", "ws": "^8.18.0", "yoga-layout": "~3.2.1" }, "peerDependencies": { "@types/react": ">=19.0.0", "react": ">=19.0.0", "react-devtools-core": ">=6.1.2" }, "optionalPeers": ["@types/react", "react-devtools-core"] }, "sha512-sbl1RdLOgkO9isK42WCZlJCFN9hb++sX9dsklOvfd1YQ3bQ2AiFu12Q6tFlr0HvEUvzraJntQCCpfEoUe9DSzA=="],
+
+    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-extendable": ["is-extendable@0.1.1", "", {}, "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="],
 
@@ -243,11 +338,21 @@
 
     "is-in-ci": ["is-in-ci@2.0.0", "", { "bin": { "is-in-ci": "cli.js" } }, "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w=="],
 
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
     "istextorbinary": ["istextorbinary@9.5.0", "", { "dependencies": { "binaryextensions": "^6.11.0", "editions": "^6.21.0", "textextensions": "^6.11.0" } }, "sha512-5mbUj3SiZXCuRf9fT3ibzbSSEWiy63gFfksmGfdOzujPjW3k+z8WvIBxcJHBoQNlaZaiyB25deviif2+osLmLw=="],
+
+    "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
 
     "js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
     "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "json-stringify-safe": ["json-stringify-safe@5.0.1", "", {}, "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="],
 
@@ -257,9 +362,37 @@
 
     "matcher": ["matcher@3.0.0", "", { "dependencies": { "escape-string-regexp": "^4.0.0" } }, "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng=="],
 
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanospinner": ["nanospinner@1.2.2", "", { "dependencies": { "picocolors": "^1.1.1" } }, "sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
     "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
@@ -269,19 +402,45 @@
 
     "onnxruntime-web": ["onnxruntime-web@1.25.0-dev.20260327-722743c0e2", "", { "dependencies": { "flatbuffers": "^25.1.24", "guid-typescript": "^1.0.9", "long": "^5.2.3", "onnxruntime-common": "1.24.0-dev.20251116-b39e144322", "platform": "^1.3.6", "protobufjs": "^7.2.4" } }, "sha512-8PXdZy4Ekhg10CLg+cFFt39b4tFDGMRJB6lGjnQL6eA+2boUQYDymZ0gtxiS+H6oIWoCjQp/ziyirvFbaFKfiw=="],
 
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
     "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "platform": ["platform@1.3.6", "", {}, "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="],
 
     "protobufjs": ["protobufjs@7.5.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg=="],
 
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
     "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
     "react-reconciler": ["react-reconciler@0.33.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA=="],
 
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
     "restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
 
     "roarr": ["roarr@2.15.4", "", { "dependencies": { "boolean": "^3.0.1", "detect-node": "^2.0.4", "globalthis": "^1.0.1", "json-stringify-safe": "^5.0.1", "semver-compare": "^1.0.0", "sprintf-js": "^1.1.2" } }, "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
@@ -291,9 +450,27 @@
 
     "semver-compare": ["semver-compare@1.0.0", "", {}, "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="],
 
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
     "serialize-error": ["serialize-error@7.0.1", "", { "dependencies": { "type-fest": "^0.13.1" } }, "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw=="],
 
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
     "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
@@ -303,6 +480,8 @@
 
     "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
 
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
     "string-width": ["string-width@8.2.0", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw=="],
 
     "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
@@ -311,9 +490,13 @@
 
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
 
+    "tar": ["tar@7.5.13", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng=="],
+
     "terminal-size": ["terminal-size@4.0.1", "", {}, "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ=="],
 
     "textextensions": ["textextensions@6.11.0", "", { "dependencies": { "editions": "^6.21.0" } }, "sha512-tXJwSr9355kFJI3lbCkPpUH5cP8/M0GGy2xLO34aZCjMXBaK3SoPnZwr/oWmo1FdCnELcs4npdCIOFtq9W3ruQ=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
     "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 
@@ -321,23 +504,39 @@
 
     "type-fest": ["type-fest@5.5.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g=="],
 
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
     "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
     "uuid": ["uuid@13.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w=="],
 
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
     "version-range": ["version-range@4.15.0", "", {}, "sha512-Ck0EJbAGxHwprkzFO966t4/5QkRuzh+/I1RxhLgUKKwEn+Cd8NwM60mE3AqBZg5gYODoXW0EFsQvbZjRlvdqbg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "widest-line": ["widest-line@6.0.0", "", { "dependencies": { "string-width": "^8.1.0" } }, "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA=="],
 
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
     "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+
+    "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
     "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "@evantahler/mcpx/@huggingface/transformers": ["@huggingface/transformers@3.8.1", "", { "dependencies": { "@huggingface/jinja": "^0.5.3", "onnxruntime-node": "1.21.0", "onnxruntime-web": "1.22.0-dev.20250409-89f8206ba4", "sharp": "^0.34.1" } }, "sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA=="],
 
     "matcher/escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
@@ -348,5 +547,13 @@
     "serialize-error/type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
 
     "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "@evantahler/mcpx/@huggingface/transformers/onnxruntime-node": ["onnxruntime-node@1.21.0", "", { "dependencies": { "global-agent": "^3.0.0", "onnxruntime-common": "1.21.0", "tar": "^7.0.1" }, "os": [ "linux", "win32", "darwin", ] }, "sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw=="],
+
+    "@evantahler/mcpx/@huggingface/transformers/onnxruntime-web": ["onnxruntime-web@1.22.0-dev.20250409-89f8206ba4", "", { "dependencies": { "flatbuffers": "^25.1.24", "guid-typescript": "^1.0.9", "long": "^5.2.3", "onnxruntime-common": "1.22.0-dev.20250409-89f8206ba4", "platform": "^1.3.6", "protobufjs": "^7.2.4" } }, "sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ=="],
+
+    "@evantahler/mcpx/@huggingface/transformers/onnxruntime-node/onnxruntime-common": ["onnxruntime-common@1.21.0", "", {}, "sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ=="],
+
+    "@evantahler/mcpx/@huggingface/transformers/onnxruntime-web/onnxruntime-common": ["onnxruntime-common@1.22.0-dev.20250409-89f8206ba4", "", {}, "sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ=="],
   }
 }

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -4,8 +4,8 @@
 |---|-----------|--------|---------|
 | 1 | [Foundation](milestone-1-foundation.md) | **Done** | Scaffolding, SQLite schema, CLI skeleton, daemon tick loop |
 | 2 | [Context & Embeddings](milestone-2-context-and-embeddings.md) | **Done** | Ingest, chunk, embed, and search content with hybrid vector search |
-| 3 | [Schedules & Task Hardening](milestone-3-schedules-and-task-hardening.md) | Planned | Recurring schedules, cycle detection, timeouts, full task/schedule CLI |
-| 4 | [MCPX Integration](milestone-4-mcpx-integration.md) | Planned | External tools via MCP servers (Gmail, Slack, web, etc.) |
+| 3 | [Schedules & Task Hardening](milestone-3-schedules-and-task-hardening.md) | **Done** | Recurring schedules, cycle detection, timeouts, full task/schedule CLI |
+| 4 | [MCPX Integration](milestone-4-mcpx-integration.md) | **Done** | External tools via MCP servers (Gmail, Slack, web, etc.) |
 | 5 | [Chat TUI](milestone-5-chat-tui.md) | Planned | Interactive Ink/React terminal UI for conversational interaction |
 | 6 | [Daemon Watchdog & Distribution](milestone-6-daemon-watchdog-and-distribution.md) | Planned | OS-level watchdog, binary compilation, agent self-modification |
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "An AI agent for knowledge work",
   "type": "module",
   "bin": {
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.88.0",
+    "@evantahler/mcpx": "0.18.3",
     "@huggingface/transformers": "^4.0.1",
     "@sqliteai/sqlite-vector": "^0.9.95",
     "ansis": "^4.2.0",

--- a/src/commands/mcpx.ts
+++ b/src/commands/mcpx.ts
@@ -1,29 +1,414 @@
+import { copyFileSync, existsSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { McpxClient } from "@evantahler/mcpx";
+import ansis from "ansis";
 import type { Command } from "commander";
+import { getMcpxDir, MCPX_SERVERS_FILENAME } from "../constants.ts";
+import { createMcpxClient, formatCallToolResult } from "../mcpx/client.ts";
 import { logger } from "../utils/logger.ts";
+
+function getServersPath(program: Command): string {
+  const dir = program.opts().dir;
+  return join(getMcpxDir(dir), MCPX_SERVERS_FILENAME);
+}
+
+async function readServersFile(
+  path: string,
+): Promise<{ mcpServers: Record<string, unknown> }> {
+  if (!existsSync(path)) {
+    return { mcpServers: {} };
+  }
+  return JSON.parse(await Bun.file(path).text());
+}
+
+async function writeServersFile(
+  path: string,
+  data: { mcpServers: Record<string, unknown> },
+): Promise<void> {
+  const dir = join(path, "..");
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  await Bun.write(path, `${JSON.stringify(data, null, 2)}\n`);
+}
+
+async function getClient(program: Command): Promise<McpxClient> {
+  const dir = program.opts().dir;
+  const client = await createMcpxClient(dir);
+  if (!client) {
+    logger.error(
+      "No MCP servers configured. Add one with: botholomew mcpx add <name>",
+    );
+    process.exit(1);
+  }
+  return client;
+}
 
 export function registerMcpxCommand(program: Command) {
   const mcpx = program
     .command("mcpx")
     .description("Manage MCP servers via MCPX");
 
+  // --- servers ---
   mcpx
-    .command("list")
-    .description("List configured MCP servers")
+    .command("servers")
+    .description("List configured MCP server names")
     .action(async () => {
-      logger.warn("Not yet implemented. Coming soon.");
+      const serversPath = getServersPath(program);
+      const data = await readServersFile(serversPath);
+      const names = Object.keys(data.mcpServers);
+      if (names.length === 0) {
+        logger.dim("No MCP servers configured.");
+        return;
+      }
+      for (const name of names) {
+        console.log(`  ${ansis.bold(name)}`);
+      }
     });
 
+  // --- info ---
   mcpx
-    .command("add <server>")
+    .command("info <server> [tool]")
+    .description("Show server overview, or schema for a specific tool")
+    .action(async (server: string, tool?: string) => {
+      const client = await getClient(program);
+      try {
+        if (tool) {
+          const schema = await client.info(server, tool);
+          if (!schema) {
+            logger.error(`Tool not found: ${tool} on server ${server}`);
+            process.exit(1);
+          }
+          console.log(ansis.bold(`${server} / ${schema.name}`));
+          if (schema.description) console.log(`  ${schema.description}`);
+          if (schema.inputSchema) {
+            console.log(ansis.dim("\n  Input Schema:"));
+            console.log(JSON.stringify(schema.inputSchema, null, 2));
+          }
+        } else {
+          const info = await client.getServerInfo(server);
+          console.log(ansis.bold(server));
+          if (info.version?.name)
+            console.log(`  Name:    ${info.version.name}`);
+          if (info.version?.version)
+            console.log(`  Version: ${info.version.version}`);
+          if (info.instructions)
+            console.log(`  Instructions: ${info.instructions}`);
+          if (info.capabilities) {
+            console.log(`  Capabilities: ${JSON.stringify(info.capabilities)}`);
+          }
+        }
+      } finally {
+        await client.close();
+      }
+    });
+
+  // --- search ---
+  mcpx
+    .command("search <terms...>")
+    .description("Search tools by keyword and/or semantic similarity")
+    .action(async (terms: string[]) => {
+      const client = await getClient(program);
+      try {
+        const results = await client.search(terms.join(" "));
+        if (results.length === 0) {
+          logger.dim("No matching tools found.");
+          return;
+        }
+        for (const r of results) {
+          const score = ansis.dim(`(${r.score.toFixed(2)})`);
+          console.log(`  ${ansis.bold(r.server)}/${r.tool}  ${score}`);
+          if (r.description) console.log(`    ${r.description}`);
+        }
+      } catch (err) {
+        logger.error(
+          `Search failed: ${err}. You may need to run: botholomew mcpx index`,
+        );
+        process.exit(1);
+      } finally {
+        await client.close();
+      }
+    });
+
+  // --- exec ---
+  mcpx
+    .command("exec <server> <tool> [args-json]")
+    .description("Execute a tool call")
+    .action(async (server: string, tool: string, argsJson?: string) => {
+      const client = await getClient(program);
+      try {
+        const args = argsJson ? JSON.parse(argsJson) : {};
+        const result = await client.exec(server, tool, args);
+        console.log(formatCallToolResult(result));
+      } catch (err) {
+        logger.error(`Exec failed: ${err}`);
+        process.exit(1);
+      } finally {
+        await client.close();
+      }
+    });
+
+  // --- add ---
+  mcpx
+    .command("add <name>")
     .description("Add an MCP server")
-    .action(async () => {
-      logger.warn("Not yet implemented. Coming soon.");
+    .option("--command <cmd>", "Stdio server command")
+    .option("--args <args...>", "Stdio server arguments")
+    .option("--url <url>", "HTTP server URL")
+    .option("--transport <type>", "HTTP transport: sse or streamable-http")
+    .option("--env <pairs...>", "Environment variables as KEY=VALUE pairs")
+    .action(
+      async (
+        name: string,
+        opts: {
+          command?: string;
+          args?: string[];
+          url?: string;
+          transport?: string;
+          env?: string[];
+        },
+      ) => {
+        const serversPath = getServersPath(program);
+        const data = await readServersFile(serversPath);
+
+        let entry: Record<string, unknown>;
+        if (opts.url) {
+          entry = { url: opts.url };
+          if (opts.transport) entry.transport = opts.transport;
+        } else if (opts.command) {
+          entry = { command: opts.command };
+          if (opts.args) entry.args = opts.args;
+        } else {
+          logger.error("Must specify --command or --url");
+          process.exit(1);
+        }
+
+        if (opts.env) {
+          const env: Record<string, string> = {};
+          for (const pair of opts.env) {
+            const eqIdx = pair.indexOf("=");
+            if (eqIdx === -1) {
+              logger.error(`Invalid env pair: ${pair} (expected KEY=VALUE)`);
+              process.exit(1);
+            }
+            env[pair.slice(0, eqIdx)] = pair.slice(eqIdx + 1);
+          }
+          entry.env = env;
+        }
+
+        data.mcpServers[name] = entry;
+        await writeServersFile(serversPath, data);
+        logger.success(`Added server: ${name}`);
+      },
+    );
+
+  // --- remove ---
+  mcpx
+    .command("remove <name>")
+    .description("Remove an MCP server")
+    .action(async (name: string) => {
+      const serversPath = getServersPath(program);
+      const data = await readServersFile(serversPath);
+      if (!(name in data.mcpServers)) {
+        logger.error(`Server not found: ${name}`);
+        process.exit(1);
+      }
+      delete data.mcpServers[name];
+      await writeServersFile(serversPath, data);
+      logger.success(`Removed server: ${name}`);
     });
 
+  // --- ping ---
   mcpx
-    .command("test <tool>")
-    .description("Test a tool call")
+    .command("ping [servers...]")
+    .description("Check connectivity to MCP servers")
+    .action(async (servers: string[]) => {
+      const client = await getClient(program);
+      try {
+        const names =
+          servers.length > 0 ? servers : await client.getServerNames();
+        for (const name of names) {
+          try {
+            const info = await client.getServerInfo(name);
+            const version = info.version?.version ?? "unknown";
+            console.log(
+              `  ${ansis.green("✓")} ${ansis.bold(name)}  v${version}`,
+            );
+          } catch (err) {
+            console.log(`  ${ansis.red("✗")} ${ansis.bold(name)}  ${err}`);
+          }
+        }
+      } finally {
+        await client.close();
+      }
+    });
+
+  // --- auth ---
+  mcpx
+    .command("auth <server>")
+    .description("Authenticate with an HTTP MCP server")
+    .action(async (server: string) => {
+      logger.info(
+        `To authenticate, run: mcpx auth ${server} -c ${getMcpxDir(program.opts().dir)}`,
+      );
+    });
+
+  // --- resource ---
+  mcpx
+    .command("resource [server] [uri]")
+    .description("List resources for a server, or read a specific resource")
+    .action(async (server?: string, uri?: string) => {
+      const client = await getClient(program);
+      try {
+        if (server && uri) {
+          const result = await client.readResource(server, uri);
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          const resources = await client.listResources(server);
+          if (resources.length === 0) {
+            logger.dim("No resources found.");
+            return;
+          }
+          for (const r of resources) {
+            console.log(
+              `  ${ansis.bold(r.server)}  ${r.resource.uri}  ${r.resource.name ?? ""}`,
+            );
+          }
+        }
+      } finally {
+        await client.close();
+      }
+    });
+
+  // --- prompt ---
+  mcpx
+    .command("prompt [server] [name] [args]")
+    .description("List prompts for a server, or get a specific prompt")
+    .action(async (server?: string, name?: string, argsJson?: string) => {
+      const client = await getClient(program);
+      try {
+        if (server && name) {
+          const args = argsJson ? JSON.parse(argsJson) : undefined;
+          const result = await client.getPrompt(server, name, args);
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          const prompts = await client.listPrompts(server);
+          if (prompts.length === 0) {
+            logger.dim("No prompts found.");
+            return;
+          }
+          for (const p of prompts) {
+            console.log(
+              `  ${ansis.bold(p.server)}  ${p.prompt.name}  ${p.prompt.description ?? ""}`,
+            );
+          }
+        }
+      } finally {
+        await client.close();
+      }
+    });
+
+  // --- task ---
+  mcpx
+    .command("task <action> <server> [taskId]")
+    .description("Manage async tasks (actions: list, get, result, cancel)")
+    .action(async (action: string, server: string, taskId?: string) => {
+      const client = await getClient(program);
+      try {
+        switch (action) {
+          case "list": {
+            const result = await client.listTasks(server);
+            console.log(JSON.stringify(result, null, 2));
+            break;
+          }
+          case "get": {
+            if (!taskId) {
+              logger.error("Task ID required for get");
+              process.exit(1);
+            }
+            const result = await client.getTask(server, taskId);
+            console.log(JSON.stringify(result, null, 2));
+            break;
+          }
+          case "result": {
+            if (!taskId) {
+              logger.error("Task ID required for result");
+              process.exit(1);
+            }
+            const result = await client.getTaskResult(server, taskId);
+            console.log(formatCallToolResult(result));
+            break;
+          }
+          case "cancel": {
+            if (!taskId) {
+              logger.error("Task ID required for cancel");
+              process.exit(1);
+            }
+            const result = await client.cancelTask(server, taskId);
+            console.log(JSON.stringify(result, null, 2));
+            break;
+          }
+          default:
+            logger.error(
+              `Unknown action: ${action}. Use list, get, result, or cancel.`,
+            );
+            process.exit(1);
+        }
+      } finally {
+        await client.close();
+      }
+    });
+
+  // --- import-global ---
+  mcpx
+    .command("import-global")
+    .description("Copy system-wide MCPX settings (~/.mcpx) into this project")
     .action(async () => {
-      logger.warn("Not yet implemented. Coming soon.");
+      const globalDir = join(homedir(), ".mcpx");
+      if (!existsSync(globalDir)) {
+        logger.error("No global MCPX config found at ~/.mcpx");
+        process.exit(1);
+      }
+
+      const projectMcpxDir = getMcpxDir(program.opts().dir);
+      if (!existsSync(projectMcpxDir)) {
+        mkdirSync(projectMcpxDir, { recursive: true });
+      }
+
+      const filesToCopy = ["servers.json", "auth.json", "search.json"];
+      let copied = 0;
+      for (const file of filesToCopy) {
+        const src = join(globalDir, file);
+        if (!existsSync(src)) continue;
+        const dest = join(projectMcpxDir, file);
+        copyFileSync(src, dest);
+        logger.success(`Copied ${file}`);
+        copied++;
+      }
+
+      if (copied === 0) {
+        logger.warn("No config files found in ~/.mcpx to copy.");
+      } else {
+        logger.success(
+          `Imported ${copied} file(s) from ~/.mcpx into ${projectMcpxDir}`,
+        );
+      }
+    });
+
+  // --- index ---
+  mcpx
+    .command("index")
+    .description("Build the search index from all configured servers")
+    .action(async () => {
+      const mcpxDir = getMcpxDir(program.opts().dir);
+      const proc = Bun.spawn(["mcpx", "index", "-c", mcpxDir], {
+        stdout: "inherit",
+        stderr: "inherit",
+      });
+      const exitCode = await proc.exited;
+      if (exitCode !== 0) {
+        process.exit(exitCode);
+      }
     });
 }

--- a/src/commands/mcpx.ts
+++ b/src/commands/mcpx.ts
@@ -98,6 +98,18 @@ export function registerMcpxCommand(program: Command) {
           if (info.capabilities) {
             console.log(`  Capabilities: ${JSON.stringify(info.capabilities)}`);
           }
+
+          const tools = await client.listTools(server);
+          if (tools.length > 0) {
+            console.log(ansis.dim(`\n  Tools (${tools.length}):`));
+            for (const t of tools) {
+              console.log(`    ${ansis.bold(t.tool.name)}`);
+              if (t.tool.description) {
+                const desc = t.tool.description.split("\n")[0] ?? "";
+                console.log(`      ${ansis.dim(desc)}`);
+              }
+            }
+          }
         }
       } finally {
         await client.close();

--- a/src/commands/mcpx.ts
+++ b/src/commands/mcpx.ts
@@ -1,72 +1,54 @@
 import { copyFileSync, existsSync, mkdirSync } from "node:fs";
+import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import type { McpxClient } from "@evantahler/mcpx";
-import ansis from "ansis";
+import { fileURLToPath } from "node:url";
 import type { Command } from "commander";
-import { getMcpxDir, MCPX_SERVERS_FILENAME } from "../constants.ts";
-import { createMcpxClient, formatCallToolResult } from "../mcpx/client.ts";
+import { getMcpxDir } from "../constants.ts";
 import { logger } from "../utils/logger.ts";
 
-function getServersPath(program: Command): string {
-  const dir = program.opts().dir;
-  return join(getMcpxDir(dir), MCPX_SERVERS_FILENAME);
+const require = createRequire(import.meta.url);
+const ourPkg = require("../../package.json");
+const mcpxPkg = require("@evantahler/mcpx/package.json");
+
+if (mcpxPkg.version !== ourPkg.dependencies["@evantahler/mcpx"]) {
+  throw new Error(
+    `@evantahler/mcpx version mismatch: installed ${mcpxPkg.version}, expected ${ourPkg.dependencies["@evantahler/mcpx"]}`,
+  );
 }
 
-async function readServersFile(
-  path: string,
-): Promise<{ mcpServers: Record<string, unknown> }> {
-  if (!existsSync(path)) {
-    return { mcpServers: {} };
-  }
-  return JSON.parse(await Bun.file(path).text());
-}
+const MCPX_CLI = fileURLToPath(import.meta.resolve("@evantahler/mcpx/cli"));
 
-async function writeServersFile(
-  path: string,
-  data: { mcpServers: Record<string, unknown> },
-): Promise<void> {
-  const dir = join(path, "..");
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true });
-  }
-  await Bun.write(path, `${JSON.stringify(data, null, 2)}\n`);
-}
-
-async function getClient(program: Command): Promise<McpxClient> {
-  const dir = program.opts().dir;
-  const client = await createMcpxClient(dir);
-  if (!client) {
-    logger.error(
-      "No MCP servers configured. Add one with: botholomew mcpx add <name>",
-    );
-    process.exit(1);
-  }
-  return client;
-}
-
-/**
- * Given a tool name, find which server provides it.
- * Errors if the tool is not found or is ambiguous (multiple servers).
- */
-async function resolveServer(
-  client: McpxClient,
-  toolName: string,
+export async function runMcpx(
+  projectDir: string,
+  args: (string | undefined)[],
+  opts?: { inherit?: boolean },
 ): Promise<string> {
-  const allTools = await client.listTools();
-  const matches = allTools.filter((t) => t.tool.name === toolName);
-  if (matches.length === 0) {
-    logger.error(`Tool not found: ${toolName}`);
-    process.exit(1);
+  const mcpxDir = getMcpxDir(projectDir);
+  const filteredArgs = args.filter((a): a is string => a !== undefined);
+  const proc = Bun.spawn(["bun", MCPX_CLI, ...filteredArgs, "-c", mcpxDir], {
+    stdout: opts?.inherit ? "inherit" : "pipe",
+    stderr: opts?.inherit ? "inherit" : "pipe",
+    stdin: opts?.inherit ? "inherit" : undefined,
+  });
+  const exitCode = await proc.exited;
+
+  if (opts?.inherit) {
+    if (exitCode !== 0) process.exit(exitCode);
+    return "";
   }
-  if (matches.length > 1) {
-    const servers = matches.map((m) => m.server).join(", ");
-    logger.error(
-      `Tool "${toolName}" exists on multiple servers: ${servers}. Specify the server explicitly.`,
-    );
-    process.exit(1);
+
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  if (exitCode !== 0) {
+    logger.error(stderr.trim() || stdout.trim());
+    process.exit(exitCode);
   }
-  return matches[0]?.server as string;
+  return stdout;
+}
+
+function getDir(program: Command): string {
+  return program.opts().dir;
 }
 
 export function registerMcpxCommand(program: Command) {
@@ -79,16 +61,8 @@ export function registerMcpxCommand(program: Command) {
     .command("servers")
     .description("List configured MCP server names")
     .action(async () => {
-      const serversPath = getServersPath(program);
-      const data = await readServersFile(serversPath);
-      const names = Object.keys(data.mcpServers);
-      if (names.length === 0) {
-        logger.dim("No MCP servers configured.");
-        return;
-      }
-      for (const name of names) {
-        console.log(`  ${ansis.bold(name)}`);
-      }
+      const out = await runMcpx(getDir(program), ["servers"]);
+      process.stdout.write(out);
     });
 
   // --- info ---
@@ -98,67 +72,8 @@ export function registerMcpxCommand(program: Command) {
       "Show server overview, or schema for a specific tool (server is optional if tool name is unambiguous)",
     )
     .action(async (first: string, second?: string) => {
-      const client = await getClient(program);
-      try {
-        let server: string;
-        let tool: string | undefined;
-
-        if (second) {
-          // info <server> <tool>
-          server = first;
-          tool = second;
-        } else {
-          // Could be a server name or a tool name
-          const serverNames = await client.getServerNames();
-          if (serverNames.includes(first)) {
-            server = first;
-          } else {
-            // Treat as tool name, resolve server
-            server = await resolveServer(client, first);
-            tool = first;
-          }
-        }
-
-        if (tool) {
-          const schema = await client.info(server, tool);
-          if (!schema) {
-            logger.error(`Tool not found: ${tool} on server ${server}`);
-            process.exit(1);
-          }
-          console.log(ansis.bold(`${server} / ${schema.name}`));
-          if (schema.description) console.log(`  ${schema.description}`);
-          if (schema.inputSchema) {
-            console.log(ansis.dim("\n  Input Schema:"));
-            console.log(JSON.stringify(schema.inputSchema, null, 2));
-          }
-        } else {
-          const info = await client.getServerInfo(server);
-          console.log(ansis.bold(server));
-          if (info.version?.name)
-            console.log(`  Name:    ${info.version.name}`);
-          if (info.version?.version)
-            console.log(`  Version: ${info.version.version}`);
-          if (info.instructions)
-            console.log(`  Instructions: ${info.instructions}`);
-          if (info.capabilities) {
-            console.log(`  Capabilities: ${JSON.stringify(info.capabilities)}`);
-          }
-
-          const tools = await client.listTools(server);
-          if (tools.length > 0) {
-            console.log(ansis.dim(`\n  Tools (${tools.length}):`));
-            for (const t of tools) {
-              console.log(`    ${ansis.bold(t.tool.name)}`);
-              if (t.tool.description) {
-                const desc = t.tool.description.split("\n")[0] ?? "";
-                console.log(`      ${ansis.dim(desc)}`);
-              }
-            }
-          }
-        }
-      } finally {
-        await client.close();
-      }
+      const out = await runMcpx(getDir(program), ["info", first, second]);
+      process.stdout.write(out);
     });
 
   // --- search ---
@@ -166,26 +81,8 @@ export function registerMcpxCommand(program: Command) {
     .command("search <terms...>")
     .description("Search tools by keyword and/or semantic similarity")
     .action(async (terms: string[]) => {
-      const client = await getClient(program);
-      try {
-        const results = await client.search(terms.join(" "));
-        if (results.length === 0) {
-          logger.dim("No matching tools found.");
-          return;
-        }
-        for (const r of results) {
-          const score = ansis.dim(`(${r.score.toFixed(2)})`);
-          console.log(`  ${ansis.bold(r.server)}/${r.tool}  ${score}`);
-          if (r.description) console.log(`    ${r.description}`);
-        }
-      } catch (err) {
-        logger.error(
-          `Search failed: ${err}. You may need to run: botholomew mcpx index`,
-        );
-        process.exit(1);
-      } finally {
-        await client.close();
-      }
+      const out = await runMcpx(getDir(program), ["search", ...terms]);
+      process.stdout.write(out);
     });
 
   // --- exec ---
@@ -195,52 +92,13 @@ export function registerMcpxCommand(program: Command) {
       "Execute a tool call (server is optional if tool name is unambiguous)",
     )
     .action(async (first: string, second?: string, third?: string) => {
-      const client = await getClient(program);
-      try {
-        let server: string;
-        let tool: string;
-        let argsJson: string | undefined;
-
-        if (second && third) {
-          // exec <server> <tool> <args-json>
-          server = first;
-          tool = second;
-          argsJson = third;
-        } else if (second) {
-          // Could be: exec <server> <tool> OR exec <tool> <args-json>
-          // Try to parse second as JSON — if it parses, first is tool
-          let parsedAsArgs = false;
-          try {
-            JSON.parse(second);
-            parsedAsArgs = true;
-          } catch {
-            // not JSON, treat as exec <server> <tool>
-          }
-
-          if (parsedAsArgs) {
-            const resolved = await resolveServer(client, first);
-            server = resolved;
-            tool = first;
-            argsJson = second;
-          } else {
-            server = first;
-            tool = second;
-          }
-        } else {
-          // exec <tool> — resolve server automatically
-          server = await resolveServer(client, first);
-          tool = first;
-        }
-
-        const args = argsJson ? JSON.parse(argsJson) : {};
-        const result = await client.exec(server, tool, args);
-        console.log(formatCallToolResult(result));
-      } catch (err) {
-        logger.error(`Exec failed: ${err}`);
-        process.exit(1);
-      } finally {
-        await client.close();
-      }
+      const out = await runMcpx(getDir(program), [
+        "exec",
+        first,
+        second,
+        third,
+      ]);
+      process.stdout.write(out);
     });
 
   // --- add ---
@@ -263,37 +121,18 @@ export function registerMcpxCommand(program: Command) {
           env?: string[];
         },
       ) => {
-        const serversPath = getServersPath(program);
-        const data = await readServersFile(serversPath);
-
-        let entry: Record<string, unknown>;
-        if (opts.url) {
-          entry = { url: opts.url };
-          if (opts.transport) entry.transport = opts.transport;
-        } else if (opts.command) {
-          entry = { command: opts.command };
-          if (opts.args) entry.args = opts.args;
-        } else {
-          logger.error("Must specify --command or --url");
-          process.exit(1);
+        const cliArgs: string[] = ["add", name];
+        if (opts.command) cliArgs.push("--command", opts.command);
+        if (opts.args) {
+          for (const a of opts.args) cliArgs.push("--args", a);
         }
-
+        if (opts.url) cliArgs.push("--url", opts.url);
+        if (opts.transport) cliArgs.push("--transport", opts.transport);
         if (opts.env) {
-          const env: Record<string, string> = {};
-          for (const pair of opts.env) {
-            const eqIdx = pair.indexOf("=");
-            if (eqIdx === -1) {
-              logger.error(`Invalid env pair: ${pair} (expected KEY=VALUE)`);
-              process.exit(1);
-            }
-            env[pair.slice(0, eqIdx)] = pair.slice(eqIdx + 1);
-          }
-          entry.env = env;
+          for (const e of opts.env) cliArgs.push("--env", e);
         }
-
-        data.mcpServers[name] = entry;
-        await writeServersFile(serversPath, data);
-        logger.success(`Added server: ${name}`);
+        const out = await runMcpx(getDir(program), cliArgs);
+        process.stdout.write(out);
       },
     );
 
@@ -302,15 +141,8 @@ export function registerMcpxCommand(program: Command) {
     .command("remove <name>")
     .description("Remove an MCP server")
     .action(async (name: string) => {
-      const serversPath = getServersPath(program);
-      const data = await readServersFile(serversPath);
-      if (!(name in data.mcpServers)) {
-        logger.error(`Server not found: ${name}`);
-        process.exit(1);
-      }
-      delete data.mcpServers[name];
-      await writeServersFile(serversPath, data);
-      logger.success(`Removed server: ${name}`);
+      const out = await runMcpx(getDir(program), ["remove", name]);
+      process.stdout.write(out);
     });
 
   // --- ping ---
@@ -318,24 +150,8 @@ export function registerMcpxCommand(program: Command) {
     .command("ping [servers...]")
     .description("Check connectivity to MCP servers")
     .action(async (servers: string[]) => {
-      const client = await getClient(program);
-      try {
-        const names =
-          servers.length > 0 ? servers : await client.getServerNames();
-        for (const name of names) {
-          try {
-            const info = await client.getServerInfo(name);
-            const version = info.version?.version ?? "unknown";
-            console.log(
-              `  ${ansis.green("✓")} ${ansis.bold(name)}  v${version}`,
-            );
-          } catch (err) {
-            console.log(`  ${ansis.red("✗")} ${ansis.bold(name)}  ${err}`);
-          }
-        }
-      } finally {
-        await client.close();
-      }
+      const out = await runMcpx(getDir(program), ["ping", ...servers]);
+      process.stdout.write(out);
     });
 
   // --- auth ---
@@ -343,9 +159,7 @@ export function registerMcpxCommand(program: Command) {
     .command("auth <server>")
     .description("Authenticate with an HTTP MCP server")
     .action(async (server: string) => {
-      logger.info(
-        `To authenticate, run: mcpx auth ${server} -c ${getMcpxDir(program.opts().dir)}`,
-      );
+      await runMcpx(getDir(program), ["auth", server], { inherit: true });
     });
 
   // --- resource ---
@@ -353,26 +167,8 @@ export function registerMcpxCommand(program: Command) {
     .command("resource [server] [uri]")
     .description("List resources for a server, or read a specific resource")
     .action(async (server?: string, uri?: string) => {
-      const client = await getClient(program);
-      try {
-        if (server && uri) {
-          const result = await client.readResource(server, uri);
-          console.log(JSON.stringify(result, null, 2));
-        } else {
-          const resources = await client.listResources(server);
-          if (resources.length === 0) {
-            logger.dim("No resources found.");
-            return;
-          }
-          for (const r of resources) {
-            console.log(
-              `  ${ansis.bold(r.server)}  ${r.resource.uri}  ${r.resource.name ?? ""}`,
-            );
-          }
-        }
-      } finally {
-        await client.close();
-      }
+      const out = await runMcpx(getDir(program), ["resource", server, uri]);
+      process.stdout.write(out);
     });
 
   // --- prompt ---
@@ -380,27 +176,13 @@ export function registerMcpxCommand(program: Command) {
     .command("prompt [server] [name] [args]")
     .description("List prompts for a server, or get a specific prompt")
     .action(async (server?: string, name?: string, argsJson?: string) => {
-      const client = await getClient(program);
-      try {
-        if (server && name) {
-          const args = argsJson ? JSON.parse(argsJson) : undefined;
-          const result = await client.getPrompt(server, name, args);
-          console.log(JSON.stringify(result, null, 2));
-        } else {
-          const prompts = await client.listPrompts(server);
-          if (prompts.length === 0) {
-            logger.dim("No prompts found.");
-            return;
-          }
-          for (const p of prompts) {
-            console.log(
-              `  ${ansis.bold(p.server)}  ${p.prompt.name}  ${p.prompt.description ?? ""}`,
-            );
-          }
-        }
-      } finally {
-        await client.close();
-      }
+      const out = await runMcpx(getDir(program), [
+        "prompt",
+        server,
+        name,
+        argsJson,
+      ]);
+      process.stdout.write(out);
     });
 
   // --- task ---
@@ -408,50 +190,13 @@ export function registerMcpxCommand(program: Command) {
     .command("task <action> <server> [taskId]")
     .description("Manage async tasks (actions: list, get, result, cancel)")
     .action(async (action: string, server: string, taskId?: string) => {
-      const client = await getClient(program);
-      try {
-        switch (action) {
-          case "list": {
-            const result = await client.listTasks(server);
-            console.log(JSON.stringify(result, null, 2));
-            break;
-          }
-          case "get": {
-            if (!taskId) {
-              logger.error("Task ID required for get");
-              process.exit(1);
-            }
-            const result = await client.getTask(server, taskId);
-            console.log(JSON.stringify(result, null, 2));
-            break;
-          }
-          case "result": {
-            if (!taskId) {
-              logger.error("Task ID required for result");
-              process.exit(1);
-            }
-            const result = await client.getTaskResult(server, taskId);
-            console.log(formatCallToolResult(result));
-            break;
-          }
-          case "cancel": {
-            if (!taskId) {
-              logger.error("Task ID required for cancel");
-              process.exit(1);
-            }
-            const result = await client.cancelTask(server, taskId);
-            console.log(JSON.stringify(result, null, 2));
-            break;
-          }
-          default:
-            logger.error(
-              `Unknown action: ${action}. Use list, get, result, or cancel.`,
-            );
-            process.exit(1);
-        }
-      } finally {
-        await client.close();
-      }
+      const out = await runMcpx(getDir(program), [
+        "task",
+        action,
+        server,
+        taskId,
+      ]);
+      process.stdout.write(out);
     });
 
   // --- import-global ---
@@ -465,7 +210,7 @@ export function registerMcpxCommand(program: Command) {
         process.exit(1);
       }
 
-      const projectMcpxDir = getMcpxDir(program.opts().dir);
+      const projectMcpxDir = getMcpxDir(getDir(program));
       if (!existsSync(projectMcpxDir)) {
         mkdirSync(projectMcpxDir, { recursive: true });
       }
@@ -495,14 +240,6 @@ export function registerMcpxCommand(program: Command) {
     .command("index")
     .description("Build the search index from all configured servers")
     .action(async () => {
-      const mcpxDir = getMcpxDir(program.opts().dir);
-      const proc = Bun.spawn(["mcpx", "index", "-c", mcpxDir], {
-        stdout: "inherit",
-        stderr: "inherit",
-      });
-      const exitCode = await proc.exited;
-      if (exitCode !== 0) {
-        process.exit(exitCode);
-      }
+      await runMcpx(getDir(program), ["index"], { inherit: true });
     });
 }

--- a/src/commands/mcpx.ts
+++ b/src/commands/mcpx.ts
@@ -45,6 +45,30 @@ async function getClient(program: Command): Promise<McpxClient> {
   return client;
 }
 
+/**
+ * Given a tool name, find which server provides it.
+ * Errors if the tool is not found or is ambiguous (multiple servers).
+ */
+async function resolveServer(
+  client: McpxClient,
+  toolName: string,
+): Promise<string> {
+  const allTools = await client.listTools();
+  const matches = allTools.filter((t) => t.tool.name === toolName);
+  if (matches.length === 0) {
+    logger.error(`Tool not found: ${toolName}`);
+    process.exit(1);
+  }
+  if (matches.length > 1) {
+    const servers = matches.map((m) => m.server).join(", ");
+    logger.error(
+      `Tool "${toolName}" exists on multiple servers: ${servers}. Specify the server explicitly.`,
+    );
+    process.exit(1);
+  }
+  return matches[0]?.server as string;
+}
+
 export function registerMcpxCommand(program: Command) {
   const mcpx = program
     .command("mcpx")
@@ -69,11 +93,32 @@ export function registerMcpxCommand(program: Command) {
 
   // --- info ---
   mcpx
-    .command("info <server> [tool]")
-    .description("Show server overview, or schema for a specific tool")
-    .action(async (server: string, tool?: string) => {
+    .command("info <first> [second]")
+    .description(
+      "Show server overview, or schema for a specific tool (server is optional if tool name is unambiguous)",
+    )
+    .action(async (first: string, second?: string) => {
       const client = await getClient(program);
       try {
+        let server: string;
+        let tool: string | undefined;
+
+        if (second) {
+          // info <server> <tool>
+          server = first;
+          tool = second;
+        } else {
+          // Could be a server name or a tool name
+          const serverNames = await client.getServerNames();
+          if (serverNames.includes(first)) {
+            server = first;
+          } else {
+            // Treat as tool name, resolve server
+            server = await resolveServer(client, first);
+            tool = first;
+          }
+        }
+
         if (tool) {
           const schema = await client.info(server, tool);
           if (!schema) {
@@ -145,11 +190,48 @@ export function registerMcpxCommand(program: Command) {
 
   // --- exec ---
   mcpx
-    .command("exec <server> <tool> [args-json]")
-    .description("Execute a tool call")
-    .action(async (server: string, tool: string, argsJson?: string) => {
+    .command("exec <first> [second] [third]")
+    .description(
+      "Execute a tool call (server is optional if tool name is unambiguous)",
+    )
+    .action(async (first: string, second?: string, third?: string) => {
       const client = await getClient(program);
       try {
+        let server: string;
+        let tool: string;
+        let argsJson: string | undefined;
+
+        if (second && third) {
+          // exec <server> <tool> <args-json>
+          server = first;
+          tool = second;
+          argsJson = third;
+        } else if (second) {
+          // Could be: exec <server> <tool> OR exec <tool> <args-json>
+          // Try to parse second as JSON — if it parses, first is tool
+          let parsedAsArgs = false;
+          try {
+            JSON.parse(second);
+            parsedAsArgs = true;
+          } catch {
+            // not JSON, treat as exec <server> <tool>
+          }
+
+          if (parsedAsArgs) {
+            const resolved = await resolveServer(client, first);
+            server = resolved;
+            tool = first;
+            argsJson = second;
+          } else {
+            server = first;
+            tool = second;
+          }
+        } else {
+          // exec <tool> — resolve server automatically
+          server = await resolveServer(client, first);
+          tool = first;
+        }
+
         const args = argsJson ? JSON.parse(argsJson) : {};
         const result = await client.exec(server, tool, args);
         console.log(formatCallToolResult(result));

--- a/src/commands/tools.ts
+++ b/src/commands/tools.ts
@@ -101,6 +101,7 @@ function registerToolAsCLI(
           conn,
           projectDir: dir,
           config: DEFAULT_CONFIG as Required<BotholomewConfig>,
+          mcpxClient: null,
         };
 
         const result = await tool.execute(input, ctx);

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -3,6 +3,7 @@ import { getDbPath } from "../constants.ts";
 import { warmupEmbedder } from "../context/embedder.ts";
 import { getConnection } from "../db/connection.ts";
 import { migrate } from "../db/schema.ts";
+import { createMcpxClient } from "../mcpx/client.ts";
 import { logger } from "../utils/logger.ts";
 import { removePidFile, writePidFile } from "../utils/pid.ts";
 import { tick } from "./tick.ts";
@@ -16,10 +17,17 @@ export async function startDaemon(projectDir: string): Promise<void> {
   // Ensure embedding model is downloaded and loaded before accepting work
   await warmupEmbedder();
 
+  // Initialize MCPX client for external tool access
+  const mcpxClient = await createMcpxClient(projectDir);
+  if (mcpxClient) {
+    logger.info("MCPX client initialized with external tools");
+  }
+
   writePidFile(projectDir, process.pid);
 
   const shutdown = async () => {
     logger.info("Daemon shutting down...");
+    await mcpxClient?.close();
     await removePidFile(projectDir);
     conn.close();
     process.exit(0);
@@ -33,7 +41,7 @@ export async function startDaemon(projectDir: string): Promise<void> {
 
   while (true) {
     try {
-      await tick(projectDir, conn, config);
+      await tick(projectDir, conn, config, mcpxClient);
     } catch (err) {
       logger.error(`Tick failed: ${err}`);
     }

--- a/src/daemon/llm.ts
+++ b/src/daemon/llm.ts
@@ -4,6 +4,7 @@ import type {
   ToolResultBlockParam,
   ToolUseBlock,
 } from "@anthropic-ai/sdk/resources/messages";
+import type { McpxClient } from "@evantahler/mcpx";
 import type { BotholomewConfig } from "../config/schemas.ts";
 import type { DbConnection } from "../db/connection.ts";
 import type { Task } from "../db/tasks.ts";
@@ -31,6 +32,7 @@ export async function runAgentLoop(input: {
   conn: DbConnection;
   threadId: string;
   projectDir: string;
+  mcpxClient?: McpxClient | null;
 }): Promise<AgentLoopResult> {
   const { systemPrompt, task, config, conn, threadId, projectDir } = input;
 
@@ -38,7 +40,12 @@ export async function runAgentLoop(input: {
     apiKey: config.anthropic_api_key || undefined,
   });
 
-  const toolCtx: ToolContext = { conn, projectDir, config };
+  const toolCtx: ToolContext = {
+    conn,
+    projectDir,
+    config,
+    mcpxClient: input.mcpxClient ?? null,
+  };
 
   const userMessage = `Please work on this task:\n\nName: ${task.name}\nDescription: ${task.description}\nPriority: ${task.priority}\n\nUse the available tools to complete this task, then call complete_task, fail_task, or wait_task to indicate the outcome.`;
 

--- a/src/daemon/prompt.ts
+++ b/src/daemon/prompt.ts
@@ -18,6 +18,7 @@ export async function buildSystemPrompt(
   task?: Task,
   conn?: DbConnection,
   _config?: Required<BotholomewConfig>,
+  options?: { hasMcpTools?: boolean },
 ): Promise<string> {
   const dotDir = getBotholomewDir(projectDir);
   const parts: string[] = [];
@@ -105,6 +106,13 @@ export async function buildSystemPrompt(
     "Always call complete_task, fail_task, or wait_task when you are done.",
   );
   parts.push("If you need to create subtasks, use create_task.");
+  if (options?.hasMcpTools) {
+    parts.push("");
+    parts.push("## External Tools (MCP)");
+    parts.push(
+      "You have access to external tools via MCP servers. Use `mcp_list_tools` or `mcp_search` to discover available tools, `mcp_info` to get a tool's input schema, then `mcp_exec` to call them.",
+    );
+  }
   parts.push("");
 
   return parts.join("\n");

--- a/src/daemon/tick.ts
+++ b/src/daemon/tick.ts
@@ -1,3 +1,4 @@
+import type { McpxClient } from "@evantahler/mcpx";
 import type { BotholomewConfig } from "../config/schemas.ts";
 import type { DbConnection } from "../db/connection.ts";
 import {
@@ -15,6 +16,7 @@ export async function tick(
   projectDir: string,
   conn: DbConnection,
   config: Required<BotholomewConfig>,
+  mcpxClient?: McpxClient | null,
 ): Promise<void> {
   logger.debug("Tick starting...");
 
@@ -54,7 +56,9 @@ export async function tick(
   );
 
   // Build system prompt (includes task-relevant context from embeddings)
-  const systemPrompt = await buildSystemPrompt(projectDir, task, conn, config);
+  const systemPrompt = await buildSystemPrompt(projectDir, task, conn, config, {
+    hasMcpTools: mcpxClient != null,
+  });
 
   try {
     const result = await runAgentLoop({
@@ -64,6 +68,7 @@ export async function tick(
       conn,
       threadId,
       projectDir,
+      mcpxClient,
     });
 
     // Update task status

--- a/src/mcpx/client.ts
+++ b/src/mcpx/client.ts
@@ -20,7 +20,13 @@ export async function createMcpxClient(
     return null;
   }
 
-  return new McpxClient({ servers: parsed });
+  const mcpxDir = getMcpxDir(projectDir);
+  const authPath = join(mcpxDir, "auth.json");
+  const auth = existsSync(authPath)
+    ? JSON.parse(await Bun.file(authPath).text())
+    : {};
+
+  return new McpxClient({ servers: parsed, auth, configDir: mcpxDir });
 }
 
 /**

--- a/src/mcpx/client.ts
+++ b/src/mcpx/client.ts
@@ -26,7 +26,17 @@ export async function createMcpxClient(
     ? JSON.parse(await Bun.file(authPath).text())
     : {};
 
-  return new McpxClient({ servers: parsed, auth, configDir: mcpxDir });
+  const searchPath = join(mcpxDir, "search.json");
+  const searchIndex = existsSync(searchPath)
+    ? JSON.parse(await Bun.file(searchPath).text())
+    : undefined;
+
+  return new McpxClient({
+    servers: parsed,
+    auth,
+    searchIndex,
+    configDir: mcpxDir,
+  });
 }
 
 /**

--- a/src/mcpx/client.ts
+++ b/src/mcpx/client.ts
@@ -1,0 +1,51 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { type CallToolResult, McpxClient } from "@evantahler/mcpx";
+import { getMcpxDir, MCPX_SERVERS_FILENAME } from "../constants.ts";
+
+/**
+ * Create an McpxClient from the project's .botholomew/mcpx/servers.json.
+ * Returns null if the file is missing or has no servers configured.
+ */
+export async function createMcpxClient(
+  projectDir: string,
+): Promise<McpxClient | null> {
+  const serversPath = join(getMcpxDir(projectDir), MCPX_SERVERS_FILENAME);
+  if (!existsSync(serversPath)) return null;
+
+  const raw = await Bun.file(serversPath).text();
+  const parsed = JSON.parse(raw);
+
+  if (!parsed.mcpServers || Object.keys(parsed.mcpServers).length === 0) {
+    return null;
+  }
+
+  return new McpxClient({ servers: parsed });
+}
+
+/**
+ * Serialize a CallToolResult's content array into a plain text string.
+ */
+export function formatCallToolResult(result: CallToolResult): string {
+  if (!result.content || !Array.isArray(result.content)) {
+    return JSON.stringify(result);
+  }
+
+  const parts: string[] = [];
+  for (const block of result.content) {
+    if (block.type === "text") {
+      parts.push(block.text ?? "");
+    } else if (block.type === "image") {
+      parts.push(`[image: ${block.mimeType}]`);
+    } else if (block.type === "resource") {
+      const uri =
+        typeof block.resource === "object"
+          ? (block.resource as Record<string, unknown>).uri
+          : block.resource;
+      parts.push(`[resource: ${uri}]`);
+    } else {
+      parts.push(JSON.stringify(block));
+    }
+  }
+  return parts.join("\n");
+}

--- a/src/tools/mcp/exec.ts
+++ b/src/tools/mcp/exec.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+import { formatCallToolResult } from "../../mcpx/client.ts";
+import type { ToolDefinition } from "../tool.ts";
+
+const inputSchema = z.object({
+  server: z.string().describe("MCP server name"),
+  tool: z.string().describe("Tool name on the server"),
+  args: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe("Tool arguments as a JSON object"),
+});
+
+const outputSchema = z.object({
+  result: z.string(),
+  is_error: z.boolean(),
+});
+
+export const mcpExecTool = {
+  name: "mcp_exec",
+  description:
+    "Execute a tool on an MCP server. Use mcp_list_tools or mcp_search to discover available tools first.",
+  group: "mcp",
+  inputSchema,
+  outputSchema,
+  execute: async (input, ctx) => {
+    if (!ctx.mcpxClient) {
+      return {
+        result:
+          "No MCP servers configured. Add servers with `botholomew mcpx add`.",
+        is_error: true,
+      };
+    }
+
+    try {
+      const callResult = await ctx.mcpxClient.exec(
+        input.server,
+        input.tool,
+        input.args,
+      );
+      return {
+        result: formatCallToolResult(callResult),
+        is_error: callResult.isError ?? false,
+      };
+    } catch (err) {
+      return {
+        result: `MCP tool error: ${err}`,
+        is_error: true,
+      };
+    }
+  },
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/mcp/info.ts
+++ b/src/tools/mcp/info.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+import type { ToolDefinition } from "../tool.ts";
+
+const inputSchema = z.object({
+  server: z.string().describe("MCP server name"),
+  tool: z.string().describe("Tool name to describe"),
+});
+
+const outputSchema = z.object({
+  found: z.boolean(),
+  name: z.string(),
+  description: z.string(),
+  input_schema: z.string(),
+});
+
+export const mcpInfoTool = {
+  name: "mcp_info",
+  description:
+    "Get the full schema (name, description, input parameters) for a specific MCP tool. Use this before calling mcp_exec to understand the required arguments.",
+  group: "mcp",
+  inputSchema,
+  outputSchema,
+  execute: async (input, ctx) => {
+    if (!ctx.mcpxClient) {
+      return {
+        found: false,
+        name: input.tool,
+        description: "No MCP servers configured.",
+        input_schema: "{}",
+      };
+    }
+
+    const tool = await ctx.mcpxClient.info(input.server, input.tool);
+    if (!tool) {
+      return {
+        found: false,
+        name: input.tool,
+        description: `Tool "${input.tool}" not found on server "${input.server}".`,
+        input_schema: "{}",
+      };
+    }
+
+    return {
+      found: true,
+      name: tool.name,
+      description: tool.description ?? "",
+      input_schema: JSON.stringify(tool.inputSchema ?? {}, null, 2),
+    };
+  },
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/mcp/list-tools.ts
+++ b/src/tools/mcp/list-tools.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+import type { ToolDefinition } from "../tool.ts";
+
+const inputSchema = z.object({
+  server: z
+    .string()
+    .optional()
+    .describe("Filter tools to a specific MCP server name"),
+});
+
+const ToolEntrySchema = z.object({
+  server: z.string(),
+  name: z.string(),
+  description: z.string(),
+});
+
+const outputSchema = z.object({
+  tools: z.array(ToolEntrySchema),
+});
+
+export const mcpListToolsTool = {
+  name: "mcp_list_tools",
+  description:
+    "List available tools from configured MCP servers. Optionally filter by server name.",
+  group: "mcp",
+  inputSchema,
+  outputSchema,
+  execute: async (input, ctx) => {
+    if (!ctx.mcpxClient) {
+      return { tools: [] };
+    }
+
+    const toolsWithServer = await ctx.mcpxClient.listTools(input.server);
+    return {
+      tools: toolsWithServer.map((t) => ({
+        server: t.server,
+        name: t.tool.name,
+        description: t.tool.description ?? "",
+      })),
+    };
+  },
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/mcp/search.ts
+++ b/src/tools/mcp/search.ts
@@ -3,6 +3,14 @@ import type { ToolDefinition } from "../tool.ts";
 
 const inputSchema = z.object({
   query: z.string().describe("Search query for finding MCP tools"),
+  keyword_only: z
+    .boolean()
+    .optional()
+    .describe("Only use keyword matching (skip semantic search)"),
+  semantic_only: z
+    .boolean()
+    .optional()
+    .describe("Only use semantic matching (skip keyword search)"),
 });
 
 const SearchResultSchema = z.object({
@@ -10,6 +18,7 @@ const SearchResultSchema = z.object({
   tool: z.string(),
   description: z.string(),
   score: z.number(),
+  match_type: z.string(),
 });
 
 const outputSchema = z.object({
@@ -19,7 +28,7 @@ const outputSchema = z.object({
 export const mcpSearchTool = {
   name: "mcp_search",
   description:
-    "Search for MCP tools by keyword and/or semantic similarity. Requires a pre-built search index (run `botholomew mcpx index`).",
+    "Search for MCP tools by keyword, semantic similarity, or both. Requires a pre-built search index (run `botholomew mcpx index`).",
   group: "mcp",
   inputSchema,
   outputSchema,
@@ -29,13 +38,17 @@ export const mcpSearchTool = {
     }
 
     try {
-      const results = await ctx.mcpxClient.search(input.query);
+      const results = await ctx.mcpxClient.search(input.query, {
+        keywordOnly: input.keyword_only,
+        semanticOnly: input.semantic_only,
+      });
       return {
         results: results.map((r) => ({
           server: r.server,
           tool: r.tool,
           description: r.description ?? "",
           score: r.score,
+          match_type: r.matchType ?? "keyword",
         })),
       };
     } catch {

--- a/src/tools/mcp/search.ts
+++ b/src/tools/mcp/search.ts
@@ -28,7 +28,7 @@ const outputSchema = z.object({
 export const mcpSearchTool = {
   name: "mcp_search",
   description:
-    "Search for MCP tools by keyword, semantic similarity, or both. Requires a pre-built search index (run `botholomew mcpx index`).",
+    "Search for MCP tools by keyword, semantic similarity, or both. By default uses hybrid search (keyword + semantic). Set keyword_only=true for exact term matching or semantic_only=true for meaning-based similarity. Requires a pre-built search index (run `botholomew mcpx index`).",
   group: "mcp",
   inputSchema,
   outputSchema,

--- a/src/tools/mcp/search.ts
+++ b/src/tools/mcp/search.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+import type { ToolDefinition } from "../tool.ts";
+
+const inputSchema = z.object({
+  query: z.string().describe("Search query for finding MCP tools"),
+});
+
+const SearchResultSchema = z.object({
+  server: z.string(),
+  tool: z.string(),
+  description: z.string(),
+  score: z.number(),
+});
+
+const outputSchema = z.object({
+  results: z.array(SearchResultSchema),
+});
+
+export const mcpSearchTool = {
+  name: "mcp_search",
+  description:
+    "Search for MCP tools by keyword and/or semantic similarity. Requires a pre-built search index (run `botholomew mcpx index`).",
+  group: "mcp",
+  inputSchema,
+  outputSchema,
+  execute: async (input, ctx) => {
+    if (!ctx.mcpxClient) {
+      return { results: [] };
+    }
+
+    try {
+      const results = await ctx.mcpxClient.search(input.query);
+      return {
+        results: results.map((r) => ({
+          server: r.server,
+          tool: r.tool,
+          description: r.description ?? "",
+          score: r.score,
+        })),
+      };
+    } catch {
+      return { results: [] };
+    }
+  },
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -13,6 +13,11 @@ import { fileMoveTool } from "./file/move.ts";
 // File tools
 import { fileReadTool } from "./file/read.ts";
 import { fileWriteTool } from "./file/write.ts";
+// MCP tools
+import { mcpExecTool } from "./mcp/exec.ts";
+import { mcpInfoTool } from "./mcp/info.ts";
+import { mcpListToolsTool } from "./mcp/list-tools.ts";
+import { mcpSearchTool } from "./mcp/search.ts";
 // Schedule tools
 import { createScheduleTool } from "./schedule/create.ts";
 import { listSchedulesTool } from "./schedule/list.ts";
@@ -57,4 +62,10 @@ export function registerAllTools(): void {
   // Search
   registerTool(searchGrepTool);
   registerTool(searchSemanticTool);
+
+  // MCP
+  registerTool(mcpListToolsTool);
+  registerTool(mcpSearchTool);
+  registerTool(mcpInfoTool);
+  registerTool(mcpExecTool);
 }

--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -1,4 +1,5 @@
 import type { Tool as AnthropicTool } from "@anthropic-ai/sdk/resources/messages";
+import type { McpxClient } from "@evantahler/mcpx";
 import { z } from "zod";
 import type { BotholomewConfig } from "../config/schemas.ts";
 import type { DbConnection } from "../db/connection.ts";
@@ -7,6 +8,7 @@ export interface ToolContext {
   conn: DbConnection;
   projectDir: string;
   config: Required<BotholomewConfig>;
+  mcpxClient: McpxClient | null;
 }
 
 export interface ToolDefinition<

--- a/test/commands/mcpx.test.ts
+++ b/test/commands/mcpx.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { runMcpx } from "../../src/commands/mcpx.ts";
+
+const TMP_DIR = join(import.meta.dir, ".tmp-mcpx-cmd-test");
+const MCPX_DIR = join(TMP_DIR, ".botholomew", "mcpx");
+
+afterEach(() => {
+  if (existsSync(TMP_DIR)) {
+    rmSync(TMP_DIR, { recursive: true });
+  }
+});
+
+describe("mcpx CLI proxy", () => {
+  test("servers returns empty array when no config exists", async () => {
+    const out = await runMcpx(TMP_DIR, ["servers"]);
+    expect(JSON.parse(out)).toEqual([]);
+  });
+
+  test("servers returns configured server names", async () => {
+    mkdirSync(MCPX_DIR, { recursive: true });
+    await Bun.write(
+      join(MCPX_DIR, "servers.json"),
+      JSON.stringify({
+        mcpServers: {
+          echo: { command: "echo", args: ["hello"] },
+        },
+      }),
+    );
+    const out = await runMcpx(TMP_DIR, ["servers"]);
+    const servers = JSON.parse(out);
+    expect(servers).toHaveLength(1);
+    expect(servers[0].name).toBe("echo");
+  });
+
+  test("filters out undefined args", async () => {
+    const out = await runMcpx(TMP_DIR, ["servers", undefined]);
+    expect(JSON.parse(out)).toEqual([]);
+  });
+});

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -18,6 +18,7 @@ export function setupToolContext(): { conn: DbConnection; ctx: ToolContext } {
     conn,
     projectDir: "/tmp/test",
     config: { ...DEFAULT_CONFIG },
+    mcpxClient: null,
   };
   return { conn, ctx };
 }

--- a/test/mcpx/client.test.ts
+++ b/test/mcpx/client.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import {
+  createMcpxClient,
+  formatCallToolResult,
+} from "../../src/mcpx/client.ts";
+
+const TMP_DIR = join(import.meta.dir, ".tmp-mcpx-test");
+const MCPX_DIR = join(TMP_DIR, ".botholomew", "mcpx");
+
+async function writeTmpServers(content: unknown) {
+  mkdirSync(MCPX_DIR, { recursive: true });
+  await Bun.write(join(MCPX_DIR, "servers.json"), JSON.stringify(content));
+}
+
+afterEach(() => {
+  if (existsSync(TMP_DIR)) {
+    rmSync(TMP_DIR, { recursive: true });
+  }
+});
+
+describe("createMcpxClient", () => {
+  test("returns null when servers.json does not exist", async () => {
+    const client = await createMcpxClient(TMP_DIR);
+    expect(client).toBeNull();
+  });
+
+  test("returns null when mcpServers is empty", async () => {
+    await writeTmpServers({ mcpServers: {} });
+    const client = await createMcpxClient(TMP_DIR);
+    expect(client).toBeNull();
+  });
+
+  test("returns McpxClient when servers are configured", async () => {
+    await writeTmpServers({
+      mcpServers: {
+        echo: { command: "echo", args: ["hello"] },
+      },
+    });
+    const client = await createMcpxClient(TMP_DIR);
+    expect(client).not.toBeNull();
+    await client?.close();
+  });
+});
+
+describe("formatCallToolResult", () => {
+  test("formats text content", () => {
+    const result = formatCallToolResult({
+      content: [
+        { type: "text" as const, text: "Hello" },
+        { type: "text" as const, text: "World" },
+      ],
+    });
+    expect(result).toBe("Hello\nWorld");
+  });
+
+  test("formats image content", () => {
+    const result = formatCallToolResult({
+      content: [{ type: "image" as const, data: "...", mimeType: "image/png" }],
+    });
+    expect(result).toBe("[image: image/png]");
+  });
+
+  test("formats resource content", () => {
+    const result = formatCallToolResult({
+      content: [
+        {
+          type: "resource" as const,
+          resource: { uri: "file:///test.txt", text: "content" },
+        },
+      ],
+    });
+    expect(result).toBe("[resource: file:///test.txt]");
+  });
+
+  test("handles unknown block types", () => {
+    // Cast to any to simulate an unexpected content type from an MCP server
+    const result = formatCallToolResult({
+      content: [{ type: "custom", data: "something" }] as never,
+    });
+    expect(result).toContain("custom");
+  });
+
+  test("handles missing content array", () => {
+    const result = formatCallToolResult({} as never);
+    expect(typeof result).toBe("string");
+  });
+});

--- a/test/tools/mcp/exec.test.ts
+++ b/test/tools/mcp/exec.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { McpxClient } from "@evantahler/mcpx";
+import { mcpExecTool } from "../../../src/tools/mcp/exec.ts";
+import { setupToolContext } from "../../helpers.ts";
+
+function mockClient(
+  response: { content: Array<{ type: string; text?: string }> },
+  isError = false,
+): McpxClient {
+  return {
+    exec: mock(async () => ({
+      ...response,
+      isError,
+    })),
+  } as unknown as McpxClient;
+}
+
+describe("mcp_exec", () => {
+  test("returns error message when mcpxClient is null", async () => {
+    const { ctx } = setupToolContext();
+    const result = await mcpExecTool.execute(
+      { server: "gmail", tool: "send_email" },
+      ctx,
+    );
+    expect(result.is_error).toBe(true);
+    expect(result.result).toContain("No MCP servers configured");
+  });
+
+  test("executes tool and returns formatted result", async () => {
+    const { ctx } = setupToolContext();
+    ctx.mcpxClient = mockClient({
+      content: [{ type: "text", text: "Email sent successfully" }],
+    });
+
+    const result = await mcpExecTool.execute(
+      { server: "gmail", tool: "send_email", args: { to: "test@test.com" } },
+      ctx,
+    );
+    expect(result.is_error).toBe(false);
+    expect(result.result).toBe("Email sent successfully");
+  });
+
+  test("propagates isError from tool result", async () => {
+    const { ctx } = setupToolContext();
+    ctx.mcpxClient = mockClient(
+      {
+        content: [{ type: "text", text: "Auth failed" }],
+      },
+      true,
+    );
+
+    const result = await mcpExecTool.execute(
+      { server: "gmail", tool: "send_email" },
+      ctx,
+    );
+    expect(result.is_error).toBe(true);
+    expect(result.result).toBe("Auth failed");
+  });
+
+  test("handles exec throwing", async () => {
+    const { ctx } = setupToolContext();
+    ctx.mcpxClient = {
+      exec: mock(async () => {
+        throw new Error("Connection refused");
+      }),
+    } as unknown as McpxClient;
+
+    const result = await mcpExecTool.execute(
+      { server: "gmail", tool: "send_email" },
+      ctx,
+    );
+    expect(result.is_error).toBe(true);
+    expect(result.result).toContain("Connection refused");
+  });
+
+  test("passes args through to exec", async () => {
+    const { ctx } = setupToolContext();
+    const execMock = mock(async () => ({
+      content: [{ type: "text" as const, text: "ok" }],
+      isError: false,
+    }));
+    ctx.mcpxClient = { exec: execMock } as unknown as McpxClient;
+
+    await mcpExecTool.execute(
+      { server: "srv", tool: "fn", args: { key: "val" } },
+      ctx,
+    );
+    expect(execMock).toHaveBeenCalledWith("srv", "fn", { key: "val" });
+  });
+});

--- a/test/tools/mcp/info.test.ts
+++ b/test/tools/mcp/info.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { McpxClient } from "@evantahler/mcpx";
+import { mcpInfoTool } from "../../../src/tools/mcp/info.ts";
+import { setupToolContext } from "../../helpers.ts";
+
+describe("mcp_info", () => {
+  test("returns not found when mcpxClient is null", async () => {
+    const { ctx } = setupToolContext();
+    const result = await mcpInfoTool.execute(
+      { server: "gmail", tool: "send_email" },
+      ctx,
+    );
+    expect(result.found).toBe(false);
+    expect(result.description).toContain("No MCP servers configured");
+  });
+
+  test("returns not found for unknown tool", async () => {
+    const { ctx } = setupToolContext();
+    ctx.mcpxClient = {
+      info: mock(async () => undefined),
+    } as unknown as McpxClient;
+
+    const result = await mcpInfoTool.execute(
+      { server: "gmail", tool: "nonexistent" },
+      ctx,
+    );
+    expect(result.found).toBe(false);
+    expect(result.description).toContain("not found");
+  });
+
+  test("returns tool schema when found", async () => {
+    const { ctx } = setupToolContext();
+    ctx.mcpxClient = {
+      info: mock(async () => ({
+        name: "send_email",
+        description: "Send an email message",
+        inputSchema: {
+          type: "object",
+          properties: {
+            to: { type: "string", description: "Recipient" },
+            subject: { type: "string", description: "Subject line" },
+            body: { type: "string", description: "Email body" },
+          },
+          required: ["to", "subject", "body"],
+        },
+      })),
+    } as unknown as McpxClient;
+
+    const result = await mcpInfoTool.execute(
+      { server: "gmail", tool: "send_email" },
+      ctx,
+    );
+    expect(result.found).toBe(true);
+    expect(result.name).toBe("send_email");
+    expect(result.description).toBe("Send an email message");
+    const schema = JSON.parse(result.input_schema);
+    expect(schema.properties.to.type).toBe("string");
+    expect(schema.required).toContain("to");
+  });
+
+  test("handles tool with no inputSchema", async () => {
+    const { ctx } = setupToolContext();
+    ctx.mcpxClient = {
+      info: mock(async () => ({
+        name: "ping",
+        description: "Ping the server",
+      })),
+    } as unknown as McpxClient;
+
+    const result = await mcpInfoTool.execute(
+      { server: "health", tool: "ping" },
+      ctx,
+    );
+    expect(result.found).toBe(true);
+    expect(result.input_schema).toBe("{}");
+  });
+});

--- a/test/tools/mcp/list-tools.test.ts
+++ b/test/tools/mcp/list-tools.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { McpxClient } from "@evantahler/mcpx";
+import { mcpListToolsTool } from "../../../src/tools/mcp/list-tools.ts";
+import { setupToolContext } from "../../helpers.ts";
+
+function mockClient(
+  tools: Array<{ server: string; name: string; description: string }>,
+): McpxClient {
+  return {
+    listTools: mock(async (server?: string) => {
+      const filtered = server
+        ? tools.filter((t) => t.server === server)
+        : tools;
+      return filtered.map((t) => ({
+        server: t.server,
+        tool: { name: t.name, description: t.description },
+      }));
+    }),
+  } as unknown as McpxClient;
+}
+
+describe("mcp_list_tools", () => {
+  test("returns empty array when mcpxClient is null", async () => {
+    const { ctx } = setupToolContext();
+    const result = await mcpListToolsTool.execute({}, ctx);
+    expect(result.tools).toEqual([]);
+  });
+
+  test("lists all tools from all servers", async () => {
+    const { ctx } = setupToolContext();
+    ctx.mcpxClient = mockClient([
+      { server: "gmail", name: "send_email", description: "Send email" },
+      { server: "slack", name: "post_message", description: "Post message" },
+    ]);
+
+    const result = await mcpListToolsTool.execute({}, ctx);
+    expect(result.tools).toHaveLength(2);
+    expect(result.tools[0]).toEqual({
+      server: "gmail",
+      name: "send_email",
+      description: "Send email",
+    });
+  });
+
+  test("filters by server name", async () => {
+    const { ctx } = setupToolContext();
+    ctx.mcpxClient = mockClient([
+      { server: "gmail", name: "send_email", description: "Send email" },
+      { server: "slack", name: "post_message", description: "Post message" },
+    ]);
+
+    const result = await mcpListToolsTool.execute({ server: "gmail" }, ctx);
+    expect(result.tools).toHaveLength(1);
+    expect(result.tools[0]?.server).toBe("gmail");
+  });
+});

--- a/test/tools/mcp/search.test.ts
+++ b/test/tools/mcp/search.test.ts
@@ -9,6 +9,7 @@ function mockClient(
     tool: string;
     description: string;
     score: number;
+    matchType?: string;
   }>,
 ): McpxClient {
   return {
@@ -31,6 +32,7 @@ describe("mcp_search", () => {
         tool: "send_email",
         description: "Send email",
         score: 0.95,
+        matchType: "both",
       },
     ]);
 
@@ -41,6 +43,7 @@ describe("mcp_search", () => {
       tool: "send_email",
       description: "Send email",
       score: 0.95,
+      match_type: "both",
     });
   });
 

--- a/test/tools/mcp/search.test.ts
+++ b/test/tools/mcp/search.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { McpxClient } from "@evantahler/mcpx";
+import { mcpSearchTool } from "../../../src/tools/mcp/search.ts";
+import { setupToolContext } from "../../helpers.ts";
+
+function mockClient(
+  results: Array<{
+    server: string;
+    tool: string;
+    description: string;
+    score: number;
+  }>,
+): McpxClient {
+  return {
+    search: mock(async () => results),
+  } as unknown as McpxClient;
+}
+
+describe("mcp_search", () => {
+  test("returns empty results when mcpxClient is null", async () => {
+    const { ctx } = setupToolContext();
+    const result = await mcpSearchTool.execute({ query: "email" }, ctx);
+    expect(result.results).toEqual([]);
+  });
+
+  test("returns search results", async () => {
+    const { ctx } = setupToolContext();
+    ctx.mcpxClient = mockClient([
+      {
+        server: "gmail",
+        tool: "send_email",
+        description: "Send email",
+        score: 0.95,
+      },
+    ]);
+
+    const result = await mcpSearchTool.execute({ query: "email" }, ctx);
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]).toEqual({
+      server: "gmail",
+      tool: "send_email",
+      description: "Send email",
+      score: 0.95,
+    });
+  });
+
+  test("returns empty results when search throws", async () => {
+    const { ctx } = setupToolContext();
+    ctx.mcpxClient = {
+      search: mock(async () => {
+        throw new Error("No search index");
+      }),
+    } as unknown as McpxClient;
+
+    const result = await mcpSearchTool.execute({ query: "email" }, ctx);
+    expect(result.results).toEqual([]);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src/**/*", "test/**/*"]
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary

- Adds `@evantahler/mcpx` as a dependency for external tool access via MCP servers
- Introduces 4 agent meta-tools (`mcp_list_tools`, `mcp_search`, `mcp_info`, `mcp_exec`) that let the daemon discover and call MCP tools on demand without context bloat
- Implements full `botholomew mcpx` CLI mirroring mcpx commands: `servers`, `info`, `search`, `exec`, `add`, `remove`, `ping`, `auth`, `resource`, `prompt`, `task`, `index`, and `import-global`
- Threads `McpxClient` through the daemon lifecycle (create on startup, pass through tick/agent loop via `ToolContext`, close on shutdown)
- Adds 23 new tests across 5 test files; all 317 tests pass with clean lint

## Test plan

- [ ] `bun run lint` passes
- [ ] `bun test` passes (317 tests)
- [ ] `botholomew mcpx add` / `remove` / `servers` manage config correctly
- [ ] `botholomew mcpx import-global` copies ~/.mcpx into project
- [ ] Daemon with MCP servers configured provides meta-tools to agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)