### PR TITLE
Fix context add: validate paths early, show progress spinners

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
         "ink-spinner": "^5.0.0",
         "ink-text-input": "^6.0.0",
         "istextorbinary": "^9.5.0",
+        "nanospinner": "^1.2.2",
         "react": "^19.1.0",
         "uuid": "^13.0.0",
         "zod": "^4.3.6",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "ink-spinner": "^5.0.0",
     "ink-text-input": "^6.0.0",
     "istextorbinary": "^9.5.0",
+    "nanospinner": "^1.2.2",
     "react": "^19.1.0",
     "uuid": "^13.0.0",
     "zod": "^4.3.6"

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -3,6 +3,7 @@ import { basename, join, resolve } from "node:path";
 import ansis from "ansis";
 import type { Command } from "commander";
 import { isText } from "istextorbinary";
+import { createSpinner } from "nanospinner";
 import { loadConfig } from "../config/loader.ts";
 import { embedSingle, warmupEmbedder } from "../context/embedder.ts";
 import { ingestContextItem } from "../context/ingest.ts";
@@ -67,43 +68,71 @@ export function registerContextCommand(program: Command) {
     .option("--prefix <prefix>", "virtual path prefix", "/")
     .action((paths: string[], opts) =>
       withDb(program, async (conn, dir) => {
-        const config = await loadConfig(dir);
-        await warmupEmbedder();
-
-        let added = 0;
-        let chunks = 0;
+        // Phase 1: Scan all paths and validate they exist
+        const filesToAdd: { filePath: string; contextPath: string }[] = [];
+        const spinner = createSpinner("Scanning files...").start();
 
         for (const path of paths) {
           const resolvedPath = resolve(path);
-          const info = await stat(resolvedPath);
+          let info: Awaited<ReturnType<typeof stat>>;
+          try {
+            info = await stat(resolvedPath);
+          } catch {
+            spinner.error({ text: `Path not found: ${resolvedPath}` });
+            process.exit(1);
+          }
 
           if (info.isDirectory()) {
             const entries = await walkDirectory(resolvedPath);
             for (const filePath of entries) {
               const relativePath = filePath.slice(resolvedPath.length);
-              const contextPath = join(opts.prefix, relativePath);
-              const count = await addFile(conn, config, filePath, contextPath);
-              if (count >= 0) {
-                added++;
-                chunks += count;
-              }
+              filesToAdd.push({
+                filePath,
+                contextPath: join(opts.prefix, relativePath),
+              });
             }
           } else {
-            const contextPath = join(opts.prefix, basename(resolvedPath));
-            const count = await addFile(
-              conn,
-              config,
-              resolvedPath,
-              contextPath,
-            );
-            if (count >= 0) {
-              added++;
-              chunks += count;
-            }
+            filesToAdd.push({
+              filePath: resolvedPath,
+              contextPath: join(opts.prefix, basename(resolvedPath)),
+            });
+          }
+        }
+
+        spinner.success({
+          text: `Found ${filesToAdd.length} file(s) to add.`,
+        });
+
+        // Phase 2: Warmup embedder
+        const embedSpinner = createSpinner(
+          "Loading embedding model...",
+        ).start();
+        const config = await loadConfig(dir);
+        await warmupEmbedder();
+        embedSpinner.success({ text: "Embedding model loaded." });
+
+        // Phase 3: Process files one-by-one
+        let added = 0;
+        let chunks = 0;
+
+        for (const [i, { filePath, contextPath }] of filesToAdd.entries()) {
+          const fileSpinner = createSpinner(
+            `Processing ${basename(filePath)} (${i + 1}/${filesToAdd.length})...`,
+          ).start();
+          const count = await addFile(conn, config, filePath, contextPath);
+          if (count >= 0) {
+            added++;
+            chunks += count;
+            fileSpinner.success({
+              text: `${contextPath} (${count} chunks)`,
+            });
+          } else {
+            fileSpinner.warn({ text: `${contextPath}: skipped` });
           }
         }
 
         logger.success(`Added ${added} file(s), ${chunks} chunk(s) indexed.`);
+        process.exit(0);
       }),
     );
 
@@ -165,12 +194,9 @@ async function addFile(
     });
 
     if (textual && content) {
-      const count = await ingestContextItem(conn, item.id, config);
-      console.log(`  + ${contextPath} (${count} chunks)`);
-      return count;
+      return await ingestContextItem(conn, item.id, config);
     }
 
-    console.log(`  + ${contextPath} (binary, not indexed)`);
     return 0;
   } catch (err) {
     logger.warn(`  ! ${contextPath}: ${err}`);

--- a/src/context/embedder.ts
+++ b/src/context/embedder.ts
@@ -3,7 +3,6 @@ import {
   EMBEDDING_DTYPE,
   EMBEDDING_MODEL_ID,
 } from "../constants.ts";
-import { logger } from "../utils/logger.ts";
 
 type EmbedFn = (texts: string[]) => Promise<number[][]>;
 
@@ -11,12 +10,10 @@ let pipelineInstance: ReturnType<typeof createPipelinePromise> | null = null;
 
 function createPipelinePromise() {
   return (async () => {
-    logger.info(`Loading embedding model ${EMBEDDING_MODEL_ID}...`);
     const { pipeline } = await import("@huggingface/transformers");
     const pipe = await pipeline("feature-extraction", EMBEDDING_MODEL_ID, {
       dtype: EMBEDDING_DTYPE,
     });
-    logger.info("Embedding model loaded.");
     return pipe;
   })();
 }


### PR DESCRIPTION
## Summary
- Restructure `context add` into three phases: validate all paths upfront, warm up the embedder, then process files one-by-one
- Missing files now fail immediately before loading the embedding model
- Add `nanospinner` progress spinners for each phase (scan, model load, per-file processing)
- Force `process.exit(0)` after completion to avoid hanging on ONNX runtime cleanup
- Move embedding model log messages out of `embedder.ts` so callers control output

## Test plan
- [x] `bun run lint` passes
- [x] `bun test` — all 346 tests pass
- [ ] `bun dev context add docs <missing-file>` — errors immediately without loading embedder
- [ ] `bun dev context add docs` — shows spinner per file, exits cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)