### PR TITLE
Update init defaults: placeholder API key and opus model

### DIFF
--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -36,7 +36,7 @@ export async function initProject(
   await Bun.write(join(dotDir, "beliefs.md"), BELIEFS_MD);
   await Bun.write(join(dotDir, "goals.md"), GOALS_MD);
 
-  // Write config (without API key)
+  // Write config (with placeholder API key)
   await Bun.write(
     join(dotDir, "config.json"),
     `${JSON.stringify(DEFAULT_CONFIG, null, 2)}\n`,

--- a/src/init/templates.ts
+++ b/src/init/templates.ts
@@ -38,7 +38,8 @@ agent-modification: true
 `;
 
 export const DEFAULT_CONFIG = {
-  model: "claude-sonnet-4-20250514",
+  anthropic_api_key: "your-api-key-here",
+  model: "claude-opus-4-20250514",
   tick_interval_seconds: 300,
   max_tick_duration_seconds: 120,
 };

--- a/test/init/index.test.ts
+++ b/test/init/index.test.ts
@@ -55,16 +55,16 @@ describe("initProject", () => {
     expect(meta["agent-modification"]).toBe(true);
   });
 
-  test("config.json has defaults without API key", async () => {
+  test("config.json has defaults with placeholder API key", async () => {
     tempDir = await mkdtemp(join(tmpdir(), "botholomew-test-"));
     await initProject(tempDir);
 
     const config = JSON.parse(
       await Bun.file(join(tempDir, ".botholomew", "config.json")).text(),
     );
-    expect(config.model).toBe("claude-sonnet-4-20250514");
+    expect(config.model).toBe("claude-opus-4-20250514");
     expect(config.tick_interval_seconds).toBe(300);
-    expect(config.anthropic_api_key).toBeUndefined();
+    expect(config.anthropic_api_key).toBe("your-api-key-here");
   });
 
   test("throws if already initialized without --force", async () => {


### PR DESCRIPTION
## Summary
- `botholomew init` now writes `anthropic_api_key: "your-api-key-here"` as a placeholder in `config.json` so users know where to set their key
- Default model changed from `claude-sonnet-4` to `claude-opus-4`
- Tests updated to match new defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)