### PR TITLE
Add interactive chat TUI with streaming and tool calls (M5)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,8 @@
         "commander": "^14.0.0",
         "gray-matter": "^4.0.3",
         "ink": "^6.0.0",
+        "ink-spinner": "^5.0.0",
+        "ink-text-input": "^6.0.0",
         "istextorbinary": "^9.5.0",
         "react": "^19.1.0",
         "uuid": "^13.0.0",
@@ -206,6 +208,8 @@
 
     "cli-cursor": ["cli-cursor@4.0.0", "", { "dependencies": { "restore-cursor": "^4.0.0" } }, "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg=="],
 
+    "cli-spinners": ["cli-spinners@2.9.2", "", {}, "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg=="],
+
     "cli-truncate": ["cli-truncate@5.2.0", "", { "dependencies": { "slice-ansi": "^8.0.0", "string-width": "^8.2.0" } }, "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw=="],
 
     "code-excerpt": ["code-excerpt@4.0.0", "", { "dependencies": { "convert-to-spaces": "^2.0.1" } }, "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA=="],
@@ -327,6 +331,10 @@
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "ink": ["ink@6.8.0", "", { "dependencies": { "@alcalzone/ansi-tokenize": "^0.2.4", "ansi-escapes": "^7.3.0", "ansi-styles": "^6.2.1", "auto-bind": "^5.0.1", "chalk": "^5.6.0", "cli-boxes": "^3.0.0", "cli-cursor": "^4.0.0", "cli-truncate": "^5.1.1", "code-excerpt": "^4.0.0", "es-toolkit": "^1.39.10", "indent-string": "^5.0.0", "is-in-ci": "^2.0.0", "patch-console": "^2.0.0", "react-reconciler": "^0.33.0", "scheduler": "^0.27.0", "signal-exit": "^3.0.7", "slice-ansi": "^8.0.0", "stack-utils": "^2.0.6", "string-width": "^8.1.1", "terminal-size": "^4.0.1", "type-fest": "^5.4.1", "widest-line": "^6.0.0", "wrap-ansi": "^9.0.0", "ws": "^8.18.0", "yoga-layout": "~3.2.1" }, "peerDependencies": { "@types/react": ">=19.0.0", "react": ">=19.0.0", "react-devtools-core": ">=6.1.2" }, "optionalPeers": ["@types/react", "react-devtools-core"] }, "sha512-sbl1RdLOgkO9isK42WCZlJCFN9hb++sX9dsklOvfd1YQ3bQ2AiFu12Q6tFlr0HvEUvzraJntQCCpfEoUe9DSzA=="],
+
+    "ink-spinner": ["ink-spinner@5.0.0", "", { "dependencies": { "cli-spinners": "^2.7.0" }, "peerDependencies": { "ink": ">=4.0.0", "react": ">=18.0.0" } }, "sha512-EYEasbEjkqLGyPOUc8hBJZNuC5GvXGMLu0w5gdTNskPc7Izc5vO3tdQEYnzvshucyGCBXc86ig0ujXPMWaQCdA=="],
+
+    "ink-text-input": ["ink-text-input@6.0.0", "", { "dependencies": { "chalk": "^5.3.0", "type-fest": "^4.18.2" }, "peerDependencies": { "ink": ">=5", "react": ">=18" } }, "sha512-Fw64n7Yha5deb1rHY137zHTAbSTNelUKuB5Kkk2HACXEtwIHBCf9OH2tP/LQ9fRYTl1F0dZgbW0zPnZk6FA9Lw=="],
 
     "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
@@ -537,6 +545,8 @@
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
     "@evantahler/mcpx/@huggingface/transformers": ["@huggingface/transformers@3.8.1", "", { "dependencies": { "@huggingface/jinja": "^0.5.3", "onnxruntime-node": "1.21.0", "onnxruntime-web": "1.22.0-dev.20250409-89f8206ba4", "sharp": "^0.34.1" } }, "sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA=="],
+
+    "ink-text-input/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "matcher/escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -6,7 +6,7 @@
 | 2 | [Context & Embeddings](milestone-2-context-and-embeddings.md) | **Done** | Ingest, chunk, embed, and search content with hybrid vector search |
 | 3 | [Schedules & Task Hardening](milestone-3-schedules-and-task-hardening.md) | **Done** | Recurring schedules, cycle detection, timeouts, full task/schedule CLI |
 | 4 | [MCPX Integration](milestone-4-mcpx-integration.md) | **Done** | External tools via MCP servers (Gmail, Slack, web, etc.) |
-| 5 | [Chat TUI](milestone-5-chat-tui.md) | Planned | Interactive Ink/React terminal UI for conversational interaction |
+| 5 | [Chat TUI](milestone-5-chat-tui.md) | **Done** | Interactive Ink/React terminal UI for conversational interaction |
 | 6 | [Daemon Watchdog & Distribution](milestone-6-daemon-watchdog-and-distribution.md) | Planned | OS-level watchdog, binary compilation, agent self-modification |
 
 ## Stub/TODO Coverage

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "dev": "bun run src/cli.ts",
     "test": "bun test",
-    "build": "bun build --compile --minify --sourcemap ./src/cli.ts --outfile dist/botholomew",
+    "build": "bun build --compile --minify --sourcemap --external react-devtools-core ./src/cli.ts --outfile dist/botholomew",
     "lint": "tsc --noEmit && biome check ."
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "An AI agent for knowledge work",
   "type": "module",
   "bin": {
@@ -30,6 +30,8 @@
     "commander": "^14.0.0",
     "gray-matter": "^4.0.3",
     "ink": "^6.0.0",
+    "ink-spinner": "^5.0.0",
+    "ink-text-input": "^6.0.0",
     "istextorbinary": "^9.5.0",
     "react": "^19.1.0",
     "uuid": "^13.0.0",

--- a/src/chat/agent.ts
+++ b/src/chat/agent.ts
@@ -65,6 +65,9 @@ export async function buildChatSystemPrompt(
   parts.push(
     "You can update the agent's beliefs and goals files when the user asks you to.",
   );
+  parts.push(
+    "Format your responses using Markdown. Use headings, bold, italic, lists, and code blocks to make your responses clear and well-structured.",
+  );
   parts.push("");
 
   return parts.join("\n");

--- a/src/chat/agent.ts
+++ b/src/chat/agent.ts
@@ -1,0 +1,213 @@
+import Anthropic from "@anthropic-ai/sdk";
+import type {
+  MessageParam,
+  ToolResultBlockParam,
+  ToolUseBlock,
+} from "@anthropic-ai/sdk/resources/messages";
+import type { BotholomewConfig } from "../config/schemas.ts";
+import { buildMetaHeader, loadPersistentContext } from "../daemon/prompt.ts";
+import type { DbConnection } from "../db/connection.ts";
+import { logInteraction } from "../db/threads.ts";
+import { registerAllTools } from "../tools/registry.ts";
+import {
+  getAllTools,
+  getTool,
+  type ToolContext,
+  toAnthropicTool,
+} from "../tools/tool.ts";
+
+registerAllTools();
+
+/** Tools available in chat mode — no daemon terminal tools, no destructive file tools */
+const CHAT_TOOL_NAMES = new Set([
+  "create_task",
+  "list_tasks",
+  "view_task",
+  "search_context",
+  "search_grep",
+  "search_semantic",
+  "list_threads",
+  "view_thread",
+  "create_schedule",
+  "list_schedules",
+  "update_beliefs",
+  "update_goals",
+  "mcp_list_tools",
+  "mcp_search",
+  "mcp_info",
+  "mcp_exec",
+]);
+
+export function getChatTools() {
+  return getAllTools()
+    .filter((t) => CHAT_TOOL_NAMES.has(t.name))
+    .map(toAnthropicTool);
+}
+
+export async function buildChatSystemPrompt(
+  projectDir: string,
+): Promise<string> {
+  const parts: string[] = [];
+
+  parts.push(...buildMetaHeader(projectDir));
+  parts.push(...(await loadPersistentContext(projectDir)));
+
+  parts.push("## Instructions");
+  parts.push(
+    "You are Botholomew's interactive chat interface. Help the user manage tasks, review results from daemon activity, search context, and answer questions.",
+  );
+  parts.push(
+    "You do NOT execute long-running work directly — enqueue tasks for the daemon instead using create_task.",
+  );
+  parts.push(
+    "Use the available tools to look up tasks, threads, schedules, and context when the user asks about them.",
+  );
+  parts.push(
+    "You can update the agent's beliefs and goals files when the user asks you to.",
+  );
+  parts.push("");
+
+  return parts.join("\n");
+}
+
+export interface ChatTurnCallbacks {
+  onToken: (text: string) => void;
+  onToolStart: (name: string, input: string) => void;
+  onToolEnd: (name: string, output: string) => void;
+}
+
+/**
+ * Run a single chat turn: stream the assistant response, execute any tool calls,
+ * and loop until the model produces end_turn with no tool calls.
+ * Mutates `messages` in-place by appending assistant/tool messages.
+ */
+export async function runChatTurn(input: {
+  messages: MessageParam[];
+  systemPrompt: string;
+  config: Required<BotholomewConfig>;
+  conn: DbConnection;
+  threadId: string;
+  toolCtx: ToolContext;
+  callbacks: ChatTurnCallbacks;
+}): Promise<void> {
+  const { messages, systemPrompt, config, conn, threadId, toolCtx, callbacks } =
+    input;
+
+  const client = new Anthropic({
+    apiKey: config.anthropic_api_key || undefined,
+  });
+
+  const chatTools = getChatTools();
+  const maxTurns = 10;
+
+  for (let turn = 0; turn < maxTurns; turn++) {
+    const startTime = Date.now();
+
+    const stream = client.messages.stream({
+      model: config.model,
+      max_tokens: 4096,
+      system: systemPrompt,
+      messages,
+      tools: chatTools,
+    });
+
+    // Collect the full response
+    let assistantText = "";
+
+    stream.on("text", (text) => {
+      assistantText += text;
+      callbacks.onToken(text);
+    });
+
+    const response = await stream.finalMessage();
+    const durationMs = Date.now() - startTime;
+    const tokenCount =
+      response.usage.input_tokens + response.usage.output_tokens;
+
+    // Log assistant text
+    if (assistantText) {
+      await logInteraction(conn, threadId, {
+        role: "assistant",
+        kind: "message",
+        content: assistantText,
+        durationMs,
+        tokenCount,
+      });
+    }
+
+    // Check for tool calls
+    const toolUseBlocks = response.content.filter(
+      (block): block is ToolUseBlock => block.type === "tool_use",
+    );
+
+    if (toolUseBlocks.length === 0) {
+      // No tool calls — turn is complete
+      messages.push({ role: "assistant", content: response.content });
+      return;
+    }
+
+    // Add assistant response to conversation
+    messages.push({ role: "assistant", content: response.content });
+
+    // Execute tool calls
+    const toolResults: ToolResultBlockParam[] = [];
+
+    for (const toolUse of toolUseBlocks) {
+      const toolInput = JSON.stringify(toolUse.input);
+      callbacks.onToolStart(toolUse.name, toolInput);
+
+      await logInteraction(conn, threadId, {
+        role: "assistant",
+        kind: "tool_use",
+        content: `Calling ${toolUse.name}`,
+        toolName: toolUse.name,
+        toolInput,
+      });
+
+      const toolStart = Date.now();
+      const result = await executeChatToolCall(toolUse, toolCtx);
+      const toolDuration = Date.now() - toolStart;
+
+      await logInteraction(conn, threadId, {
+        role: "tool",
+        kind: "tool_result",
+        content: result,
+        toolName: toolUse.name,
+        durationMs: toolDuration,
+      });
+
+      callbacks.onToolEnd(toolUse.name, result);
+
+      toolResults.push({
+        type: "tool_result",
+        tool_use_id: toolUse.id,
+        content: result,
+      });
+    }
+
+    messages.push({ role: "user", content: toolResults });
+    // Loop to get the model's next response after tool results
+  }
+}
+
+async function executeChatToolCall(
+  toolUse: ToolUseBlock,
+  ctx: ToolContext,
+): Promise<string> {
+  const tool = getTool(toolUse.name);
+  if (!tool) return `Unknown tool: ${toolUse.name}`;
+  if (!CHAT_TOOL_NAMES.has(tool.name))
+    return `Tool not available in chat mode: ${tool.name}`;
+
+  const parsed = tool.inputSchema.safeParse(toolUse.input);
+  if (!parsed.success) {
+    return `Invalid input: ${JSON.stringify(parsed.error)}`;
+  }
+
+  try {
+    const result = await tool.execute(parsed.data, ctx);
+    return typeof result === "string" ? result : JSON.stringify(result);
+  } catch (err) {
+    return `Tool error: ${err}`;
+  }
+}

--- a/src/chat/session.ts
+++ b/src/chat/session.ts
@@ -1,0 +1,136 @@
+import type { MessageParam } from "@anthropic-ai/sdk/resources/messages";
+import { loadConfig } from "../config/loader.ts";
+import type { BotholomewConfig } from "../config/schemas.ts";
+import { getDbPath } from "../constants.ts";
+import type { DbConnection } from "../db/connection.ts";
+import { getConnection } from "../db/connection.ts";
+import { migrate } from "../db/schema.ts";
+import {
+  createThread,
+  endThread,
+  getThread,
+  logInteraction,
+  reopenThread,
+} from "../db/threads.ts";
+import { createMcpxClient } from "../mcpx/client.ts";
+import type { ToolContext } from "../tools/tool.ts";
+import {
+  buildChatSystemPrompt,
+  type ChatTurnCallbacks,
+  runChatTurn,
+} from "./agent.ts";
+
+export interface ChatSession {
+  conn: DbConnection;
+  threadId: string;
+  projectDir: string;
+  config: Required<BotholomewConfig>;
+  messages: MessageParam[];
+  systemPrompt: string;
+  toolCtx: ToolContext;
+  cleanup: () => Promise<void>;
+}
+
+export async function startChatSession(
+  projectDir: string,
+  existingThreadId?: string,
+): Promise<ChatSession> {
+  const config = await loadConfig(projectDir);
+
+  if (!config.anthropic_api_key) {
+    throw new Error(
+      "no API key found. add anthropic_api_key to .botholomew/config.json",
+    );
+  }
+
+  const conn = getConnection(getDbPath(projectDir));
+  migrate(conn);
+
+  let threadId: string;
+  const messages: MessageParam[] = [];
+
+  if (existingThreadId) {
+    // Resume existing thread
+    const result = await getThread(conn, existingThreadId);
+    if (!result) {
+      conn.close();
+      throw new Error(`Thread not found: ${existingThreadId}`);
+    }
+    threadId = existingThreadId;
+    await reopenThread(conn, threadId);
+
+    // Rebuild message history from interactions
+    for (const interaction of result.interactions) {
+      if (interaction.kind !== "message") continue;
+      if (interaction.role === "user") {
+        messages.push({ role: "user", content: interaction.content });
+      } else if (interaction.role === "assistant") {
+        messages.push({ role: "assistant", content: interaction.content });
+      }
+    }
+  } else {
+    threadId = await createThread(
+      conn,
+      "chat_session",
+      undefined,
+      "Interactive chat",
+    );
+  }
+
+  const systemPrompt = await buildChatSystemPrompt(projectDir);
+
+  const mcpxClient = await createMcpxClient(projectDir);
+
+  const toolCtx: ToolContext = {
+    conn,
+    projectDir,
+    config,
+    mcpxClient,
+  };
+
+  const cleanup = async () => {
+    await mcpxClient?.close();
+  };
+
+  return {
+    conn,
+    threadId,
+    projectDir,
+    config,
+    messages,
+    systemPrompt,
+    toolCtx,
+    cleanup,
+  };
+}
+
+export async function sendMessage(
+  session: ChatSession,
+  userMessage: string,
+  callbacks: ChatTurnCallbacks,
+): Promise<void> {
+  // Log and append user message
+  await logInteraction(session.conn, session.threadId, {
+    role: "user",
+    kind: "message",
+    content: userMessage,
+  });
+
+  session.messages.push({ role: "user", content: userMessage });
+
+  await runChatTurn({
+    messages: session.messages,
+    systemPrompt: session.systemPrompt,
+    config: session.config,
+    conn: session.conn,
+    threadId: session.threadId,
+    toolCtx: session.toolCtx,
+    callbacks,
+  });
+}
+
+export async function endChatSession(session: ChatSession): Promise<void> {
+  await endThread(session.conn, session.threadId);
+  await session.cleanup();
+  session.conn.close();
+}

--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -15,6 +15,12 @@ export function registerChatCommand(program: Command) {
           projectDir: dir,
           threadId: opts.threadId,
         }),
+        {
+          kittyKeyboard: {
+            mode: "enabled",
+            flags: ["disambiguateEscapeCodes", "reportEventTypes"],
+          },
+        },
       );
       await instance.waitUntilExit();
     });

--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -1,11 +1,21 @@
 import type { Command } from "commander";
-import { logger } from "../utils/logger.ts";
 
 export function registerChatCommand(program: Command) {
   program
     .command("chat")
     .description("Open the interactive chat TUI")
-    .action(async () => {
-      logger.warn("Chat TUI not yet implemented. Coming soon.");
+    .option("--thread-id <id>", "Resume an existing chat thread")
+    .action(async (opts: { threadId?: string }) => {
+      const { render } = await import("ink");
+      const React = await import("react");
+      const { App } = await import("../tui/App.tsx");
+      const dir = program.opts().dir;
+      const instance = render(
+        React.createElement(App, {
+          projectDir: dir,
+          threadId: opts.threadId,
+        }),
+      );
+      await instance.waitUntilExit();
     });
 }

--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -3,7 +3,17 @@ import type { Command } from "commander";
 export function registerChatCommand(program: Command) {
   program
     .command("chat")
-    .description("Open the interactive chat TUI")
+    .description(
+      "Open the interactive chat TUI\n\n" +
+        "  Keyboard shortcuts:\n" +
+        "    Enter          Send message\n" +
+        "    ⌥+Enter        Insert newline (multiline input)\n" +
+        "    ↑/↓            Browse input history\n\n" +
+        "  Commands:\n" +
+        "    /help           Show keyboard shortcuts\n" +
+        "    /tools          Open tool call inspector\n" +
+        "    /quit, /exit    End the chat session",
+    )
     .option("--thread-id <id>", "Resume an existing chat thread")
     .action(async (opts: { threadId?: string }) => {
       const { render } = await import("ink");

--- a/src/daemon/prompt.ts
+++ b/src/daemon/prompt.ts
@@ -13,35 +13,18 @@ const pkg = await Bun.file(
   new URL("../../package.json", import.meta.url),
 ).json();
 
-export async function buildSystemPrompt(
+/**
+ * Load persistent context files from .botholomew/ directory.
+ * Returns an array of formatted string sections for "always" loaded files.
+ * If taskKeywords are provided, also includes "contextual" files that match.
+ */
+export async function loadPersistentContext(
   projectDir: string,
-  task?: Task,
-  conn?: DbConnection,
-  _config?: Required<BotholomewConfig>,
-  options?: { hasMcpTools?: boolean },
-): Promise<string> {
+  taskKeywords?: Set<string> | null,
+): Promise<string[]> {
   const dotDir = getBotholomewDir(projectDir);
   const parts: string[] = [];
 
-  // Meta information
-  parts.push(`# Botholomew v${pkg.version}`);
-  parts.push(`Current time: ${new Date().toISOString()}`);
-  parts.push(`Project directory: ${projectDir}`);
-  parts.push(`OS: ${process.platform} ${process.arch}`);
-  parts.push(`User: ${process.env.USER || process.env.USERNAME || "unknown"}`);
-  parts.push("");
-
-  // Build keyword set from task for contextual loading
-  const taskKeywords = task
-    ? new Set(
-        `${task.name} ${task.description}`
-          .toLowerCase()
-          .split(/\s+/)
-          .filter((w) => w.length > 3),
-      )
-    : null;
-
-  // Load context files from .botholomew/
   try {
     const files = await readdir(dotDir);
     const mdFiles = files.filter((f) => f.endsWith(".md"));
@@ -56,7 +39,6 @@ export async function buildSystemPrompt(
         parts.push(content);
         parts.push("");
       } else if (meta.loading === "contextual" && taskKeywords) {
-        // Include contextual files if keywords overlap with task
         const contentLower = content.toLowerCase();
         const hasOverlap = [...taskKeywords].some((kw) =>
           contentLower.includes(kw),
@@ -71,6 +53,48 @@ export async function buildSystemPrompt(
   } catch {
     // .botholomew dir might not have md files yet
   }
+
+  return parts;
+}
+
+/**
+ * Build common meta header (version, time, OS, user).
+ */
+export function buildMetaHeader(projectDir: string): string[] {
+  return [
+    `# Botholomew v${pkg.version}`,
+    `Current time: ${new Date().toISOString()}`,
+    `Project directory: ${projectDir}`,
+    `OS: ${process.platform} ${process.arch}`,
+    `User: ${process.env.USER || process.env.USERNAME || "unknown"}`,
+    "",
+  ];
+}
+
+export async function buildSystemPrompt(
+  projectDir: string,
+  task?: Task,
+  conn?: DbConnection,
+  _config?: Required<BotholomewConfig>,
+  options?: { hasMcpTools?: boolean },
+): Promise<string> {
+  const parts: string[] = [];
+
+  // Meta information
+  parts.push(...buildMetaHeader(projectDir));
+
+  // Build keyword set from task for contextual loading
+  const taskKeywords = task
+    ? new Set(
+        `${task.name} ${task.description}`
+          .toLowerCase()
+          .split(/\s+/)
+          .filter((w) => w.length > 3),
+      )
+    : null;
+
+  // Load context files from .botholomew/
+  parts.push(...(await loadPersistentContext(projectDir, taskKeywords)));
 
   // Relevant context from embeddings search
   if (task && conn) {

--- a/src/db/threads.ts
+++ b/src/db/threads.ts
@@ -147,6 +147,13 @@ export async function endThread(
   );
 }
 
+export async function reopenThread(
+  db: DbConnection,
+  threadId: string,
+): Promise<void> {
+  db.query("UPDATE threads SET ended_at = NULL WHERE id = ?1").run(threadId);
+}
+
 export async function getThread(
   db: DbConnection,
   threadId: string,

--- a/src/tools/context/search.ts
+++ b/src/tools/context/search.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+import { searchContextByKeyword } from "../../db/context.ts";
+import type { ToolDefinition } from "../tool.ts";
+
+const inputSchema = z.object({
+  query: z
+    .string()
+    .describe("Search query (keyword match on title and content)"),
+  limit: z.number().optional().describe("Max results (default 20)"),
+});
+
+const outputSchema = z.object({
+  results: z.array(
+    z.object({
+      id: z.string(),
+      title: z.string(),
+      context_path: z.string(),
+      content_preview: z.string(),
+    }),
+  ),
+  count: z.number(),
+});
+
+export const searchContextTool = {
+  name: "search_context",
+  description: "Search the context database by keyword.",
+  group: "context",
+  inputSchema,
+  outputSchema,
+  execute: async (input, ctx) => {
+    const items = await searchContextByKeyword(
+      ctx.conn,
+      input.query,
+      input.limit,
+    );
+    return {
+      results: items.map((item) => ({
+        id: item.id,
+        title: item.title,
+        context_path: item.context_path,
+        content_preview: (item.content ?? "").slice(0, 500),
+      })),
+      count: items.length,
+    };
+  },
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/context/update-beliefs.ts
+++ b/src/tools/context/update-beliefs.ts
@@ -1,0 +1,54 @@
+import { join } from "node:path";
+import { z } from "zod";
+import { getBotholomewDir } from "../../constants.ts";
+import {
+  type ContextFileMeta,
+  parseContextFile,
+  serializeContextFile,
+} from "../../utils/frontmatter.ts";
+import type { ToolDefinition } from "../tool.ts";
+
+const inputSchema = z.object({
+  content: z
+    .string()
+    .describe(
+      "The new beliefs content (replaces existing body, frontmatter is preserved)",
+    ),
+});
+
+const outputSchema = z.object({
+  message: z.string(),
+  path: z.string(),
+});
+
+export const updateBeliefsTool = {
+  name: "update_beliefs",
+  description:
+    "Update the agent's beliefs file (.botholomew/beliefs.md). Preserves frontmatter, replaces content body.",
+  group: "context",
+  inputSchema,
+  outputSchema,
+  execute: async (input, ctx) => {
+    const filePath = join(getBotholomewDir(ctx.projectDir), "beliefs.md");
+    const file = Bun.file(filePath);
+
+    let meta: ContextFileMeta = {
+      loading: "always",
+      "agent-modification": true,
+    };
+
+    if (await file.exists()) {
+      const raw = await file.text();
+      const parsed = parseContextFile(raw);
+      meta = parsed.meta;
+    }
+
+    const serialized = serializeContextFile(meta, input.content);
+    await Bun.write(filePath, serialized);
+
+    return {
+      message: "Updated beliefs.md",
+      path: filePath,
+    };
+  },
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/context/update-goals.ts
+++ b/src/tools/context/update-goals.ts
@@ -1,0 +1,54 @@
+import { join } from "node:path";
+import { z } from "zod";
+import { getBotholomewDir } from "../../constants.ts";
+import {
+  type ContextFileMeta,
+  parseContextFile,
+  serializeContextFile,
+} from "../../utils/frontmatter.ts";
+import type { ToolDefinition } from "../tool.ts";
+
+const inputSchema = z.object({
+  content: z
+    .string()
+    .describe(
+      "The new goals content (replaces existing body, frontmatter is preserved)",
+    ),
+});
+
+const outputSchema = z.object({
+  message: z.string(),
+  path: z.string(),
+});
+
+export const updateGoalsTool = {
+  name: "update_goals",
+  description:
+    "Update the agent's goals file (.botholomew/goals.md). Preserves frontmatter, replaces content body.",
+  group: "context",
+  inputSchema,
+  outputSchema,
+  execute: async (input, ctx) => {
+    const filePath = join(getBotholomewDir(ctx.projectDir), "goals.md");
+    const file = Bun.file(filePath);
+
+    let meta: ContextFileMeta = {
+      loading: "always",
+      "agent-modification": true,
+    };
+
+    if (await file.exists()) {
+      const raw = await file.text();
+      const parsed = parseContextFile(raw);
+      meta = parsed.meta;
+    }
+
+    const serialized = serializeContextFile(meta, input.content);
+    await Bun.write(filePath, serialized);
+
+    return {
+      message: "Updated goals.md",
+      path: filePath,
+    };
+  },
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -1,3 +1,7 @@
+// Context tools
+import { searchContextTool } from "./context/search.ts";
+import { updateBeliefsTool } from "./context/update-beliefs.ts";
+import { updateGoalsTool } from "./context/update-goals.ts";
 // Directory tools
 import { dirCreateTool } from "./dir/create.ts";
 import { dirListTool } from "./dir/list.ts";
@@ -28,7 +32,12 @@ import { searchSemanticTool } from "./search/semantic.ts";
 import { completeTaskTool } from "./task/complete.ts";
 import { createTaskTool } from "./task/create.ts";
 import { failTaskTool } from "./task/fail.ts";
+import { listTasksTool } from "./task/list.ts";
+import { viewTaskTool } from "./task/view.ts";
 import { waitTaskTool } from "./task/wait.ts";
+// Thread tools
+import { listThreadsTool } from "./thread/list.ts";
+import { viewThreadTool } from "./thread/view.ts";
 import { registerTool } from "./tool.ts";
 
 export function registerAllTools(): void {
@@ -37,6 +46,8 @@ export function registerAllTools(): void {
   registerTool(failTaskTool);
   registerTool(waitTaskTool);
   registerTool(createTaskTool);
+  registerTool(listTasksTool);
+  registerTool(viewTaskTool);
 
   // Directory
   registerTool(dirCreateTool);
@@ -62,6 +73,15 @@ export function registerAllTools(): void {
   // Search
   registerTool(searchGrepTool);
   registerTool(searchSemanticTool);
+
+  // Thread
+  registerTool(listThreadsTool);
+  registerTool(viewThreadTool);
+
+  // Context
+  registerTool(searchContextTool);
+  registerTool(updateBeliefsTool);
+  registerTool(updateGoalsTool);
 
   // MCP
   registerTool(mcpListToolsTool);

--- a/src/tools/task/list.ts
+++ b/src/tools/task/list.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+import { listTasks, TASK_PRIORITIES, TASK_STATUSES } from "../../db/tasks.ts";
+import type { ToolDefinition } from "../tool.ts";
+
+const inputSchema = z.object({
+  status: z.enum(TASK_STATUSES).optional().describe("Filter by status"),
+  priority: z.enum(TASK_PRIORITIES).optional().describe("Filter by priority"),
+  limit: z.number().optional().describe("Max number of tasks to return"),
+});
+
+const outputSchema = z.object({
+  tasks: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+      status: z.string(),
+      priority: z.string(),
+      description: z.string(),
+      created_at: z.string(),
+    }),
+  ),
+  count: z.number(),
+});
+
+export const listTasksTool = {
+  name: "list_tasks",
+  description: "List tasks with optional status and priority filters.",
+  group: "task",
+  inputSchema,
+  outputSchema,
+  execute: async (input, ctx) => {
+    const tasks = await listTasks(ctx.conn, {
+      status: input.status,
+      priority: input.priority,
+      limit: input.limit,
+    });
+    return {
+      tasks: tasks.map((t) => ({
+        id: t.id,
+        name: t.name,
+        status: t.status,
+        priority: t.priority,
+        description: t.description,
+        created_at: t.created_at.toISOString(),
+      })),
+      count: tasks.length,
+    };
+  },
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/task/view.ts
+++ b/src/tools/task/view.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+import { getTask } from "../../db/tasks.ts";
+import type { ToolDefinition } from "../tool.ts";
+
+const inputSchema = z.object({
+  id: z.string().describe("Task ID to view"),
+});
+
+const outputSchema = z.object({
+  task: z
+    .object({
+      id: z.string(),
+      name: z.string(),
+      description: z.string(),
+      status: z.string(),
+      priority: z.string(),
+      waiting_reason: z.string().nullable(),
+      claimed_by: z.string().nullable(),
+      blocked_by: z.array(z.string()),
+      context_ids: z.array(z.string()),
+      created_at: z.string(),
+      updated_at: z.string(),
+    })
+    .nullable(),
+});
+
+export const viewTaskTool = {
+  name: "view_task",
+  description: "View full details of a task by ID.",
+  group: "task",
+  inputSchema,
+  outputSchema,
+  execute: async (input, ctx) => {
+    const task = await getTask(ctx.conn, input.id);
+    if (!task) return { task: null };
+    return {
+      task: {
+        id: task.id,
+        name: task.name,
+        description: task.description,
+        status: task.status,
+        priority: task.priority,
+        waiting_reason: task.waiting_reason,
+        claimed_by: task.claimed_by,
+        blocked_by: task.blocked_by,
+        context_ids: task.context_ids,
+        created_at: task.created_at.toISOString(),
+        updated_at: task.updated_at.toISOString(),
+      },
+    };
+  },
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/thread/list.ts
+++ b/src/tools/thread/list.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+import { listThreads } from "../../db/threads.ts";
+import type { ToolDefinition } from "../tool.ts";
+
+const inputSchema = z.object({
+  type: z
+    .enum(["daemon_tick", "chat_session"])
+    .optional()
+    .describe("Filter by thread type"),
+  limit: z.number().optional().describe("Max number of threads to return"),
+});
+
+const outputSchema = z.object({
+  threads: z.array(
+    z.object({
+      id: z.string(),
+      type: z.string(),
+      task_id: z.string().nullable(),
+      title: z.string(),
+      started_at: z.string(),
+      ended_at: z.string().nullable(),
+    }),
+  ),
+  count: z.number(),
+});
+
+export const listThreadsTool = {
+  name: "list_threads",
+  description: "List conversation threads (daemon ticks or chat sessions).",
+  group: "thread",
+  inputSchema,
+  outputSchema,
+  execute: async (input, ctx) => {
+    const threads = await listThreads(ctx.conn, {
+      type: input.type,
+      limit: input.limit,
+    });
+    return {
+      threads: threads.map((t) => ({
+        id: t.id,
+        type: t.type,
+        task_id: t.task_id,
+        title: t.title,
+        started_at: t.started_at.toISOString(),
+        ended_at: t.ended_at?.toISOString() ?? null,
+      })),
+      count: threads.length,
+    };
+  },
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/thread/view.ts
+++ b/src/tools/thread/view.ts
@@ -1,0 +1,63 @@
+import { z } from "zod";
+import { getThread } from "../../db/threads.ts";
+import type { ToolDefinition } from "../tool.ts";
+
+const inputSchema = z.object({
+  id: z.string().describe("Thread ID to view"),
+});
+
+const outputSchema = z.object({
+  thread: z
+    .object({
+      id: z.string(),
+      type: z.string(),
+      task_id: z.string().nullable(),
+      title: z.string(),
+      started_at: z.string(),
+      ended_at: z.string().nullable(),
+    })
+    .nullable(),
+  interactions: z.array(
+    z.object({
+      id: z.string(),
+      sequence: z.number(),
+      role: z.string(),
+      kind: z.string(),
+      content: z.string(),
+      tool_name: z.string().nullable(),
+      created_at: z.string(),
+    }),
+  ),
+});
+
+export const viewThreadTool = {
+  name: "view_thread",
+  description:
+    "View a thread and its full interaction log (messages, tool calls, results).",
+  group: "thread",
+  inputSchema,
+  outputSchema,
+  execute: async (input, ctx) => {
+    const result = await getThread(ctx.conn, input.id);
+    if (!result) return { thread: null, interactions: [] };
+    return {
+      thread: {
+        id: result.thread.id,
+        type: result.thread.type,
+        task_id: result.thread.task_id,
+        title: result.thread.title,
+        started_at: result.thread.started_at.toISOString(),
+        ended_at: result.thread.ended_at?.toISOString() ?? null,
+      },
+      interactions: result.interactions.map((i) => ({
+        id: i.id,
+        sequence: i.sequence,
+        role: i.role,
+        kind: i.kind,
+        content: i.content,
+        tool_name: i.tool_name,
+        created_at: i.created_at.toISOString(),
+      })),
+    };
+  },
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -1,5 +1,5 @@
 import { Box, Text, useApp } from "ink";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   type ChatSession,
   endChatSession,
@@ -12,6 +12,7 @@ import { InputBar } from "./components/InputBar.tsx";
 import { type ChatMessage, MessageList } from "./components/MessageList.tsx";
 import { StatusBar } from "./components/StatusBar.tsx";
 import type { ToolCallData } from "./components/ToolCall.tsx";
+import { ToolPanel } from "./components/ToolPanel.tsx";
 
 interface AppProps {
   projectDir: string;
@@ -86,6 +87,7 @@ export function App({ projectDir, threadId: resumeThreadId }: AppProps) {
   const [ready, setReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const sessionRef = useRef<ChatSession | null>(null);
+  const [toolPanelOpen, setToolPanelOpen] = useState(false);
   const queueRef = useRef<string[]>([]);
   const processingRef = useRef(false);
 
@@ -110,6 +112,17 @@ export function App({ projectDir, threadId: resumeThreadId }: AppProps) {
             );
           }
         }
+
+        // Show startup hint
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: msgId(),
+            role: "system" as const,
+            content: "Type /help for keyboard shortcuts and commands.",
+            timestamp: new Date(),
+          },
+        ]);
 
         setReady(true);
       })
@@ -221,6 +234,54 @@ export function App({ projectDir, threadId: resumeThreadId }: AppProps) {
       const trimmed = text.trim();
       if (!trimmed || !sessionRef.current) return;
 
+      setInputValue("");
+
+      // Handle /help
+      if (trimmed === "/help") {
+        const helpMsg: ChatMessage = {
+          id: msgId(),
+          role: "system",
+          content: [
+            "Keyboard shortcuts:",
+            "  Enter          Send message",
+            "  ⌥+Enter        Insert newline",
+            "  ↑/↓            Browse input history",
+            "",
+            "Commands:",
+            "  /help           Show this help",
+            "  /tools          Toggle tool call inspector",
+            "  /quit, /exit    End the chat session",
+          ].join("\n"),
+          timestamp: new Date(),
+        };
+        setMessages((prev) => [...prev, helpMsg]);
+        return;
+      }
+
+      // Handle /tools
+      if (trimmed === "/tools") {
+        setMessages((prev) => {
+          const hasTools = prev.some(
+            (m) => m.toolCalls && m.toolCalls.length > 0,
+          );
+          if (!hasTools) {
+            return [
+              ...prev,
+              {
+                id: msgId(),
+                role: "system" as const,
+                content: "No tool calls to inspect yet.",
+                timestamp: new Date(),
+              },
+            ];
+          }
+          // Use setTimeout to toggle panel after state update
+          setTimeout(() => setToolPanelOpen((p) => !p), 0);
+          return prev;
+        });
+        return;
+      }
+
       // Handle /quit
       if (trimmed === "/quit" || trimmed === "/exit") {
         if (sessionRef.current) {
@@ -235,12 +296,17 @@ export function App({ projectDir, threadId: resumeThreadId }: AppProps) {
         return;
       }
 
-      setInputValue("");
       setInputHistory((prev) => [...prev, trimmed]);
       queueRef.current.push(trimmed);
       processQueue();
     },
     [exit, processQueue],
+  );
+
+  // Collect all tool calls from messages for the panel
+  const allToolCalls = useMemo(
+    () => messages.flatMap((m) => m.toolCalls ?? []),
+    [messages],
   );
 
   if (error) {
@@ -267,11 +333,17 @@ export function App({ projectDir, threadId: resumeThreadId }: AppProps) {
         isLoading={isLoading}
         activeToolCalls={activeToolCalls}
       />
+      {toolPanelOpen && allToolCalls.length > 0 && (
+        <ToolPanel
+          toolCalls={allToolCalls}
+          onClose={() => setToolPanelOpen(false)}
+        />
+      )}
       <InputBar
         value={inputValue}
         onChange={setInputValue}
         onSubmit={handleSubmit}
-        disabled={false}
+        disabled={toolPanelOpen}
         history={inputHistory}
         header={
           <StatusBar

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -1,14 +1,272 @@
-import { Box, Text } from "ink";
+import { Box, Text, useApp } from "ink";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  type ChatSession,
+  endChatSession,
+  sendMessage,
+  startChatSession,
+} from "../chat/session.ts";
+import type { Interaction } from "../db/threads.ts";
+import { getThread } from "../db/threads.ts";
+import { InputBar } from "./components/InputBar.tsx";
+import { type ChatMessage, MessageList } from "./components/MessageList.tsx";
+import { StatusBar } from "./components/StatusBar.tsx";
+import type { ToolCallData } from "./components/ToolCall.tsx";
 
-export function App() {
+interface AppProps {
+  projectDir: string;
+  threadId?: string;
+}
+
+let nextMsgId = 0;
+function msgId(): string {
+  return `msg-${++nextMsgId}`;
+}
+
+function restoreMessagesFromInteractions(
+  interactions: Interaction[],
+): ChatMessage[] {
+  const result: ChatMessage[] = [];
+  let pendingTools: ToolCallData[] = [];
+
+  for (const ix of interactions) {
+    if (ix.kind === "tool_use") {
+      pendingTools.push({
+        name: ix.tool_name ?? "unknown",
+        input: ix.tool_input ?? "{}",
+        running: false,
+      });
+    } else if (ix.kind === "tool_result") {
+      // Attach output to the matching pending tool call
+      const tc = pendingTools.find((t) => t.name === ix.tool_name && !t.output);
+      if (tc) {
+        tc.output = ix.content;
+      }
+    } else if (ix.kind === "message" && ix.role === "user") {
+      result.push({
+        id: msgId(),
+        role: "user",
+        content: ix.content,
+        timestamp: ix.created_at,
+      });
+    } else if (ix.kind === "message" && ix.role === "assistant") {
+      result.push({
+        id: msgId(),
+        role: "assistant",
+        content: ix.content,
+        timestamp: ix.created_at,
+        toolCalls: pendingTools.length > 0 ? [...pendingTools] : undefined,
+      });
+      pendingTools = [];
+    }
+  }
+
+  // If there are leftover tool calls with no following assistant message
+  if (pendingTools.length > 0) {
+    result.push({
+      id: msgId(),
+      role: "assistant",
+      content: "",
+      timestamp: new Date(),
+      toolCalls: [...pendingTools],
+    });
+  }
+
+  return result;
+}
+
+export function App({ projectDir, threadId: resumeThreadId }: AppProps) {
+  const { exit } = useApp();
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [inputValue, setInputValue] = useState("");
+  const [inputHistory, setInputHistory] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [streamingText, setStreamingText] = useState("");
+  const [activeToolCalls, setActiveToolCalls] = useState<ToolCallData[]>([]);
+  const [ready, setReady] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const sessionRef = useRef<ChatSession | null>(null);
+
+  // Initialize session
+  useEffect(() => {
+    let cancelled = false;
+
+    startChatSession(projectDir, resumeThreadId)
+      .then(async (session) => {
+        if (cancelled) {
+          endChatSession(session);
+          return;
+        }
+        sessionRef.current = session;
+
+        // If resuming, populate the message list from DB interactions
+        if (session.messages.length > 0) {
+          const threadData = await getThread(session.conn, session.threadId);
+          if (threadData) {
+            setMessages(
+              restoreMessagesFromInteractions(threadData.interactions),
+            );
+          }
+        }
+
+        setReady(true);
+      })
+      .catch((err) => {
+        setError(`Failed to start session: ${err}`);
+      });
+
+    return () => {
+      cancelled = true;
+      if (sessionRef.current) {
+        const threadId = sessionRef.current.threadId;
+        endChatSession(sessionRef.current);
+        process.stderr.write(
+          `\nThread: ${threadId}\nResume with: \x1b[32mbotholomew chat --thread-id ${threadId}\x1b[0m\n`,
+        );
+      }
+    };
+  }, [projectDir, resumeThreadId]);
+
+  const handleSubmit = useCallback(
+    async (text: string) => {
+      const trimmed = text.trim();
+      if (!trimmed || !sessionRef.current) return;
+
+      // Handle /quit
+      if (trimmed === "/quit" || trimmed === "/exit") {
+        if (sessionRef.current) {
+          const threadId = sessionRef.current.threadId;
+          await endChatSession(sessionRef.current);
+          sessionRef.current = null;
+          process.stderr.write(
+            `\nThread: ${threadId}\nResume with: \x1b[32mbotholomew chat --thread-id ${threadId}\x1b[0m\n`,
+          );
+        }
+        exit();
+        return;
+      }
+
+      setInputValue("");
+      setInputHistory((prev) => [...prev, trimmed]);
+      setIsLoading(true);
+      setStreamingText("");
+      setActiveToolCalls([]);
+
+      // Add user message
+      const userMsg: ChatMessage = {
+        id: msgId(),
+        role: "user",
+        content: trimmed,
+        timestamp: new Date(),
+      };
+      setMessages((prev) => [...prev, userMsg]);
+
+      // Collect tool calls for the current segment (reset after each finalization)
+      let pendingToolCalls: ToolCallData[] = [];
+      let currentText = "";
+
+      const finalizeSegment = () => {
+        if (currentText || pendingToolCalls.length > 0) {
+          const assistantMsg: ChatMessage = {
+            id: msgId(),
+            role: "assistant",
+            content: currentText,
+            timestamp: new Date(),
+            toolCalls:
+              pendingToolCalls.length > 0 ? [...pendingToolCalls] : undefined,
+          };
+          setMessages((prev) => [...prev, assistantMsg]);
+          currentText = "";
+          pendingToolCalls = [];
+          setStreamingText("");
+          setActiveToolCalls([]);
+        }
+      };
+
+      try {
+        await sendMessage(sessionRef.current, trimmed, {
+          onToken: (token) => {
+            currentText += token;
+            setStreamingText(currentText);
+          },
+          onToolStart: (name, input) => {
+            // If we had streamed text before this tool call, finalize it
+            if (currentText) {
+              finalizeSegment();
+            }
+            const tc: ToolCallData = { name, input, running: true };
+            pendingToolCalls.push(tc);
+            setActiveToolCalls([...pendingToolCalls]);
+          },
+          onToolEnd: (name, output) => {
+            const tc = pendingToolCalls.find(
+              (t) => t.name === name && t.running,
+            );
+            if (tc) {
+              tc.running = false;
+              tc.output = output;
+            }
+            setActiveToolCalls([...pendingToolCalls]);
+          },
+        });
+
+        // Finalize any remaining text or tool calls
+        finalizeSegment();
+      } catch (err) {
+        const errorMsg: ChatMessage = {
+          id: msgId(),
+          role: "system",
+          content: `Error: ${err}`,
+          timestamp: new Date(),
+        };
+        setMessages((prev) => [...prev, errorMsg]);
+      } finally {
+        setIsLoading(false);
+        setStreamingText("");
+        setActiveToolCalls([]);
+      }
+    },
+    [exit],
+  );
+
+  if (error) {
+    return (
+      <Box flexDirection="column" padding={1}>
+        <Text color="red">{error}</Text>
+      </Box>
+    );
+  }
+
+  if (!ready || !sessionRef.current) {
+    return (
+      <Box flexDirection="column" padding={1}>
+        <Text dimColor>Starting chat session...</Text>
+      </Box>
+    );
+  }
+
   return (
-    <Box flexDirection="column" padding={1}>
-      <Text bold color="blue">
-        Botholomew Chat
-      </Text>
-      <Text dimColor>
-        Chat TUI coming soon. Use the daemon and task commands for now.
-      </Text>
+    <Box flexDirection="column" height="100%">
+      <MessageList
+        messages={messages}
+        streamingText={streamingText}
+        isLoading={isLoading}
+        activeToolCalls={activeToolCalls}
+      />
+      <InputBar
+        value={inputValue}
+        onChange={setInputValue}
+        onSubmit={handleSubmit}
+        disabled={isLoading}
+        history={inputHistory}
+        header={
+          <StatusBar
+            projectDir={projectDir}
+            conn={sessionRef.current.conn}
+            isLoading={isLoading}
+          />
+        }
+      />
     </Box>
   );
 }

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -86,6 +86,8 @@ export function App({ projectDir, threadId: resumeThreadId }: AppProps) {
   const [ready, setReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const sessionRef = useRef<ChatSession | null>(null);
+  const queueRef = useRef<string[]>([]);
+  const processingRef = useRef(false);
 
   // Initialize session
   useEffect(() => {
@@ -127,27 +129,13 @@ export function App({ projectDir, threadId: resumeThreadId }: AppProps) {
     };
   }, [projectDir, resumeThreadId]);
 
-  const handleSubmit = useCallback(
-    async (text: string) => {
-      const trimmed = text.trim();
-      if (!trimmed || !sessionRef.current) return;
+  const processQueue = useCallback(async () => {
+    if (processingRef.current || !sessionRef.current) return;
+    processingRef.current = true;
 
-      // Handle /quit
-      if (trimmed === "/quit" || trimmed === "/exit") {
-        if (sessionRef.current) {
-          const threadId = sessionRef.current.threadId;
-          await endChatSession(sessionRef.current);
-          sessionRef.current = null;
-          process.stderr.write(
-            `\nThread: ${threadId}\nResume with: \x1b[32mbotholomew chat --thread-id ${threadId}\x1b[0m\n`,
-          );
-        }
-        exit();
-        return;
-      }
-
-      setInputValue("");
-      setInputHistory((prev) => [...prev, trimmed]);
+    while (queueRef.current.length > 0) {
+      const trimmed = queueRef.current.shift();
+      if (!trimmed) break;
       setIsLoading(true);
       setStreamingText("");
       setActiveToolCalls([]);
@@ -161,7 +149,7 @@ export function App({ projectDir, threadId: resumeThreadId }: AppProps) {
       };
       setMessages((prev) => [...prev, userMsg]);
 
-      // Collect tool calls for the current segment (reset after each finalization)
+      // Collect tool calls for the current segment
       let pendingToolCalls: ToolCallData[] = [];
       let currentText = "";
 
@@ -190,7 +178,6 @@ export function App({ projectDir, threadId: resumeThreadId }: AppProps) {
             setStreamingText(currentText);
           },
           onToolStart: (name, input) => {
-            // If we had streamed text before this tool call, finalize it
             if (currentText) {
               finalizeSegment();
             }
@@ -210,7 +197,6 @@ export function App({ projectDir, threadId: resumeThreadId }: AppProps) {
           },
         });
 
-        // Finalize any remaining text or tool calls
         finalizeSegment();
       } catch (err) {
         const errorMsg: ChatMessage = {
@@ -221,12 +207,40 @@ export function App({ projectDir, threadId: resumeThreadId }: AppProps) {
         };
         setMessages((prev) => [...prev, errorMsg]);
       } finally {
-        setIsLoading(false);
         setStreamingText("");
         setActiveToolCalls([]);
       }
+    }
+
+    setIsLoading(false);
+    processingRef.current = false;
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (text: string) => {
+      const trimmed = text.trim();
+      if (!trimmed || !sessionRef.current) return;
+
+      // Handle /quit
+      if (trimmed === "/quit" || trimmed === "/exit") {
+        if (sessionRef.current) {
+          const threadId = sessionRef.current.threadId;
+          await endChatSession(sessionRef.current);
+          sessionRef.current = null;
+          process.stderr.write(
+            `\nThread: ${threadId}\nResume with: \x1b[32mbotholomew chat --thread-id ${threadId}\x1b[0m\n`,
+          );
+        }
+        exit();
+        return;
+      }
+
+      setInputValue("");
+      setInputHistory((prev) => [...prev, trimmed]);
+      queueRef.current.push(trimmed);
+      processQueue();
     },
-    [exit],
+    [exit, processQueue],
   );
 
   if (error) {
@@ -257,7 +271,7 @@ export function App({ projectDir, threadId: resumeThreadId }: AppProps) {
         value={inputValue}
         onChange={setInputValue}
         onSubmit={handleSubmit}
-        disabled={isLoading}
+        disabled={false}
         history={inputHistory}
         header={
           <StatusBar

--- a/src/tui/components/InputBar.tsx
+++ b/src/tui/components/InputBar.tsx
@@ -1,0 +1,104 @@
+import { Box, Text, useInput } from "ink";
+import TextInput from "ink-text-input";
+import type { ReactNode } from "react";
+import { useCallback, useRef, useState } from "react";
+
+interface InputBarProps {
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: (value: string) => void;
+  disabled: boolean;
+  history: string[];
+  header?: ReactNode;
+}
+
+export function InputBar({
+  value,
+  onChange,
+  onSubmit,
+  disabled,
+  history,
+  header,
+}: InputBarProps) {
+  // historyIndex: -1 means "not browsing history" (current input shown)
+  // 0 = most recent, 1 = second most recent, etc.
+  const [historyIndex, setHistoryIndex] = useState(-1);
+  const savedInput = useRef("");
+
+  const handleChange = useCallback(
+    (newValue: string) => {
+      // If user types while browsing history, exit history mode
+      if (historyIndex !== -1) {
+        setHistoryIndex(-1);
+      }
+      onChange(newValue);
+    },
+    [historyIndex, onChange],
+  );
+
+  const handleSubmit = useCallback(
+    (text: string) => {
+      setHistoryIndex(-1);
+      savedInput.current = "";
+      onSubmit(text);
+    },
+    [onSubmit],
+  );
+
+  useInput(
+    (_input, key) => {
+      if (disabled || history.length === 0) return;
+
+      if (key.upArrow) {
+        const nextIndex = historyIndex + 1;
+        if (nextIndex < history.length) {
+          if (historyIndex === -1) {
+            savedInput.current = value;
+          }
+          setHistoryIndex(nextIndex);
+          const entry = history[history.length - 1 - nextIndex];
+          if (entry !== undefined) onChange(entry);
+        }
+      } else if (key.downArrow) {
+        if (historyIndex > 0) {
+          const nextIndex = historyIndex - 1;
+          setHistoryIndex(nextIndex);
+          const entry = history[history.length - 1 - nextIndex];
+          if (entry !== undefined) onChange(entry);
+        } else if (historyIndex === 0) {
+          setHistoryIndex(-1);
+          onChange(savedInput.current);
+        }
+      }
+    },
+    { isActive: !disabled },
+  );
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="single"
+      borderColor={disabled ? "gray" : "green"}
+      paddingX={1}
+    >
+      {header && (
+        <Box borderBottom borderColor="gray" paddingBottom={0} marginBottom={0}>
+          {header}
+        </Box>
+      )}
+      <Box>
+        <Text color={disabled ? "gray" : "green"}>{"❯ "}</Text>
+        {disabled ? (
+          <Text dimColor>{value || "..."}</Text>
+        ) : (
+          <TextInput
+            value={value}
+            onChange={handleChange}
+            onSubmit={handleSubmit}
+            placeholder="Type a message..."
+          />
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/src/tui/components/InputBar.tsx
+++ b/src/tui/components/InputBar.tsx
@@ -1,7 +1,6 @@
 import { Box, Text, useInput } from "ink";
-import TextInput from "ink-text-input";
 import type { ReactNode } from "react";
-import { useCallback, useRef, useState } from "react";
+import { useRef, useState } from "react";
 
 interface InputBarProps {
   value: string;
@@ -20,36 +19,35 @@ export function InputBar({
   history,
   header,
 }: InputBarProps) {
-  // historyIndex: -1 means "not browsing history" (current input shown)
-  // 0 = most recent, 1 = second most recent, etc.
   const [historyIndex, setHistoryIndex] = useState(-1);
   const savedInput = useRef("");
 
-  const handleChange = useCallback(
-    (newValue: string) => {
-      // If user types while browsing history, exit history mode
-      if (historyIndex !== -1) {
-        setHistoryIndex(-1);
-      }
-      onChange(newValue);
-    },
-    [historyIndex, onChange],
-  );
-
-  const handleSubmit = useCallback(
-    (text: string) => {
-      setHistoryIndex(-1);
-      savedInput.current = "";
-      onSubmit(text);
-    },
-    [onSubmit],
-  );
-
   useInput(
-    (_input, key) => {
-      if (disabled || history.length === 0) return;
+    (input, key) => {
+      if (disabled) return;
 
-      if (key.upArrow) {
+      // Enter: submit (shift+enter or opt+enter inserts newline)
+      if (key.return) {
+        if (key.shift || key.meta) {
+          onChange(`${value}\n`);
+        } else {
+          setHistoryIndex(-1);
+          savedInput.current = "";
+          onSubmit(value);
+        }
+        return;
+      }
+
+      // Backspace
+      if (key.backspace || key.delete) {
+        if (value.length > 0) {
+          onChange(value.slice(0, -1));
+        }
+        return;
+      }
+
+      // History navigation
+      if (key.upArrow && history.length > 0) {
         const nextIndex = historyIndex + 1;
         if (nextIndex < history.length) {
           if (historyIndex === -1) {
@@ -59,7 +57,10 @@ export function InputBar({
           const entry = history[history.length - 1 - nextIndex];
           if (entry !== undefined) onChange(entry);
         }
-      } else if (key.downArrow) {
+        return;
+      }
+
+      if (key.downArrow && history.length > 0) {
         if (historyIndex > 0) {
           const nextIndex = historyIndex - 1;
           setHistoryIndex(nextIndex);
@@ -69,10 +70,33 @@ export function InputBar({
           setHistoryIndex(-1);
           onChange(savedInput.current);
         }
+        return;
+      }
+
+      // Ignore other control keys
+      if (
+        key.ctrl ||
+        key.escape ||
+        key.leftArrow ||
+        key.rightArrow ||
+        key.tab
+      ) {
+        return;
+      }
+
+      // Regular character input
+      if (input) {
+        if (historyIndex !== -1) {
+          setHistoryIndex(-1);
+        }
+        onChange(`${value}${input}`);
       }
     },
     { isActive: !disabled },
   );
+
+  const isMultiline = value.includes("\n");
+  const placeholder = !value && !disabled;
 
   return (
     <Box
@@ -86,17 +110,19 @@ export function InputBar({
           {header}
         </Box>
       )}
-      <Box>
-        <Text color={disabled ? "gray" : "green"}>{"❯ "}</Text>
-        {disabled ? (
-          <Text dimColor>{value || "..."}</Text>
-        ) : (
-          <TextInput
-            value={value}
-            onChange={handleChange}
-            onSubmit={handleSubmit}
-            placeholder="Type a message..."
-          />
+      <Box flexDirection="column">
+        <Box>
+          <Text color={disabled ? "gray" : "green"}>{"❯ "}</Text>
+          {placeholder ? (
+            <Text dimColor>Type a message...</Text>
+          ) : (
+            <Text>{value}</Text>
+          )}
+        </Box>
+        {isMultiline && (
+          <Box>
+            <Text dimColor> ⌥+return for newline · return to send</Text>
+          </Box>
         )}
       </Box>
     </Box>

--- a/src/tui/components/InputBar.tsx
+++ b/src/tui/components/InputBar.tsx
@@ -105,14 +105,10 @@ export function InputBar({
       borderColor={disabled ? "gray" : "green"}
       paddingX={1}
     >
-      {header && (
-        <Box borderBottom borderColor="gray" paddingBottom={0} marginBottom={0}>
-          {header}
-        </Box>
-      )}
+      {header}
       <Box flexDirection="column">
         <Box>
-          <Text color={disabled ? "gray" : "green"}>{"❯ "}</Text>
+          <Text color={disabled ? "gray" : "green"}>{"› "}</Text>
           {placeholder ? (
             <Text dimColor>Type a message...</Text>
           ) : (
@@ -121,7 +117,7 @@ export function InputBar({
         </Box>
         {isMultiline && (
           <Box>
-            <Text dimColor> ⌥+return for newline · return to send</Text>
+            <Text dimColor> alt+return for newline, return to send</Text>
           </Box>
         )}
       </Box>

--- a/src/tui/components/MessageList.tsx
+++ b/src/tui/components/MessageList.tsx
@@ -1,0 +1,142 @@
+import { Box, Text, useStdout } from "ink";
+import Spinner from "ink-spinner";
+import { ToolCall, type ToolCallData } from "./ToolCall.tsx";
+
+export interface ChatMessage {
+  id: string;
+  role: "user" | "assistant" | "system";
+  content: string;
+  timestamp: Date;
+  toolCalls?: ToolCallData[];
+}
+
+interface MessageListProps {
+  messages: ChatMessage[];
+  streamingText: string;
+  isLoading: boolean;
+  activeToolCalls: ToolCallData[];
+}
+
+function formatTime(date: Date): string {
+  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+function padLine(text: string, width: number): string {
+  const pad = Math.max(0, width - text.length);
+  return text + " ".repeat(pad);
+}
+
+function MessageBubble({ message }: { message: ChatMessage }) {
+  const { stdout } = useStdout();
+  const cols = stdout?.columns ?? 80;
+  const time = formatTime(message.timestamp);
+
+  if (message.role === "user") {
+    return (
+      <Box flexDirection="column" marginTop={1}>
+        <Text backgroundColor="#1a3a5c">
+          <Text bold color="cyan">
+            {" You "}
+          </Text>
+          <Text dimColor>{padLine(time, cols - 5)}</Text>
+        </Text>
+        <Text backgroundColor="#1a3a5c">
+          {padLine(` ${message.content}`, cols)}
+        </Text>
+      </Box>
+    );
+  }
+
+  if (message.role === "system") {
+    return (
+      <Box marginTop={1}>
+        <Text color="yellow" dimColor>
+          ⚠ {message.content}
+        </Text>
+        <Text dimColor> {time}</Text>
+      </Box>
+    );
+  }
+
+  // assistant
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      <Box>
+        <Text bold color="green">
+          Botholomew
+        </Text>
+        <Text dimColor> {time}</Text>
+      </Box>
+      <Box marginLeft={1} flexDirection="column">
+        {message.toolCalls && message.toolCalls.length > 0 && (
+          <Box
+            flexDirection="column"
+            borderStyle="round"
+            borderColor="gray"
+            paddingX={1}
+            marginBottom={0}
+          >
+            {message.toolCalls.map((tc) => (
+              <ToolCall key={`${tc.name}-${tc.input.slice(0, 20)}`} tool={tc} />
+            ))}
+          </Box>
+        )}
+        <Text>{message.content}</Text>
+      </Box>
+    </Box>
+  );
+}
+
+export function MessageList({
+  messages,
+  streamingText,
+  isLoading,
+  activeToolCalls,
+}: MessageListProps) {
+  return (
+    <Box flexDirection="column" flexGrow={1} overflow="hidden">
+      {messages.map((msg) => (
+        <MessageBubble key={msg.id} message={msg} />
+      ))}
+
+      {/* Active streaming / tool calls */}
+      {(streamingText || activeToolCalls.length > 0) && (
+        <Box flexDirection="column" marginTop={1}>
+          <Box>
+            <Text bold color="green">
+              Botholomew
+            </Text>
+            <Text dimColor> {formatTime(new Date())}</Text>
+          </Box>
+          {activeToolCalls.length > 0 && (
+            <Box
+              flexDirection="column"
+              marginLeft={1}
+              borderStyle="round"
+              borderColor="yellow"
+              paddingX={1}
+            >
+              {activeToolCalls.map((tc) => (
+                <ToolCall key={`active-${tc.name}`} tool={tc} />
+              ))}
+            </Box>
+          )}
+          {streamingText && (
+            <Box marginLeft={1}>
+              <Text>{streamingText}</Text>
+            </Box>
+          )}
+        </Box>
+      )}
+
+      {isLoading && !streamingText && activeToolCalls.length === 0 && (
+        <Box marginTop={1}>
+          <Text color="yellow">
+            <Spinner type="dots" />
+          </Text>
+          <Text dimColor> Thinking...</Text>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/tui/components/MessageList.tsx
+++ b/src/tui/components/MessageList.tsx
@@ -1,5 +1,6 @@
 import { Box, Text, useStdout } from "ink";
 import Spinner from "ink-spinner";
+import { memo, useMemo } from "react";
 import { ToolCall, type ToolCallData } from "./ToolCall.tsx";
 
 export interface ChatMessage {
@@ -26,12 +27,31 @@ function padLine(text: string, width: number): string {
   return text + " ".repeat(pad);
 }
 
-function MessageBubble({ message }: { message: ChatMessage }) {
+function renderMarkdown(text: string): string {
+  if (!text) return "";
+  return Bun.markdown.ansi(text).trimEnd();
+}
+
+const MessageBubble = memo(function MessageBubble({
+  message,
+}: {
+  message: ChatMessage;
+}) {
   const { stdout } = useStdout();
   const cols = stdout?.columns ?? 80;
   const time = formatTime(message.timestamp);
 
+  const renderedContent = useMemo(
+    () =>
+      message.role === "assistant" ? renderMarkdown(message.content) : null,
+    [message.role, message.content],
+  );
+
   if (message.role === "user") {
+    const paddedContent = message.content
+      .split("\n")
+      .map((line) => padLine(` ${line}`, cols))
+      .join("\n");
     return (
       <Box flexDirection="column" marginTop={1}>
         <Text backgroundColor="#1a3a5c">
@@ -40,9 +60,7 @@ function MessageBubble({ message }: { message: ChatMessage }) {
           </Text>
           <Text dimColor>{padLine(time, cols - 5)}</Text>
         </Text>
-        <Text backgroundColor="#1a3a5c">
-          {padLine(` ${message.content}`, cols)}
-        </Text>
+        <Text backgroundColor="#1a3a5c">{paddedContent}</Text>
       </Box>
     );
   }
@@ -81,11 +99,11 @@ function MessageBubble({ message }: { message: ChatMessage }) {
             ))}
           </Box>
         )}
-        <Text>{message.content}</Text>
+        <Text>{renderedContent}</Text>
       </Box>
     </Box>
   );
-}
+});
 
 export function MessageList({
   messages,
@@ -123,7 +141,7 @@ export function MessageList({
           )}
           {streamingText && (
             <Box marginLeft={1}>
-              <Text>{streamingText}</Text>
+              <Text>{renderMarkdown(streamingText)}</Text>
             </Box>
           )}
         </Box>

--- a/src/tui/components/StatusBar.tsx
+++ b/src/tui/components/StatusBar.tsx
@@ -1,0 +1,73 @@
+import { Box, Text } from "ink";
+import { useEffect, useState } from "react";
+import type { DbConnection } from "../../db/connection.ts";
+import { listTasks } from "../../db/tasks.ts";
+import { getDaemonStatus } from "../../utils/pid.ts";
+
+interface StatusBarProps {
+  projectDir: string;
+  conn: DbConnection;
+  isLoading: boolean;
+}
+
+interface Status {
+  daemonRunning: boolean;
+  pendingCount: number;
+  inProgressCount: number;
+}
+
+export function StatusBar({ projectDir, conn, isLoading }: StatusBarProps) {
+  const [status, setStatus] = useState<Status>({
+    daemonRunning: false,
+    pendingCount: 0,
+    inProgressCount: 0,
+  });
+
+  useEffect(() => {
+    let mounted = true;
+
+    const refresh = async () => {
+      const daemon = await getDaemonStatus(projectDir);
+      const pending = await listTasks(conn, { status: "pending" });
+      const inProgress = await listTasks(conn, { status: "in_progress" });
+      if (mounted) {
+        setStatus({
+          daemonRunning: daemon !== null,
+          pendingCount: pending.length,
+          inProgressCount: inProgress.length,
+        });
+      }
+    };
+
+    refresh();
+    const interval = setInterval(refresh, 5000);
+    return () => {
+      mounted = false;
+      clearInterval(interval);
+    };
+  }, [projectDir, conn]);
+
+  return (
+    <Box paddingX={0}>
+      <Text bold color="blue">
+        🤖 Botholomew
+      </Text>
+      <Text dimColor> │ </Text>
+      {isLoading ? (
+        <Text color="yellow">⏳ Working...</Text>
+      ) : (
+        <Text color="green">💬 Ready</Text>
+      )}
+      <Text dimColor> │ </Text>
+      {status.daemonRunning ? (
+        <Text color="green">✅ Daemon</Text>
+      ) : (
+        <Text color="red">🛑 Daemon</Text>
+      )}
+      <Text dimColor> │ </Text>
+      <Text>
+        📋 {status.pendingCount} pending, {status.inProgressCount} active
+      </Text>
+    </Box>
+  );
+}

--- a/src/tui/components/StatusBar.tsx
+++ b/src/tui/components/StatusBar.tsx
@@ -50,23 +50,23 @@ export function StatusBar({ projectDir, conn, isLoading }: StatusBarProps) {
   return (
     <Box paddingX={0}>
       <Text bold color="blue">
-        🤖 Botholomew
+        Botholomew
       </Text>
-      <Text dimColor> │ </Text>
+      <Text dimColor> | </Text>
       {isLoading ? (
-        <Text color="yellow">⏳ Working...</Text>
+        <Text color="yellow">Working...</Text>
       ) : (
-        <Text color="green">💬 Ready</Text>
+        <Text color="green">Ready</Text>
       )}
-      <Text dimColor> │ </Text>
+      <Text dimColor> | </Text>
       {status.daemonRunning ? (
-        <Text color="green">✅ Daemon</Text>
+        <Text color="green">Daemon</Text>
       ) : (
-        <Text color="red">🛑 Daemon</Text>
+        <Text color="red">Daemon (off)</Text>
       )}
-      <Text dimColor> │ </Text>
+      <Text dimColor> | </Text>
       <Text>
-        📋 {status.pendingCount} pending, {status.inProgressCount} active
+        {status.pendingCount} pending, {status.inProgressCount} active
       </Text>
     </Box>
   );

--- a/src/tui/components/ToolCall.tsx
+++ b/src/tui/components/ToolCall.tsx
@@ -1,0 +1,38 @@
+import { Box, Text } from "ink";
+
+export interface ToolCallData {
+  name: string;
+  input: string;
+  output?: string;
+  running: boolean;
+}
+
+interface ToolCallProps {
+  tool: ToolCallData;
+}
+
+export function ToolCall({ tool }: ToolCallProps) {
+  const truncatedInput =
+    tool.input.length > 60 ? `${tool.input.slice(0, 60)}…` : tool.input;
+  const truncatedOutput = tool.output ? tool.output.slice(0, 120) : "";
+
+  return (
+    <Box flexDirection="column">
+      <Box>
+        <Text color={tool.running ? "yellow" : "gray"}>
+          {tool.running ? "  ⟳ " : "  ✔ "}
+        </Text>
+        <Text color={tool.running ? "yellow" : "magenta"} bold>
+          {tool.name}
+        </Text>
+        <Text dimColor> ({truncatedInput})</Text>
+      </Box>
+      {truncatedOutput && !tool.running && (
+        <Text dimColor wrap="truncate-end">
+          {"    → "}
+          {truncatedOutput}
+        </Text>
+      )}
+    </Box>
+  );
+}

--- a/src/tui/components/ToolPanel.tsx
+++ b/src/tui/components/ToolPanel.tsx
@@ -1,0 +1,328 @@
+import { Box, Text, useInput } from "ink";
+import { useMemo, useState } from "react";
+import type { ToolCallData } from "./ToolCall.tsx";
+
+interface ToolPanelProps {
+  toolCalls: ToolCallData[];
+  onClose: () => void;
+}
+
+/** A flattened row in the JSON tree */
+interface TreeRow {
+  depth: number;
+  key: string;
+  value: string | null; // null = expandable parent
+  path: string;
+  hasChildren: boolean;
+}
+
+function flattenJson(
+  obj: unknown,
+  parentPath: string,
+  depth: number,
+  expanded: Set<string>,
+): TreeRow[] {
+  const rows: TreeRow[] = [];
+
+  if (obj === null || obj === undefined) {
+    return rows;
+  }
+
+  if (Array.isArray(obj)) {
+    for (let i = 0; i < obj.length; i++) {
+      const path = `${parentPath}[${i}]`;
+      const child = obj[i];
+      if (typeof child === "object" && child !== null) {
+        rows.push({
+          depth,
+          key: `[${i}]`,
+          value: expanded.has(path) ? null : `[…]`,
+          path,
+          hasChildren: true,
+        });
+        if (expanded.has(path)) {
+          rows.push(...flattenJson(child, path, depth + 1, expanded));
+        }
+      } else {
+        rows.push({
+          depth,
+          key: `[${i}]`,
+          value: formatValue(child),
+          path,
+          hasChildren: false,
+        });
+      }
+    }
+  } else if (typeof obj === "object") {
+    for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+      const path = parentPath ? `${parentPath}.${k}` : k;
+      if (typeof v === "object" && v !== null) {
+        const childCount = Array.isArray(v) ? v.length : Object.keys(v).length;
+        const preview = Array.isArray(v)
+          ? `[${childCount} items]`
+          : `{${childCount} keys}`;
+        rows.push({
+          depth,
+          key: k,
+          value: expanded.has(path) ? null : preview,
+          path,
+          hasChildren: true,
+        });
+        if (expanded.has(path)) {
+          rows.push(...flattenJson(v, path, depth + 1, expanded));
+        }
+      } else {
+        rows.push({
+          depth,
+          key: k,
+          value: formatValue(v),
+          path,
+          hasChildren: false,
+        });
+      }
+    }
+  }
+
+  return rows;
+}
+
+function formatValue(v: unknown): string {
+  if (v === null) return "null";
+  if (v === undefined) return "undefined";
+  if (typeof v === "string") {
+    if (v.length > 80) return `"${v.slice(0, 77)}…"`;
+    return `"${v}"`;
+  }
+  return String(v);
+}
+
+function safeParseJson(str: string): unknown {
+  try {
+    return JSON.parse(str);
+  } catch {
+    return str;
+  }
+}
+
+type PanelTab = "input" | "output";
+
+export function ToolPanel({ toolCalls, onClose }: ToolPanelProps) {
+  const [selectedTool, setSelectedTool] = useState(0);
+  const [tab, setTab] = useState<PanelTab>("input");
+  const [cursor, setCursor] = useState(0);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const tool = toolCalls[selectedTool];
+
+  const data = useMemo(() => {
+    if (!tool) return null;
+    return tab === "input"
+      ? safeParseJson(tool.input)
+      : safeParseJson(tool.output ?? "");
+  }, [tool, tab]);
+
+  const rows = useMemo(() => {
+    if (data === null || data === undefined) return [];
+    if (typeof data === "string") {
+      return data
+        .split("\n")
+        .filter((l) => l.trim())
+        .map(
+          (line, i): TreeRow => ({
+            depth: 0,
+            key: "",
+            value: line,
+            path: `line-${i}`,
+            hasChildren: false,
+          }),
+        );
+    }
+    return flattenJson(data, "", 0, expanded);
+  }, [data, expanded]);
+
+  useInput((input, key) => {
+    if (key.escape) {
+      onClose();
+      return;
+    }
+
+    if (key.tab) {
+      setTab((t) => (t === "input" ? "output" : "input"));
+      setCursor(0);
+      setExpanded(new Set());
+      return;
+    }
+
+    if (key.leftArrow) {
+      setSelectedTool((i) => Math.max(0, i - 1));
+      setCursor(0);
+      setExpanded(new Set());
+      return;
+    }
+    if (key.rightArrow) {
+      setSelectedTool((i) => Math.min(toolCalls.length - 1, i + 1));
+      setCursor(0);
+      setExpanded(new Set());
+      return;
+    }
+
+    if (key.upArrow) {
+      setCursor((c) => Math.max(0, c - 1));
+      return;
+    }
+    if (key.downArrow) {
+      setCursor((c) => Math.min(rows.length - 1, c + 1));
+      return;
+    }
+
+    if (key.return) {
+      const row = rows[cursor];
+      if (row?.hasChildren) {
+        setExpanded((prev) => {
+          const next = new Set(prev);
+          if (next.has(row.path)) {
+            for (const p of next) {
+              if (
+                p === row.path ||
+                p.startsWith(`${row.path}.`) ||
+                p.startsWith(`${row.path}[`)
+              ) {
+                next.delete(p);
+              }
+            }
+          } else {
+            next.add(row.path);
+          }
+          return next;
+        });
+      }
+      return;
+    }
+
+    if (input === "e") {
+      const allPaths = new Set<string>();
+      const expandAll = (obj: unknown, parentPath: string) => {
+        if (typeof obj === "object" && obj !== null) {
+          if (Array.isArray(obj)) {
+            for (let i = 0; i < obj.length; i++) {
+              const p = `${parentPath}[${i}]`;
+              if (typeof obj[i] === "object" && obj[i] !== null) {
+                allPaths.add(p);
+                expandAll(obj[i], p);
+              }
+            }
+          } else {
+            for (const [k, v] of Object.entries(obj)) {
+              const p = parentPath ? `${parentPath}.${k}` : k;
+              if (typeof v === "object" && v !== null) {
+                allPaths.add(p);
+                expandAll(v, p);
+              }
+            }
+          }
+        }
+      };
+      if (data && typeof data === "object") expandAll(data, "");
+      setExpanded(allPaths);
+      return;
+    }
+
+    if (input === "c") {
+      setExpanded(new Set());
+      setCursor(0);
+    }
+  });
+
+  if (!tool) return null;
+
+  const hasOutput = Boolean(tool.output);
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor="cyan"
+      paddingX={1}
+      height={16}
+    >
+      {/* Header */}
+      <Box justifyContent="space-between">
+        <Box>
+          <Text bold color="cyan">
+            🔍 Tool Inspector
+          </Text>
+          <Text dimColor>
+            {" "}
+            ({selectedTool + 1}/{toolCalls.length})
+          </Text>
+        </Box>
+        <Text dimColor>
+          esc close · ←→ tools · tab switch · ↑↓ navigate · enter expand · e/c
+          all
+        </Text>
+      </Box>
+
+      {/* Tool name */}
+      <Box>
+        <Text bold color="magenta">
+          {tool.name}
+        </Text>
+        {tool.running && <Text color="yellow"> ⟳ running</Text>}
+      </Box>
+
+      {/* Tabs */}
+      <Box gap={2}>
+        <Text
+          bold={tab === "input"}
+          color={tab === "input" ? "green" : undefined}
+          dimColor={tab !== "input"}
+        >
+          {tab === "input" ? "▸ " : "  "}Input
+        </Text>
+        <Text
+          bold={tab === "output"}
+          color={tab === "output" ? "green" : undefined}
+          dimColor={tab !== "output" && !hasOutput}
+        >
+          {tab === "output" ? "▸ " : "  "}Output{!hasOutput ? " (none)" : ""}
+        </Text>
+      </Box>
+
+      {/* Tree content */}
+      <Box flexDirection="column" flexGrow={1} overflow="hidden">
+        {rows.length === 0 && <Text dimColor> (empty)</Text>}
+        {rows.map((row, i) => {
+          const isSelected = i === cursor;
+          const indent = "  ".repeat(row.depth);
+          const arrow = row.hasChildren
+            ? expanded.has(row.path)
+              ? "▾ "
+              : "▸ "
+            : "  ";
+
+          return (
+            <Box key={row.path}>
+              <Text
+                backgroundColor={isSelected ? "#333" : undefined}
+                color={isSelected ? "cyan" : undefined}
+              >
+                {indent}
+                {arrow}
+                {row.key ? (
+                  <>
+                    <Text color="blue" bold={isSelected}>
+                      {row.key}
+                    </Text>
+                    {row.value !== null ? `: ${row.value}` : ""}
+                  </>
+                ) : (
+                  (row.value ?? "")
+                )}
+              </Text>
+            </Box>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+}

--- a/test/chat/agent.test.ts
+++ b/test/chat/agent.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { buildChatSystemPrompt, getChatTools } from "../../src/chat/agent.ts";
+
+describe("getChatTools", () => {
+  test("returns only chat-allowed tools", () => {
+    const tools = getChatTools();
+    const names = tools.map((t) => t.name);
+
+    // Should include chat tools
+    expect(names).toContain("create_task");
+    expect(names).toContain("list_tasks");
+    expect(names).toContain("view_task");
+    expect(names).toContain("list_threads");
+    expect(names).toContain("view_thread");
+    expect(names).toContain("search_context");
+    expect(names).toContain("update_beliefs");
+    expect(names).toContain("update_goals");
+    expect(names).toContain("list_schedules");
+    expect(names).toContain("create_schedule");
+
+    // Should NOT include daemon terminal tools
+    expect(names).not.toContain("complete_task");
+    expect(names).not.toContain("fail_task");
+    expect(names).not.toContain("wait_task");
+
+    // Should NOT include destructive file tools
+    expect(names).not.toContain("file_write");
+    expect(names).not.toContain("file_delete");
+    expect(names).not.toContain("file_edit");
+  });
+
+  test("returns valid Anthropic tool format", () => {
+    const tools = getChatTools();
+    for (const tool of tools) {
+      expect(tool.name).toBeTruthy();
+      expect(tool.description).toBeTruthy();
+      expect(tool.input_schema).toBeTruthy();
+      expect(tool.input_schema.type).toBe("object");
+    }
+  });
+});
+
+describe("buildChatSystemPrompt", () => {
+  test("includes chat-specific instructions", async () => {
+    const prompt = await buildChatSystemPrompt("/tmp/test-project");
+    expect(prompt).toContain("Botholomew");
+    expect(prompt).toContain("interactive chat interface");
+    expect(prompt).toContain("create_task");
+    expect(prompt).not.toContain("You are the Botholomew daemon");
+  });
+
+  test("includes meta header", async () => {
+    const prompt = await buildChatSystemPrompt("/tmp/test-project");
+    expect(prompt).toContain("Current time:");
+    expect(prompt).toContain("/tmp/test-project");
+  });
+});

--- a/test/chat/session.test.ts
+++ b/test/chat/session.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  type ChatSession,
+  endChatSession,
+  startChatSession,
+} from "../../src/chat/session.ts";
+import { listThreads } from "../../src/db/threads.ts";
+
+let projectDir: string;
+let session: ChatSession | null = null;
+
+beforeEach(async () => {
+  projectDir = await mkdtemp(join(tmpdir(), "both-test-"));
+  const bothDir = join(projectDir, ".botholomew");
+  await mkdir(bothDir, { recursive: true });
+  // Write a minimal config
+  await writeFile(
+    join(bothDir, "config.json"),
+    JSON.stringify({ anthropic_api_key: "test-key" }),
+  );
+});
+
+afterEach(async () => {
+  if (session) {
+    await endChatSession(session);
+    session = null;
+  }
+  await rm(projectDir, { recursive: true, force: true });
+});
+
+describe("startChatSession", () => {
+  test("creates a session with a thread", async () => {
+    session = await startChatSession(projectDir);
+    expect(session.threadId).toBeTruthy();
+    expect(session.conn).toBeTruthy();
+    expect(session.messages).toEqual([]);
+    expect(session.systemPrompt).toContain("interactive chat interface");
+  });
+
+  test("creates a chat_session thread in the database", async () => {
+    session = await startChatSession(projectDir);
+    const threads = await listThreads(session.conn, {
+      type: "chat_session",
+    });
+    expect(threads.length).toBe(1);
+    expect(threads[0]?.id).toBe(session.threadId);
+  });
+});
+
+describe("endChatSession", () => {
+  test("closes the thread and connection", async () => {
+    session = await startChatSession(projectDir);
+    const conn = session.conn;
+
+    // Verify thread exists and is open
+    const threads = await listThreads(conn, { type: "chat_session" });
+    expect(threads[0]?.ended_at).toBeNull();
+
+    await endChatSession(session);
+    session = null;
+
+    // Connection is closed, so we can't query it anymore
+    // But we verified the thread was open before closing
+  });
+});

--- a/test/tools/context-search.test.ts
+++ b/test/tools/context-search.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { searchContextTool } from "../../src/tools/context/search.ts";
+import type { ToolContext } from "../../src/tools/tool.ts";
+import { seedFile, setupToolContext } from "../helpers.ts";
+
+let ctx: ToolContext;
+
+beforeEach(() => {
+  ({ ctx } = setupToolContext());
+});
+
+describe("search_context", () => {
+  test("returns empty results for no matches", async () => {
+    const result = await searchContextTool.execute(
+      { query: "nonexistent" },
+      ctx,
+    );
+    expect(result.results).toEqual([]);
+    expect(result.count).toBe(0);
+  });
+
+  test("finds items by content", async () => {
+    await seedFile(
+      ctx.conn,
+      "/notes/meeting.md",
+      "Discussed quarterly revenue",
+    );
+    const result = await searchContextTool.execute({ query: "revenue" }, ctx);
+    expect(result.count).toBe(1);
+    expect(result.results[0]?.context_path).toBe("/notes/meeting.md");
+  });
+
+  test("finds items by title", async () => {
+    await seedFile(ctx.conn, "/reports/budget.md", "Numbers here", {
+      title: "Budget Report",
+    });
+    const result = await searchContextTool.execute({ query: "budget" }, ctx);
+    expect(result.count).toBe(1);
+  });
+
+  test("respects limit", async () => {
+    await seedFile(ctx.conn, "/a.md", "test content");
+    await seedFile(ctx.conn, "/b.md", "test content");
+    await seedFile(ctx.conn, "/c.md", "test content");
+    const result = await searchContextTool.execute(
+      { query: "test", limit: 2 },
+      ctx,
+    );
+    expect(result.count).toBe(2);
+  });
+
+  test("returns content preview", async () => {
+    await seedFile(ctx.conn, "/doc.md", "A very long document about testing");
+    const result = await searchContextTool.execute({ query: "testing" }, ctx);
+    expect(result.results[0]?.content_preview).toContain("testing");
+  });
+});

--- a/test/tools/task-list-view.test.ts
+++ b/test/tools/task-list-view.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { createTask } from "../../src/db/tasks.ts";
+import { listTasksTool } from "../../src/tools/task/list.ts";
+import { viewTaskTool } from "../../src/tools/task/view.ts";
+import type { ToolContext } from "../../src/tools/tool.ts";
+import { setupToolContext } from "../helpers.ts";
+
+let ctx: ToolContext;
+
+beforeEach(() => {
+  ({ ctx } = setupToolContext());
+});
+
+// ── list_tasks ────────────────────────────────────────────
+
+describe("list_tasks", () => {
+  test("returns empty list when no tasks", async () => {
+    const result = await listTasksTool.execute({}, ctx);
+    expect(result.tasks).toEqual([]);
+    expect(result.count).toBe(0);
+  });
+
+  test("returns all tasks", async () => {
+    await createTask(ctx.conn, { name: "Task A" });
+    await createTask(ctx.conn, { name: "Task B" });
+    const result = await listTasksTool.execute({}, ctx);
+    expect(result.count).toBe(2);
+    expect(result.tasks.map((t) => t.name)).toEqual(["Task A", "Task B"]);
+  });
+
+  test("filters by status", async () => {
+    await createTask(ctx.conn, { name: "Pending" });
+    const result = await listTasksTool.execute({ status: "pending" }, ctx);
+    expect(result.count).toBe(1);
+    expect(result.tasks[0]?.status).toBe("pending");
+  });
+
+  test("filters by priority", async () => {
+    await createTask(ctx.conn, { name: "Low", priority: "low" });
+    await createTask(ctx.conn, { name: "High", priority: "high" });
+    const result = await listTasksTool.execute({ priority: "high" }, ctx);
+    expect(result.count).toBe(1);
+    expect(result.tasks[0]?.name).toBe("High");
+  });
+
+  test("respects limit", async () => {
+    await createTask(ctx.conn, { name: "A" });
+    await createTask(ctx.conn, { name: "B" });
+    await createTask(ctx.conn, { name: "C" });
+    const result = await listTasksTool.execute({ limit: 2 }, ctx);
+    expect(result.count).toBe(2);
+  });
+});
+
+// ── view_task ─────────────────────────────────────────────
+
+describe("view_task", () => {
+  test("returns task details", async () => {
+    const task = await createTask(ctx.conn, {
+      name: "My Task",
+      description: "Do stuff",
+      priority: "high",
+    });
+    const result = await viewTaskTool.execute({ id: task.id }, ctx);
+    expect(result.task).not.toBeNull();
+    expect(result.task?.name).toBe("My Task");
+    expect(result.task?.description).toBe("Do stuff");
+    expect(result.task?.priority).toBe("high");
+    expect(result.task?.status).toBe("pending");
+  });
+
+  test("returns null for missing task", async () => {
+    const result = await viewTaskTool.execute({ id: "nonexistent" }, ctx);
+    expect(result.task).toBeNull();
+  });
+
+  test("includes blocked_by and context_ids", async () => {
+    const dep = await createTask(ctx.conn, { name: "Dep" });
+    const task = await createTask(ctx.conn, {
+      name: "Blocked",
+      blocked_by: [dep.id],
+    });
+    const result = await viewTaskTool.execute({ id: task.id }, ctx);
+    expect(result.task?.blocked_by).toEqual([dep.id]);
+  });
+});

--- a/test/tools/thread-list-view.test.ts
+++ b/test/tools/thread-list-view.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+  createThread,
+  endThread,
+  logInteraction,
+} from "../../src/db/threads.ts";
+import { listThreadsTool } from "../../src/tools/thread/list.ts";
+import { viewThreadTool } from "../../src/tools/thread/view.ts";
+import type { ToolContext } from "../../src/tools/tool.ts";
+import { setupToolContext } from "../helpers.ts";
+
+let ctx: ToolContext;
+
+beforeEach(() => {
+  ({ ctx } = setupToolContext());
+});
+
+// ── list_threads ──────────────────────────────────────────
+
+describe("list_threads", () => {
+  test("returns empty list when no threads", async () => {
+    const result = await listThreadsTool.execute({}, ctx);
+    expect(result.threads).toEqual([]);
+    expect(result.count).toBe(0);
+  });
+
+  test("returns all threads", async () => {
+    await createThread(ctx.conn, "daemon_tick", undefined, "Tick 1");
+    await createThread(ctx.conn, "chat_session", undefined, "Chat 1");
+    const result = await listThreadsTool.execute({}, ctx);
+    expect(result.count).toBe(2);
+  });
+
+  test("filters by type", async () => {
+    await createThread(ctx.conn, "daemon_tick", undefined, "Tick");
+    await createThread(ctx.conn, "chat_session", undefined, "Chat");
+    const result = await listThreadsTool.execute({ type: "chat_session" }, ctx);
+    expect(result.count).toBe(1);
+    expect(result.threads[0]?.type).toBe("chat_session");
+  });
+
+  test("respects limit", async () => {
+    await createThread(ctx.conn, "daemon_tick", undefined, "A");
+    await createThread(ctx.conn, "daemon_tick", undefined, "B");
+    await createThread(ctx.conn, "daemon_tick", undefined, "C");
+    const result = await listThreadsTool.execute({ limit: 2 }, ctx);
+    expect(result.count).toBe(2);
+  });
+});
+
+// ── view_thread ───────────────────────────────────────────
+
+describe("view_thread", () => {
+  test("returns thread with interactions", async () => {
+    const threadId = await createThread(
+      ctx.conn,
+      "daemon_tick",
+      undefined,
+      "Test Thread",
+    );
+    await logInteraction(ctx.conn, threadId, {
+      role: "user",
+      kind: "message",
+      content: "Hello",
+    });
+    await logInteraction(ctx.conn, threadId, {
+      role: "assistant",
+      kind: "message",
+      content: "Hi there",
+    });
+    await endThread(ctx.conn, threadId);
+
+    const result = await viewThreadTool.execute({ id: threadId }, ctx);
+    expect(result.thread).not.toBeNull();
+    expect(result.thread?.title).toBe("Test Thread");
+    expect(result.interactions.length).toBe(2);
+    expect(result.interactions[0]?.content).toBe("Hello");
+    expect(result.interactions[1]?.content).toBe("Hi there");
+  });
+
+  test("returns null for missing thread", async () => {
+    const result = await viewThreadTool.execute({ id: "nonexistent" }, ctx);
+    expect(result.thread).toBeNull();
+    expect(result.interactions).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Implements Milestone 5: full interactive chat TUI using Ink 6 + React 19 with streaming responses, tool call display, and session resume via `--thread-id`
- Adds chat agent (`src/chat/`) with multi-turn tool execution loop, streaming token callbacks, and Anthropic SDK integration
- New TUI components: InputBar with up/down arrow history navigation, MessageList with timestamped messages and full-width user message styling, StatusBar embedded as input header, and ToolCall display with colored status indicators
- Adds new tools for chat mode: list/view tasks, list/view threads, search context, update beliefs/goals — registered in the tool registry with chat-mode allow-list
- Refactors `daemon/prompt.ts` to extract reusable `buildMetaHeader()` and `loadPersistentContext()` for shared use between daemon and chat agent
- Restores full interaction history (including tool calls) when resuming a chat session from the database

## Test plan
- [x] `bun test` passes (346 tests)
- [x] `bun run lint` passes (tsc + biome)
- [ ] Manual: run `botholomew chat`, send messages, verify streaming and tool calls render
- [ ] Manual: resume a thread with `--thread-id`, verify history and tool calls restore
- [ ] Manual: verify up/down arrow history navigation in input bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)