### PR TITLE
Add terminal background color awareness to TUI

### DIFF
--- a/src/tui/components/MessageList.tsx
+++ b/src/tui/components/MessageList.tsx
@@ -1,6 +1,7 @@
 import { Box, Text, useStdout } from "ink";
 import Spinner from "ink-spinner";
 import { memo, useMemo } from "react";
+import { theme } from "../theme.ts";
 import { ToolCall, type ToolCallData } from "./ToolCall.tsx";
 
 export interface ChatMessage {
@@ -54,13 +55,13 @@ const MessageBubble = memo(function MessageBubble({
       .join("\n");
     return (
       <Box flexDirection="column" marginTop={1}>
-        <Text backgroundColor="#1a3a5c">
+        <Text backgroundColor={theme.userBg}>
           <Text bold color="cyan">
             {" You "}
           </Text>
           <Text dimColor>{padLine(time, cols - 5)}</Text>
         </Text>
-        <Text backgroundColor="#1a3a5c">{paddedContent}</Text>
+        <Text backgroundColor={theme.userBg}>{paddedContent}</Text>
       </Box>
     );
   }
@@ -68,7 +69,7 @@ const MessageBubble = memo(function MessageBubble({
   if (message.role === "system") {
     return (
       <Box marginTop={1}>
-        <Text color="yellow" dimColor>
+        <Text color={theme.accent} dimColor>
           ⚠ {message.content}
         </Text>
         <Text dimColor> {time}</Text>
@@ -131,7 +132,7 @@ export function MessageList({
               flexDirection="column"
               marginLeft={1}
               borderStyle="round"
-              borderColor="yellow"
+              borderColor={theme.accentBorder}
               paddingX={1}
             >
               {activeToolCalls.map((tc) => (
@@ -149,7 +150,7 @@ export function MessageList({
 
       {isLoading && !streamingText && activeToolCalls.length === 0 && (
         <Box marginTop={1}>
-          <Text color="yellow">
+          <Text color={theme.accent}>
             <Spinner type="dots" />
           </Text>
           <Text dimColor> Thinking...</Text>

--- a/src/tui/components/StatusBar.tsx
+++ b/src/tui/components/StatusBar.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import type { DbConnection } from "../../db/connection.ts";
 import { listTasks } from "../../db/tasks.ts";
 import { getDaemonStatus } from "../../utils/pid.ts";
+import { theme } from "../theme.ts";
 
 interface StatusBarProps {
   projectDir: string;
@@ -54,7 +55,7 @@ export function StatusBar({ projectDir, conn, isLoading }: StatusBarProps) {
       </Text>
       <Text dimColor> | </Text>
       {isLoading ? (
-        <Text color="yellow">Working...</Text>
+        <Text color={theme.accent}>Working...</Text>
       ) : (
         <Text color="green">Ready</Text>
       )}

--- a/src/tui/components/ToolCall.tsx
+++ b/src/tui/components/ToolCall.tsx
@@ -1,4 +1,5 @@
 import { Box, Text } from "ink";
+import { theme } from "../theme.ts";
 
 export interface ToolCallData {
   name: string;
@@ -19,10 +20,10 @@ export function ToolCall({ tool }: ToolCallProps) {
   return (
     <Box flexDirection="column">
       <Box>
-        <Text color={tool.running ? "yellow" : "gray"}>
+        <Text color={tool.running ? theme.accent : theme.muted}>
           {tool.running ? "  ⟳ " : "  ✔ "}
         </Text>
-        <Text color={tool.running ? "yellow" : "magenta"} bold>
+        <Text color={tool.running ? theme.accent : theme.toolName} bold>
           {tool.name}
         </Text>
         <Text dimColor> ({truncatedInput})</Text>

--- a/src/tui/components/ToolPanel.tsx
+++ b/src/tui/components/ToolPanel.tsx
@@ -1,5 +1,6 @@
 import { Box, Text, useInput } from "ink";
 import { useMemo, useState } from "react";
+import { theme } from "../theme.ts";
 import type { ToolCallData } from "./ToolCall.tsx";
 
 interface ToolPanelProps {
@@ -267,7 +268,7 @@ export function ToolPanel({ toolCalls, onClose }: ToolPanelProps) {
         <Text bold color="magenta">
           {tool.name}
         </Text>
-        {tool.running && <Text color="yellow"> ⟳ running</Text>}
+        {tool.running && <Text color={theme.accent}> ⟳ running</Text>}
       </Box>
 
       {/* Tabs */}
@@ -303,7 +304,7 @@ export function ToolPanel({ toolCalls, onClose }: ToolPanelProps) {
           return (
             <Box key={row.path}>
               <Text
-                backgroundColor={isSelected ? "#333" : undefined}
+                backgroundColor={isSelected ? theme.selectionBg : undefined}
                 color={isSelected ? "cyan" : undefined}
               >
                 {indent}

--- a/src/tui/theme.ts
+++ b/src/tui/theme.ts
@@ -1,0 +1,58 @@
+/**
+ * Terminal-background-aware color theme for the TUI.
+ *
+ * Detection order:
+ * 1. COLORFGBG env var (set by Terminal.app, iTerm2, xterm)
+ * 2. macOS system appearance via `defaults read -g AppleInterfaceStyle`
+ * 3. Falls back to dark theme
+ */
+
+import { spawnSync } from "node:child_process";
+
+function detectDarkBackground(): boolean {
+  // 1. Check COLORFGBG env var
+  const colorfgbg = process.env.COLORFGBG;
+  if (colorfgbg) {
+    const parts = colorfgbg.split(";");
+    const bg = Number.parseInt(parts[parts.length - 1] ?? "", 10);
+    if (!Number.isNaN(bg)) {
+      // Standard terminal colors: 0-6 are dark, 7+ are light
+      return bg <= 6;
+    }
+  }
+
+  // 2. On macOS, check system appearance
+  if (process.platform === "darwin") {
+    try {
+      const result = spawnSync(
+        "defaults",
+        ["read", "-g", "AppleInterfaceStyle"],
+        { encoding: "utf-8", timeout: 500 },
+      );
+      // Returns "Dark" in dark mode; exits non-zero in light mode
+      return result.stdout?.trim() === "Dark";
+    } catch {
+      // fall through to default
+    }
+  }
+
+  return true; // default to dark
+}
+
+const isDark = detectDarkBackground();
+
+export const theme = {
+  accent: isDark ? "yellow" : "#B8860B",
+  accentBorder: isDark ? "yellow" : "#B8860B",
+  userBg: isDark ? "#1a3a5c" : "#d0e0f0",
+  selectionBg: isDark ? "#333" : "#ddd",
+  success: "green",
+  error: "red",
+  info: "cyan",
+  primary: "blue",
+  toolName: "magenta",
+  muted: "gray",
+} as const;
+
+// Exported for testing
+export { detectDarkBackground };

--- a/test/tui/theme.test.ts
+++ b/test/tui/theme.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+
+describe("theme", () => {
+  let originalColorfgbg: string | undefined;
+
+  beforeEach(() => {
+    originalColorfgbg = process.env.COLORFGBG;
+  });
+
+  afterEach(() => {
+    if (originalColorfgbg === undefined) {
+      delete process.env.COLORFGBG;
+    } else {
+      process.env.COLORFGBG = originalColorfgbg;
+    }
+  });
+
+  function loadTheme() {
+    // Re-import to pick up env changes
+    delete require.cache[require.resolve("../../src/tui/theme.ts")];
+    return require("../../src/tui/theme.ts");
+  }
+
+  // --- COLORFGBG detection (takes priority) ---
+
+  test("detects dark background from COLORFGBG", () => {
+    process.env.COLORFGBG = "15;0";
+    const { detectDarkBackground } = loadTheme();
+    expect(detectDarkBackground()).toBe(true);
+  });
+
+  test("detects light background from COLORFGBG", () => {
+    process.env.COLORFGBG = "0;15";
+    const { detectDarkBackground } = loadTheme();
+    expect(detectDarkBackground()).toBe(false);
+  });
+
+  test("detects light background with bg=7", () => {
+    process.env.COLORFGBG = "0;7";
+    const { detectDarkBackground } = loadTheme();
+    expect(detectDarkBackground()).toBe(false);
+  });
+
+  test("detects dark background with bg=6", () => {
+    process.env.COLORFGBG = "15;6";
+    const { detectDarkBackground } = loadTheme();
+    expect(detectDarkBackground()).toBe(true);
+  });
+
+  test("handles three-part COLORFGBG (rxvt style)", () => {
+    process.env.COLORFGBG = "0;default;15";
+    const { detectDarkBackground } = loadTheme();
+    expect(detectDarkBackground()).toBe(false);
+  });
+
+  test("falls through on malformed COLORFGBG", () => {
+    process.env.COLORFGBG = "garbage";
+    const { detectDarkBackground } = loadTheme();
+    // Falls through to macOS detection or default
+    expect(typeof detectDarkBackground()).toBe("boolean");
+  });
+
+  test("falls through on empty COLORFGBG", () => {
+    process.env.COLORFGBG = "";
+    const { detectDarkBackground } = loadTheme();
+    expect(typeof detectDarkBackground()).toBe("boolean");
+  });
+
+  // --- macOS fallback ---
+
+  test("without COLORFGBG on macOS, matches system appearance", () => {
+    if (process.platform !== "darwin") return; // skip on non-macOS
+    delete process.env.COLORFGBG;
+
+    const result = spawnSync(
+      "defaults",
+      ["read", "-g", "AppleInterfaceStyle"],
+      { encoding: "utf-8", timeout: 500 },
+    );
+    const systemIsDark = result.stdout?.trim() === "Dark";
+
+    const { detectDarkBackground } = loadTheme();
+    expect(detectDarkBackground()).toBe(systemIsDark);
+  });
+
+  // --- Theme values ---
+
+  test("dark theme uses yellow accent", () => {
+    process.env.COLORFGBG = "15;0"; // force dark
+    const { theme } = loadTheme();
+    expect(theme.accent).toBe("yellow");
+    expect(theme.userBg).toBe("#1a3a5c");
+    expect(theme.selectionBg).toBe("#333");
+  });
+
+  test("light theme uses dark goldenrod accent", () => {
+    process.env.COLORFGBG = "0;15"; // force light
+    const { theme } = loadTheme();
+    expect(theme.accent).toBe("#B8860B");
+    expect(theme.userBg).toBe("#d0e0f0");
+    expect(theme.selectionBg).toBe("#ddd");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `src/tui/theme.ts` that detects light vs dark terminal backgrounds using the `COLORFGBG` env var and macOS system appearance (`defaults read -g AppleInterfaceStyle`)
- Replaces all hardcoded `"yellow"` and dark-only hex colors across TUI components with theme-aware constants (dark goldenrod `#B8860B` on light backgrounds, standard `yellow` on dark)
- Also adapts user message background (`#1a3a5c` → `#d0e0f0`) and selection background (`#333` → `#ddd`) for light terminals
- Includes 10 tests covering COLORFGBG parsing, macOS fallback, and theme value assertions

## Test plan
- [x] `bun run lint` passes
- [x] `bun test` passes (356 tests, 0 failures)
- [ ] Manual: run `bun dev chat` on a light-background terminal — yellow text should be replaced with readable dark goldenrod
- [ ] Manual: run on a dark-background terminal — colors unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)