### PR TITLE
Add tabbed TUI with Chat, Tools, Context, and Help panels

### DIFF
--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -15,7 +15,8 @@ export function registerChatCommand(program: Command) {
         "    /quit, /exit    End the chat session",
     )
     .option("--thread-id <id>", "Resume an existing chat thread")
-    .action(async (opts: { threadId?: string }) => {
+    .option("-p, --prompt <text>", "Start chat with an initial prompt")
+    .action(async (opts: { threadId?: string; prompt?: string }) => {
       const { render } = await import("ink");
       const React = await import("react");
       const { App } = await import("../tui/App.tsx");
@@ -24,6 +25,7 @@ export function registerChatCommand(program: Command) {
         React.createElement(App, {
           projectDir: dir,
           threadId: opts.threadId,
+          initialPrompt: opts.prompt,
         }),
         {
           kittyKeyboard: {

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -1,4 +1,4 @@
-import { Box, Text, useApp } from "ink";
+import { Box, Text, useApp, useInput } from "ink";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   type ChatSession,
@@ -8,9 +8,12 @@ import {
 } from "../chat/session.ts";
 import type { Interaction } from "../db/threads.ts";
 import { getThread } from "../db/threads.ts";
+import { ContextPanel } from "./components/ContextPanel.tsx";
+import { HelpPanel } from "./components/HelpPanel.tsx";
 import { InputBar } from "./components/InputBar.tsx";
 import { type ChatMessage, MessageList } from "./components/MessageList.tsx";
 import { StatusBar } from "./components/StatusBar.tsx";
+import { TabBar, type TabId } from "./components/TabBar.tsx";
 import type { ToolCallData } from "./components/ToolCall.tsx";
 import { ToolPanel } from "./components/ToolPanel.tsx";
 
@@ -38,7 +41,6 @@ function restoreMessagesFromInteractions(
         running: false,
       });
     } else if (ix.kind === "tool_result") {
-      // Attach output to the matching pending tool call
       const tc = pendingTools.find((t) => t.name === ix.tool_name && !t.output);
       if (tc) {
         tc.output = ix.content;
@@ -62,7 +64,6 @@ function restoreMessagesFromInteractions(
     }
   }
 
-  // If there are leftover tool calls with no following assistant message
   if (pendingTools.length > 0) {
     result.push({
       id: msgId(),
@@ -87,7 +88,8 @@ export function App({ projectDir, threadId: resumeThreadId }: AppProps) {
   const [ready, setReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const sessionRef = useRef<ChatSession | null>(null);
-  const [toolPanelOpen, setToolPanelOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState<TabId>(1);
+  const [daemonRunning, setDaemonRunning] = useState(false);
   const queueRef = useRef<string[]>([]);
   const processingRef = useRef(false);
 
@@ -103,7 +105,6 @@ export function App({ projectDir, threadId: resumeThreadId }: AppProps) {
         }
         sessionRef.current = session;
 
-        // If resuming, populate the message list from DB interactions
         if (session.messages.length > 0) {
           const threadData = await getThread(session.conn, session.threadId);
           if (threadData) {
@@ -113,13 +114,13 @@ export function App({ projectDir, threadId: resumeThreadId }: AppProps) {
           }
         }
 
-        // Show startup hint
         setMessages((prev) => [
           ...prev,
           {
             id: msgId(),
             role: "system" as const,
-            content: "Type /help for keyboard shortcuts and commands.",
+            content:
+              "Press Tab to switch between panels. Type /help for commands.",
             timestamp: new Date(),
           },
         ]);
@@ -142,6 +143,35 @@ export function App({ projectDir, threadId: resumeThreadId }: AppProps) {
     };
   }, [projectDir, resumeThreadId]);
 
+  // Tab switching via useInput at the App level
+  // On the Chat tab (1), only Tab key switches — number keys go to InputBar.
+  // On other tabs, both Tab and number keys switch tabs, Escape returns to Chat.
+  useInput(
+    (input, key) => {
+      if (activeTab !== 1) {
+        // Number keys jump to tab on non-chat tabs
+        const num = Number.parseInt(input, 10);
+        if (num >= 1 && num <= 4) {
+          setActiveTab(num as TabId);
+          return;
+        }
+        // Escape returns to chat
+        if (key.escape) {
+          setActiveTab(1);
+          return;
+        }
+      }
+    },
+    { isActive: activeTab !== 1 },
+  );
+
+  // Tab key cycles tabs — always active (InputBar ignores tab)
+  useInput((_input, key) => {
+    if (key.tab && !key.shift) {
+      setActiveTab((t) => ((t % 4) + 1) as TabId);
+    }
+  });
+
   const processQueue = useCallback(async () => {
     if (processingRef.current || !sessionRef.current) return;
     processingRef.current = true;
@@ -153,7 +183,6 @@ export function App({ projectDir, threadId: resumeThreadId }: AppProps) {
       setStreamingText("");
       setActiveToolCalls([]);
 
-      // Add user message
       const userMsg: ChatMessage = {
         id: msgId(),
         role: "user",
@@ -162,7 +191,6 @@ export function App({ projectDir, threadId: resumeThreadId }: AppProps) {
       };
       setMessages((prev) => [...prev, userMsg]);
 
-      // Collect tool calls for the current segment
       let pendingToolCalls: ToolCallData[] = [];
       let currentText = "";
 
@@ -236,20 +264,21 @@ export function App({ projectDir, threadId: resumeThreadId }: AppProps) {
 
       setInputValue("");
 
-      // Handle /help
       if (trimmed === "/help") {
         const helpMsg: ChatMessage = {
           id: msgId(),
           role: "system",
           content: [
             "Keyboard shortcuts:",
+            "  Tab            Switch between panels",
+            "  1-4            Jump to panel (when not in Chat)",
+            "  Escape         Return to Chat",
             "  Enter          Send message",
             "  ⌥+Enter        Insert newline",
             "  ↑/↓            Browse input history",
             "",
             "Commands:",
             "  /help           Show this help",
-            "  /tools          Toggle tool call inspector",
             "  /quit, /exit    End the chat session",
           ].join("\n"),
           timestamp: new Date(),
@@ -258,31 +287,6 @@ export function App({ projectDir, threadId: resumeThreadId }: AppProps) {
         return;
       }
 
-      // Handle /tools
-      if (trimmed === "/tools") {
-        setMessages((prev) => {
-          const hasTools = prev.some(
-            (m) => m.toolCalls && m.toolCalls.length > 0,
-          );
-          if (!hasTools) {
-            return [
-              ...prev,
-              {
-                id: msgId(),
-                role: "system" as const,
-                content: "No tool calls to inspect yet.",
-                timestamp: new Date(),
-              },
-            ];
-          }
-          // Use setTimeout to toggle panel after state update
-          setTimeout(() => setToolPanelOpen((p) => !p), 0);
-          return prev;
-        });
-        return;
-      }
-
-      // Handle /quit
       if (trimmed === "/quit" || trimmed === "/exit") {
         if (sessionRef.current) {
           const threadId = sessionRef.current.threadId;
@@ -303,7 +307,6 @@ export function App({ projectDir, threadId: resumeThreadId }: AppProps) {
     [exit, processQueue],
   );
 
-  // Collect all tool calls from messages for the panel
   const allToolCalls = useMemo(
     () => messages.flatMap((m) => m.toolCalls ?? []),
     [messages],
@@ -325,31 +328,49 @@ export function App({ projectDir, threadId: resumeThreadId }: AppProps) {
     );
   }
 
+  const conn = sessionRef.current.conn;
+  const threadId = sessionRef.current.threadId;
+
   return (
     <Box flexDirection="column" height="100%">
-      <MessageList
-        messages={messages}
-        streamingText={streamingText}
-        isLoading={isLoading}
-        activeToolCalls={activeToolCalls}
-      />
-      {toolPanelOpen && allToolCalls.length > 0 && (
-        <ToolPanel
-          toolCalls={allToolCalls}
-          onClose={() => setToolPanelOpen(false)}
+      <TabBar activeTab={activeTab} />
+
+      {/* Tab content area */}
+      {activeTab === 1 && (
+        <MessageList
+          messages={messages}
+          streamingText={streamingText}
+          isLoading={isLoading}
+          activeToolCalls={activeToolCalls}
         />
       )}
+      {activeTab === 2 && (
+        <ToolPanel toolCalls={allToolCalls} isActive={activeTab === 2} />
+      )}
+      {activeTab === 3 && (
+        <ContextPanel conn={conn} isActive={activeTab === 3} />
+      )}
+      {activeTab === 4 && (
+        <HelpPanel
+          projectDir={projectDir}
+          threadId={threadId}
+          daemonRunning={daemonRunning}
+        />
+      )}
+
+      {/* Bottom bar: StatusBar + InputBar (input only on Chat tab) */}
       <InputBar
         value={inputValue}
         onChange={setInputValue}
         onSubmit={handleSubmit}
-        disabled={toolPanelOpen}
+        disabled={activeTab !== 1}
         history={inputHistory}
         header={
           <StatusBar
             projectDir={projectDir}
-            conn={sessionRef.current.conn}
+            conn={conn}
             isLoading={isLoading}
+            onDaemonStatusChange={setDaemonRunning}
           />
         }
       />

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -9,6 +9,7 @@ import {
 import type { Interaction } from "../db/threads.ts";
 import { getThread } from "../db/threads.ts";
 import { ContextPanel } from "./components/ContextPanel.tsx";
+import { Divider } from "./components/Divider.tsx";
 import { HelpPanel } from "./components/HelpPanel.tsx";
 import { InputBar } from "./components/InputBar.tsx";
 import { type ChatMessage, MessageList } from "./components/MessageList.tsx";
@@ -20,6 +21,7 @@ import { ToolPanel } from "./components/ToolPanel.tsx";
 interface AppProps {
   projectDir: string;
   threadId?: string;
+  initialPrompt?: string;
 }
 
 let nextMsgId = 0;
@@ -39,6 +41,7 @@ function restoreMessagesFromInteractions(
         name: ix.tool_name ?? "unknown",
         input: ix.tool_input ?? "{}",
         running: false,
+        timestamp: ix.created_at,
       });
     } else if (ix.kind === "tool_result") {
       const tc = pendingTools.find((t) => t.name === ix.tool_name && !t.output);
@@ -77,7 +80,11 @@ function restoreMessagesFromInteractions(
   return result;
 }
 
-export function App({ projectDir, threadId: resumeThreadId }: AppProps) {
+export function App({
+  projectDir,
+  threadId: resumeThreadId,
+  initialPrompt,
+}: AppProps) {
   const { exit } = useApp();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [inputValue, setInputValue] = useState("");
@@ -222,7 +229,12 @@ export function App({ projectDir, threadId: resumeThreadId }: AppProps) {
             if (currentText) {
               finalizeSegment();
             }
-            const tc: ToolCallData = { name, input, running: true };
+            const tc: ToolCallData = {
+              name,
+              input,
+              running: true,
+              timestamp: new Date(),
+            };
             pendingToolCalls.push(tc);
             setActiveToolCalls([...pendingToolCalls]);
           },
@@ -257,6 +269,17 @@ export function App({ projectDir, threadId: resumeThreadId }: AppProps) {
     processingRef.current = false;
   }, []);
 
+  // Auto-submit initial prompt once session is ready
+  const initialPromptSent = useRef(false);
+  useEffect(() => {
+    if (ready && initialPrompt && !initialPromptSent.current) {
+      initialPromptSent.current = true;
+      queueRef.current.push(initialPrompt);
+      setInputHistory((prev) => [...prev, initialPrompt]);
+      processQueue();
+    }
+  }, [ready, initialPrompt, processQueue]);
+
   const handleSubmit = useCallback(
     async (text: string) => {
       const trimmed = text.trim();
@@ -269,13 +292,27 @@ export function App({ projectDir, threadId: resumeThreadId }: AppProps) {
           id: msgId(),
           role: "system",
           content: [
-            "Keyboard shortcuts:",
-            "  Tab            Switch between panels",
+            "Navigation:",
+            "  Tab            Cycle between panels",
             "  1-4            Jump to panel (when not in Chat)",
             "  Escape         Return to Chat",
+            "",
+            "Chat (Tab 1):",
             "  Enter          Send message",
             "  ⌥+Enter        Insert newline",
             "  ↑/↓            Browse input history",
+            "",
+            "Tools (Tab 2):",
+            "  ↑/↓            Select tool call",
+            "  Shift+↑/↓      Scroll detail pane",
+            "  j/k            Scroll detail pane",
+            "",
+            "Context (Tab 3):",
+            "  ↑/↓            Navigate items",
+            "  Enter          Expand directory / preview file",
+            "  Backspace      Go up one directory",
+            "  /              Search context",
+            "  d              Delete selected item",
             "",
             "Commands:",
             "  /help           Show this help",
@@ -334,6 +371,7 @@ export function App({ projectDir, threadId: resumeThreadId }: AppProps) {
   return (
     <Box flexDirection="column" height="100%">
       <TabBar activeTab={activeTab} />
+      <Divider isLoading={isLoading} />
 
       {/* Tab content area */}
       {activeTab === 1 && (

--- a/src/tui/components/ContextPanel.tsx
+++ b/src/tui/components/ContextPanel.tsx
@@ -1,0 +1,306 @@
+import { Box, Text, useInput } from "ink";
+import { useCallback, useEffect, useState } from "react";
+import type { DbConnection } from "../../db/connection.ts";
+import {
+  type ContextItem,
+  getDistinctDirectories,
+  listContextItemsByPrefix,
+  searchContextByKeyword,
+} from "../../db/context.ts";
+
+interface ContextPanelProps {
+  conn: DbConnection;
+  isActive: boolean;
+}
+
+interface DirEntry {
+  type: "directory";
+  name: string;
+  path: string;
+}
+
+interface FileEntry {
+  type: "file";
+  item: ContextItem;
+}
+
+type Entry = DirEntry | FileEntry;
+
+export function ContextPanel({ conn, isActive }: ContextPanelProps) {
+  const [currentPath, setCurrentPath] = useState("/");
+  const [entries, setEntries] = useState<Entry[]>([]);
+  const [cursor, setCursor] = useState(0);
+  const [preview, setPreview] = useState<ContextItem | null>(null);
+  const [searchMode, setSearchMode] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<ContextItem[] | null>(
+    null,
+  );
+
+  const loadEntries = useCallback(
+    async (path: string) => {
+      const dirs = await getDistinctDirectories(conn, path);
+      const files = await listContextItemsByPrefix(conn, path, {
+        recursive: false,
+      });
+
+      const dirEntries: DirEntry[] = dirs.map((d) => ({
+        type: "directory",
+        name: d,
+        path: `${d}/`,
+      }));
+
+      // Files are items directly under this path (not in subdirectories)
+      const fileEntries: FileEntry[] = files
+        .filter((f) => !dirs.some((d) => f.context_path.startsWith(`${d}/`)))
+        .map((f) => ({ type: "file", item: f }));
+
+      setEntries([...dirEntries, ...fileEntries]);
+      setCursor(0);
+      setPreview(null);
+    },
+    [conn],
+  );
+
+  useEffect(() => {
+    if (searchResults === null) {
+      loadEntries(currentPath);
+    }
+  }, [currentPath, loadEntries, searchResults]);
+
+  const executeSearch = useCallback(
+    async (query: string) => {
+      if (!query.trim()) {
+        setSearchResults(null);
+        return;
+      }
+      const results = await searchContextByKeyword(conn, query.trim(), 50);
+      setSearchResults(results);
+      setCursor(0);
+      setPreview(null);
+    },
+    [conn],
+  );
+
+  useInput(
+    (input, key) => {
+      // Search mode: capture text input
+      if (searchMode) {
+        if (key.return) {
+          setSearchMode(false);
+          executeSearch(searchQuery);
+          return;
+        }
+        if (key.escape) {
+          setSearchMode(false);
+          setSearchQuery("");
+          setSearchResults(null);
+          return;
+        }
+        if (key.backspace || key.delete) {
+          setSearchQuery((q) => q.slice(0, -1));
+          return;
+        }
+        if (input && !key.ctrl && !key.meta) {
+          setSearchQuery((q) => q + input);
+        }
+        return;
+      }
+
+      // Normal navigation
+      if (input === "/") {
+        setSearchMode(true);
+        setSearchQuery("");
+        return;
+      }
+
+      if (key.escape) {
+        if (searchResults !== null) {
+          setSearchResults(null);
+          setPreview(null);
+          return;
+        }
+        if (preview) {
+          setPreview(null);
+          return;
+        }
+      }
+
+      if (key.upArrow) {
+        setCursor((c) => Math.max(0, c - 1));
+        setPreview(null);
+        return;
+      }
+      if (key.downArrow) {
+        if (searchResults !== null) {
+          setCursor((c) => Math.min(searchResults.length - 1, c + 1));
+        } else {
+          setCursor((c) => Math.min(entries.length - 1, c + 1));
+        }
+        setPreview(null);
+        return;
+      }
+
+      if (key.return) {
+        if (searchResults !== null) {
+          const item = searchResults[cursor];
+          if (item) setPreview(item);
+          return;
+        }
+        const entry = entries[cursor];
+        if (!entry) return;
+        if (entry.type === "directory") {
+          setCurrentPath(entry.path);
+        } else {
+          setPreview(entry.item);
+        }
+        return;
+      }
+
+      if (key.backspace || key.delete) {
+        if (currentPath !== "/") {
+          const parts = currentPath.replace(/\/$/, "").split("/");
+          parts.pop();
+          const parent = parts.length <= 1 ? "/" : `${parts.join("/")}/`;
+          setCurrentPath(parent);
+        }
+      }
+    },
+    { isActive },
+  );
+
+  // Render search results view
+  if (searchResults !== null) {
+    return (
+      <Box flexDirection="column" flexGrow={1} paddingX={1} overflow="hidden">
+        <Box>
+          <Text bold color="cyan">
+            Search results for: &quot;{searchQuery}&quot;
+          </Text>
+          <Text dimColor> ({searchResults.length} matches · esc to clear)</Text>
+        </Box>
+        <Box flexDirection="column" marginTop={1} flexGrow={1}>
+          {searchResults.length === 0 && <Text dimColor>No results found</Text>}
+          {searchResults.map((item, i) => (
+            <Box key={item.id}>
+              <Text
+                backgroundColor={i === cursor ? "#333" : undefined}
+                color={i === cursor ? "cyan" : undefined}
+              >
+                {"  "}📄 {item.context_path}
+                <Text dimColor> ({item.mime_type})</Text>
+              </Text>
+            </Box>
+          ))}
+        </Box>
+        {preview && (
+          <Box
+            flexDirection="column"
+            borderStyle="round"
+            borderColor="cyan"
+            paddingX={1}
+            height={10}
+          >
+            <Text bold color="cyan">
+              {preview.context_path}
+            </Text>
+            <Text dimColor>
+              {preview.mime_type} · {preview.is_textual ? "text" : "binary"} ·{" "}
+              {preview.indexed_at ? "indexed" : "not indexed"}
+            </Text>
+            <Text>
+              {preview.content ? preview.content.slice(0, 500) : "(no content)"}
+            </Text>
+          </Box>
+        )}
+      </Box>
+    );
+  }
+
+  // Render file preview
+  if (preview) {
+    return (
+      <Box flexDirection="column" flexGrow={1} paddingX={1} overflow="hidden">
+        <Box>
+          <Text bold color="cyan">
+            {preview.context_path}
+          </Text>
+          <Text dimColor> (esc to go back)</Text>
+        </Box>
+        <Box marginTop={1} flexDirection="column">
+          <Text dimColor>
+            Type: {preview.mime_type} · Title: {preview.title}
+            {preview.description ? ` · ${preview.description}` : ""}
+          </Text>
+          <Text dimColor>
+            Source: {preview.source_path ?? "n/a"} ·{" "}
+            {preview.indexed_at ? "Indexed" : "Not indexed"} · Updated:{" "}
+            {preview.updated_at.toLocaleDateString()}
+          </Text>
+        </Box>
+        <Box
+          marginTop={1}
+          flexDirection="column"
+          flexGrow={1}
+          overflow="hidden"
+        >
+          <Text>
+            {preview.content ? preview.content : "(binary or empty content)"}
+          </Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  // Render directory listing
+  return (
+    <Box flexDirection="column" flexGrow={1} paddingX={1} overflow="hidden">
+      <Box>
+        <Text bold color="cyan">
+          {currentPath}
+        </Text>
+        <Text dimColor>
+          {" "}
+          ({entries.length} items · / to search · backspace to go up)
+        </Text>
+      </Box>
+      {searchMode && (
+        <Box marginTop={1}>
+          <Text color="green">search: </Text>
+          <Text>{searchQuery}</Text>
+          <Text dimColor>█</Text>
+        </Box>
+      )}
+      <Box flexDirection="column" marginTop={1} flexGrow={1}>
+        {entries.length === 0 && <Text dimColor>No context items found</Text>}
+        {entries.map((entry, i) => {
+          const isSelected = i === cursor;
+          if (entry.type === "directory") {
+            return (
+              <Box key={entry.path}>
+                <Text
+                  backgroundColor={isSelected ? "#333" : undefined}
+                  color={isSelected ? "cyan" : "blue"}
+                  bold={isSelected}
+                >
+                  {"  "}📁 {entry.name}/
+                </Text>
+              </Box>
+            );
+          }
+          return (
+            <Box key={entry.item.id}>
+              <Text
+                backgroundColor={isSelected ? "#333" : undefined}
+                color={isSelected ? "cyan" : undefined}
+              >
+                {"  "}📄 {entry.item.title}
+                <Text dimColor> ({entry.item.mime_type})</Text>
+              </Text>
+            </Box>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+}

--- a/src/tui/components/ContextPanel.tsx
+++ b/src/tui/components/ContextPanel.tsx
@@ -1,8 +1,10 @@
-import { Box, Text, useInput } from "ink";
-import { useCallback, useEffect, useState } from "react";
+import { Box, Text, useInput, useStdout } from "ink";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import type { DbConnection } from "../../db/connection.ts";
 import {
   type ContextItem,
+  deleteContextItem,
+  deleteContextItemsByPrefix,
   getDistinctDirectories,
   listContextItemsByPrefix,
   searchContextByKeyword,
@@ -26,16 +28,36 @@ interface FileEntry {
 
 type Entry = DirEntry | FileEntry;
 
+// Reserve lines for header, search bar, padding, tab bar, status/input bar
+const CHROME_LINES = 8;
+
 export function ContextPanel({ conn, isActive }: ContextPanelProps) {
+  const { stdout } = useStdout();
+  const termRows = stdout?.rows ?? 24;
+
   const [currentPath, setCurrentPath] = useState("/");
   const [entries, setEntries] = useState<Entry[]>([]);
   const [cursor, setCursor] = useState(0);
+  const [scrollOffset, setScrollOffset] = useState(0);
   const [preview, setPreview] = useState<ContextItem | null>(null);
+  const [previewScroll, setPreviewScroll] = useState(0);
   const [searchMode, setSearchMode] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [searchResults, setSearchResults] = useState<ContextItem[] | null>(
     null,
   );
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  const visibleRows = Math.max(1, termRows - CHROME_LINES);
+
+  // Keep cursor in view by adjusting scroll offset
+  useEffect(() => {
+    if (cursor < scrollOffset) {
+      setScrollOffset(cursor);
+    } else if (cursor >= scrollOffset + visibleRows) {
+      setScrollOffset(cursor - visibleRows + 1);
+    }
+  }, [cursor, scrollOffset, visibleRows]);
 
   const loadEntries = useCallback(
     async (path: string) => {
@@ -50,13 +72,13 @@ export function ContextPanel({ conn, isActive }: ContextPanelProps) {
         path: `${d}/`,
       }));
 
-      // Files are items directly under this path (not in subdirectories)
       const fileEntries: FileEntry[] = files
         .filter((f) => !dirs.some((d) => f.context_path.startsWith(`${d}/`)))
         .map((f) => ({ type: "file", item: f }));
 
       setEntries([...dirEntries, ...fileEntries]);
       setCursor(0);
+      setScrollOffset(0);
       setPreview(null);
     },
     [conn],
@@ -77,10 +99,25 @@ export function ContextPanel({ conn, isActive }: ContextPanelProps) {
       const results = await searchContextByKeyword(conn, query.trim(), 50);
       setSearchResults(results);
       setCursor(0);
+      setScrollOffset(0);
       setPreview(null);
     },
     [conn],
   );
+
+  // Compute the items list and visible window for the current view
+  const items = searchResults ?? entries;
+  const itemCount = items.length;
+  const visibleItems = useMemo(
+    () => items.slice(scrollOffset, scrollOffset + visibleRows),
+    [items, scrollOffset, visibleRows],
+  );
+
+  // Preview content split into lines for scrolling
+  const previewLines = useMemo(() => {
+    if (!preview?.content) return [];
+    return preview.content.split("\n");
+  }, [preview]);
 
   useInput(
     (input, key) => {
@@ -107,7 +144,50 @@ export function ContextPanel({ conn, isActive }: ContextPanelProps) {
         return;
       }
 
+      // Preview mode: scroll content
+      if (preview) {
+        if (key.upArrow) {
+          setPreviewScroll((s) => Math.max(0, s - 1));
+          return;
+        }
+        if (key.downArrow) {
+          const maxScroll = Math.max(0, previewLines.length - visibleRows + 2);
+          setPreviewScroll((s) => Math.min(maxScroll, s + 1));
+          return;
+        }
+        if (key.escape) {
+          setPreview(null);
+          setPreviewScroll(0);
+          return;
+        }
+        return;
+      }
+
+      // Delete confirmation mode
+      if (confirmDelete) {
+        if (input === "y") {
+          const entry = entries[cursor];
+          if (entry) {
+            if (entry.type === "directory") {
+              deleteContextItemsByPrefix(conn, entry.path);
+            } else {
+              deleteContextItem(conn, entry.item.id);
+            }
+            setConfirmDelete(false);
+            loadEntries(currentPath);
+          }
+        } else {
+          setConfirmDelete(false);
+        }
+        return;
+      }
+
       // Normal navigation
+      if (input === "d" && itemCount > 0 && searchResults === null) {
+        setConfirmDelete(true);
+        return;
+      }
+
       if (input === "/") {
         setSearchMode(true);
         setSearchQuery("");
@@ -118,33 +198,27 @@ export function ContextPanel({ conn, isActive }: ContextPanelProps) {
         if (searchResults !== null) {
           setSearchResults(null);
           setPreview(null);
-          return;
-        }
-        if (preview) {
-          setPreview(null);
+          setScrollOffset(0);
           return;
         }
       }
 
       if (key.upArrow) {
         setCursor((c) => Math.max(0, c - 1));
-        setPreview(null);
         return;
       }
       if (key.downArrow) {
-        if (searchResults !== null) {
-          setCursor((c) => Math.min(searchResults.length - 1, c + 1));
-        } else {
-          setCursor((c) => Math.min(entries.length - 1, c + 1));
-        }
-        setPreview(null);
+        setCursor((c) => Math.min(itemCount - 1, c + 1));
         return;
       }
 
       if (key.return) {
         if (searchResults !== null) {
           const item = searchResults[cursor];
-          if (item) setPreview(item);
+          if (item) {
+            setPreview(item);
+            setPreviewScroll(0);
+          }
           return;
         }
         const entry = entries[cursor];
@@ -153,6 +227,7 @@ export function ContextPanel({ conn, isActive }: ContextPanelProps) {
           setCurrentPath(entry.path);
         } else {
           setPreview(entry.item);
+          setPreviewScroll(0);
         }
         return;
       }
@@ -170,7 +245,7 @@ export function ContextPanel({ conn, isActive }: ContextPanelProps) {
   );
 
   // Render search results view
-  if (searchResults !== null) {
+  if (searchResults !== null && !preview) {
     return (
       <Box flexDirection="column" flexGrow={1} paddingX={1} overflow="hidden">
         <Box>
@@ -181,35 +256,27 @@ export function ContextPanel({ conn, isActive }: ContextPanelProps) {
         </Box>
         <Box flexDirection="column" marginTop={1} flexGrow={1}>
           {searchResults.length === 0 && <Text dimColor>No results found</Text>}
-          {searchResults.map((item, i) => (
-            <Box key={item.id}>
-              <Text
-                backgroundColor={i === cursor ? "#333" : undefined}
-                color={i === cursor ? "cyan" : undefined}
-              >
-                {"  "}📄 {item.context_path}
-                <Text dimColor> ({item.mime_type})</Text>
-              </Text>
-            </Box>
-          ))}
+          {visibleItems.map((item, vi) => {
+            const i = vi + scrollOffset;
+            const ci = item as ContextItem;
+            return (
+              <Box key={ci.id}>
+                <Text
+                  backgroundColor={i === cursor ? "#333" : undefined}
+                  color={i === cursor ? "cyan" : undefined}
+                >
+                  {"  "}📄 {ci.context_path}
+                  <Text dimColor> ({ci.mime_type})</Text>
+                </Text>
+              </Box>
+            );
+          })}
         </Box>
-        {preview && (
-          <Box
-            flexDirection="column"
-            borderStyle="round"
-            borderColor="cyan"
-            paddingX={1}
-            height={10}
-          >
-            <Text bold color="cyan">
-              {preview.context_path}
-            </Text>
+        {itemCount > visibleRows && (
+          <Box>
             <Text dimColor>
-              {preview.mime_type} · {preview.is_textual ? "text" : "binary"} ·{" "}
-              {preview.indexed_at ? "indexed" : "not indexed"}
-            </Text>
-            <Text>
-              {preview.content ? preview.content.slice(0, 500) : "(no content)"}
+              [{scrollOffset + 1}–
+              {Math.min(scrollOffset + visibleRows, itemCount)} of {itemCount}]
             </Text>
           </Box>
         )}
@@ -217,15 +284,19 @@ export function ContextPanel({ conn, isActive }: ContextPanelProps) {
     );
   }
 
-  // Render file preview
+  // Render file preview with scrolling
   if (preview) {
+    const visiblePreviewLines = previewLines.slice(
+      previewScroll,
+      previewScroll + visibleRows - 2,
+    );
     return (
       <Box flexDirection="column" flexGrow={1} paddingX={1} overflow="hidden">
         <Box>
           <Text bold color="cyan">
             {preview.context_path}
           </Text>
-          <Text dimColor> (esc to go back)</Text>
+          <Text dimColor> (esc to go back · ↑↓ to scroll)</Text>
         </Box>
         <Box marginTop={1} flexDirection="column">
           <Text dimColor>
@@ -244,15 +315,29 @@ export function ContextPanel({ conn, isActive }: ContextPanelProps) {
           flexGrow={1}
           overflow="hidden"
         >
-          <Text>
-            {preview.content ? preview.content : "(binary or empty content)"}
-          </Text>
+          {preview.content ? (
+            visiblePreviewLines.map((line, i) => {
+              const lineNum = previewScroll + i;
+              return <Text key={lineNum}>{line || " "}</Text>;
+            })
+          ) : (
+            <Text dimColor>(binary or empty content)</Text>
+          )}
         </Box>
+        {previewLines.length > visibleRows - 2 && (
+          <Box>
+            <Text dimColor>
+              [line {previewScroll + 1}–
+              {Math.min(previewScroll + visibleRows - 2, previewLines.length)}{" "}
+              of {previewLines.length}]
+            </Text>
+          </Box>
+        )}
       </Box>
     );
   }
 
-  // Render directory listing
+  // Render directory listing with scroll window
   return (
     <Box flexDirection="column" flexGrow={1} paddingX={1} overflow="hidden">
       <Box>
@@ -261,7 +346,7 @@ export function ContextPanel({ conn, isActive }: ContextPanelProps) {
         </Text>
         <Text dimColor>
           {" "}
-          ({entries.length} items · / to search · backspace to go up)
+          ({entries.length} items · / search · d delete · backspace up)
         </Text>
       </Box>
       {searchMode && (
@@ -271,9 +356,22 @@ export function ContextPanel({ conn, isActive }: ContextPanelProps) {
           <Text dimColor>█</Text>
         </Box>
       )}
+      {confirmDelete && entries[cursor] && (
+        <Box marginTop={1}>
+          <Text color="red" bold>
+            Delete{" "}
+            {entries[cursor].type === "directory"
+              ? `${entries[cursor].name}/ and all contents`
+              : (entries[cursor] as FileEntry).item.title}
+            ? (y/n)
+          </Text>
+        </Box>
+      )}
       <Box flexDirection="column" marginTop={1} flexGrow={1}>
         {entries.length === 0 && <Text dimColor>No context items found</Text>}
-        {entries.map((entry, i) => {
+        {visibleItems.map((raw, vi) => {
+          const i = vi + scrollOffset;
+          const entry = raw as Entry;
           const isSelected = i === cursor;
           if (entry.type === "directory") {
             return (
@@ -301,6 +399,14 @@ export function ContextPanel({ conn, isActive }: ContextPanelProps) {
           );
         })}
       </Box>
+      {itemCount > visibleRows && (
+        <Box>
+          <Text dimColor>
+            [{scrollOffset + 1}–
+            {Math.min(scrollOffset + visibleRows, itemCount)} of {itemCount}]
+          </Text>
+        </Box>
+      )}
     </Box>
   );
 }

--- a/src/tui/components/Divider.tsx
+++ b/src/tui/components/Divider.tsx
@@ -1,0 +1,14 @@
+import { Text, useStdout } from "ink";
+import { theme } from "../theme.ts";
+
+interface DividerProps {
+  isLoading: boolean;
+}
+
+export function Divider({ isLoading }: DividerProps) {
+  const { stdout } = useStdout();
+  const cols = stdout?.columns ?? 80;
+  const line = "─".repeat(cols);
+
+  return <Text color={isLoading ? theme.accent : theme.muted}>{line}</Text>;
+}

--- a/src/tui/components/HelpPanel.tsx
+++ b/src/tui/components/HelpPanel.tsx
@@ -48,19 +48,13 @@ export function HelpPanel({
           Tools (Tab 2)
         </Text>
         <Text>
-          {"  "}←/→{"            "}Switch between tool calls
+          {"  "}↑/↓{"            "}Select tool call
         </Text>
         <Text>
-          {"  "}↑/↓{"            "}Navigate JSON tree
+          {"  "}Shift+↑/↓{"      "}Scroll detail pane
         </Text>
         <Text>
-          {"  "}Enter{"          "}Expand/collapse node
-        </Text>
-        <Text>
-          {"  "}Tab{"            "}Switch Input/Output
-        </Text>
-        <Text>
-          {"  "}e / c{"          "}Expand / collapse all
+          {"  "}j / k{"          "}Scroll detail pane
         </Text>
       </Box>
 
@@ -79,6 +73,9 @@ export function HelpPanel({
         </Text>
         <Text>
           {"  "}/{"              "}Search context
+        </Text>
+        <Text>
+          {"  "}d{"              "}Delete selected item (with confirmation)
         </Text>
       </Box>
 

--- a/src/tui/components/HelpPanel.tsx
+++ b/src/tui/components/HelpPanel.tsx
@@ -1,0 +1,120 @@
+import { Box, Text } from "ink";
+
+interface HelpPanelProps {
+  projectDir: string;
+  threadId: string;
+  daemonRunning: boolean;
+}
+
+export function HelpPanel({
+  projectDir,
+  threadId,
+  daemonRunning,
+}: HelpPanelProps) {
+  return (
+    <Box flexDirection="column" flexGrow={1} paddingX={1} overflow="hidden">
+      <Box marginTop={1} flexDirection="column">
+        <Text bold color="cyan">
+          Navigation
+        </Text>
+        <Text>
+          {"  "}Tab{"            "}Cycle between tabs
+        </Text>
+        <Text>
+          {"  "}1-4{"            "}Jump to tab (non-chat tabs)
+        </Text>
+        <Text>
+          {"  "}Escape{"         "}Return to Chat tab
+        </Text>
+      </Box>
+
+      <Box marginTop={1} flexDirection="column">
+        <Text bold color="cyan">
+          Chat (Tab 1)
+        </Text>
+        <Text>
+          {"  "}Enter{"          "}Send message
+        </Text>
+        <Text>
+          {"  "}⌥+Enter{"        "}Insert newline
+        </Text>
+        <Text>
+          {"  "}↑/↓{"            "}Browse input history
+        </Text>
+      </Box>
+
+      <Box marginTop={1} flexDirection="column">
+        <Text bold color="cyan">
+          Tools (Tab 2)
+        </Text>
+        <Text>
+          {"  "}←/→{"            "}Switch between tool calls
+        </Text>
+        <Text>
+          {"  "}↑/↓{"            "}Navigate JSON tree
+        </Text>
+        <Text>
+          {"  "}Enter{"          "}Expand/collapse node
+        </Text>
+        <Text>
+          {"  "}Tab{"            "}Switch Input/Output
+        </Text>
+        <Text>
+          {"  "}e / c{"          "}Expand / collapse all
+        </Text>
+      </Box>
+
+      <Box marginTop={1} flexDirection="column">
+        <Text bold color="cyan">
+          Context (Tab 3)
+        </Text>
+        <Text>
+          {"  "}↑/↓{"            "}Navigate items
+        </Text>
+        <Text>
+          {"  "}Enter{"          "}Expand directory / preview file
+        </Text>
+        <Text>
+          {"  "}Backspace{"      "}Go up one directory
+        </Text>
+        <Text>
+          {"  "}/{"              "}Search context
+        </Text>
+      </Box>
+
+      <Box marginTop={1} flexDirection="column">
+        <Text bold color="cyan">
+          Commands
+        </Text>
+        <Text>
+          {"  "}/help{"          "}Show help in chat
+        </Text>
+        <Text>
+          {"  "}/quit, /exit{"   "}End the chat session
+        </Text>
+      </Box>
+
+      <Box marginTop={1} flexDirection="column">
+        <Text bold color="cyan">
+          System Info
+        </Text>
+        <Text>
+          {"  "}Project{"   "}
+          {projectDir}
+        </Text>
+        <Text>
+          {"  "}Thread{"    "}
+          {threadId}
+        </Text>
+        <Text>
+          {"  "}Daemon{"    "}
+          {daemonRunning ? (
+            <Text color="green">running</Text>
+          ) : (
+            <Text color="red">off</Text>
+          )}
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/tui/components/InputBar.tsx
+++ b/src/tui/components/InputBar.tsx
@@ -20,6 +20,7 @@ export function InputBar({
   header,
 }: InputBarProps) {
   const [historyIndex, setHistoryIndex] = useState(-1);
+  const [cursorPos, setCursorPos] = useState(0);
   const savedInput = useRef("");
 
   useInput(
@@ -29,10 +30,14 @@ export function InputBar({
       // Enter: submit (shift+enter or opt+enter inserts newline)
       if (key.return) {
         if (key.shift || key.meta) {
-          onChange(`${value}\n`);
+          const before = value.slice(0, cursorPos);
+          const after = value.slice(cursorPos);
+          onChange(`${before}\n${after}`);
+          setCursorPos(cursorPos + 1);
         } else {
           setHistoryIndex(-1);
           savedInput.current = "";
+          setCursorPos(0);
           onSubmit(value);
         }
         return;
@@ -40,9 +45,22 @@ export function InputBar({
 
       // Backspace
       if (key.backspace || key.delete) {
-        if (value.length > 0) {
-          onChange(value.slice(0, -1));
+        if (cursorPos > 0) {
+          const before = value.slice(0, cursorPos - 1);
+          const after = value.slice(cursorPos);
+          onChange(before + after);
+          setCursorPos(cursorPos - 1);
         }
+        return;
+      }
+
+      // Left/right arrow for cursor movement
+      if (key.leftArrow) {
+        setCursorPos((c) => Math.max(0, c - 1));
+        return;
+      }
+      if (key.rightArrow) {
+        setCursorPos((c) => Math.min(value.length, c + 1));
         return;
       }
 
@@ -55,7 +73,10 @@ export function InputBar({
           }
           setHistoryIndex(nextIndex);
           const entry = history[history.length - 1 - nextIndex];
-          if (entry !== undefined) onChange(entry);
+          if (entry !== undefined) {
+            onChange(entry);
+            setCursorPos(entry.length);
+          }
         }
         return;
       }
@@ -65,22 +86,20 @@ export function InputBar({
           const nextIndex = historyIndex - 1;
           setHistoryIndex(nextIndex);
           const entry = history[history.length - 1 - nextIndex];
-          if (entry !== undefined) onChange(entry);
+          if (entry !== undefined) {
+            onChange(entry);
+            setCursorPos(entry.length);
+          }
         } else if (historyIndex === 0) {
           setHistoryIndex(-1);
           onChange(savedInput.current);
+          setCursorPos(savedInput.current.length);
         }
         return;
       }
 
       // Ignore other control keys
-      if (
-        key.ctrl ||
-        key.escape ||
-        key.leftArrow ||
-        key.rightArrow ||
-        key.tab
-      ) {
+      if (key.ctrl || key.escape || key.tab) {
         return;
       }
 
@@ -89,7 +108,10 @@ export function InputBar({
         if (historyIndex !== -1) {
           setHistoryIndex(-1);
         }
-        onChange(`${value}${input}`);
+        const before = value.slice(0, cursorPos);
+        const after = value.slice(cursorPos);
+        onChange(before + input + after);
+        setCursorPos(cursorPos + input.length);
       }
     },
     { isActive: !disabled },
@@ -112,7 +134,11 @@ export function InputBar({
           {placeholder ? (
             <Text dimColor>Type a message...</Text>
           ) : (
-            <Text>{value}</Text>
+            <Text>
+              {value.slice(0, cursorPos)}
+              <Text inverse>{value[cursorPos] ?? " "}</Text>
+              {value.slice(cursorPos + 1)}
+            </Text>
           )}
         </Box>
         {isMultiline && (

--- a/src/tui/components/StatusBar.tsx
+++ b/src/tui/components/StatusBar.tsx
@@ -9,6 +9,7 @@ interface StatusBarProps {
   projectDir: string;
   conn: DbConnection;
   isLoading: boolean;
+  onDaemonStatusChange?: (running: boolean) => void;
 }
 
 interface Status {
@@ -17,7 +18,12 @@ interface Status {
   inProgressCount: number;
 }
 
-export function StatusBar({ projectDir, conn, isLoading }: StatusBarProps) {
+export function StatusBar({
+  projectDir,
+  conn,
+  isLoading,
+  onDaemonStatusChange,
+}: StatusBarProps) {
   const [status, setStatus] = useState<Status>({
     daemonRunning: false,
     pendingCount: 0,
@@ -32,11 +38,13 @@ export function StatusBar({ projectDir, conn, isLoading }: StatusBarProps) {
       const pending = await listTasks(conn, { status: "pending" });
       const inProgress = await listTasks(conn, { status: "in_progress" });
       if (mounted) {
+        const daemonRunning = daemon !== null;
         setStatus({
-          daemonRunning: daemon !== null,
+          daemonRunning,
           pendingCount: pending.length,
           inProgressCount: inProgress.length,
         });
+        onDaemonStatusChange?.(daemonRunning);
       }
     };
 
@@ -46,7 +54,7 @@ export function StatusBar({ projectDir, conn, isLoading }: StatusBarProps) {
       mounted = false;
       clearInterval(interval);
     };
-  }, [projectDir, conn]);
+  }, [projectDir, conn, onDaemonStatusChange]);
 
   return (
     <Box paddingX={0}>

--- a/src/tui/components/TabBar.tsx
+++ b/src/tui/components/TabBar.tsx
@@ -1,0 +1,38 @@
+import { Box, Text } from "ink";
+
+export type TabId = 1 | 2 | 3 | 4;
+
+const TABS: { id: TabId; label: string }[] = [
+  { id: 1, label: "Chat" },
+  { id: 2, label: "Tools" },
+  { id: 3, label: "Context" },
+  { id: 4, label: "Help" },
+];
+
+interface TabBarProps {
+  activeTab: TabId;
+}
+
+export function TabBar({ activeTab }: TabBarProps) {
+  return (
+    <Box paddingX={1} gap={1}>
+      {TABS.map(({ id, label }) => {
+        const active = id === activeTab;
+        return (
+          <Box key={id}>
+            <Text
+              bold={active}
+              color={active ? "cyan" : undefined}
+              dimColor={!active}
+              backgroundColor={active ? "#1a3a5c" : undefined}
+            >
+              {` ${id} ${label} `}
+            </Text>
+          </Box>
+        );
+      })}
+      <Box flexGrow={1} />
+      <Text dimColor>tab to switch</Text>
+    </Box>
+  );
+}

--- a/src/tui/components/ToolCall.tsx
+++ b/src/tui/components/ToolCall.tsx
@@ -6,6 +6,7 @@ export interface ToolCallData {
   input: string;
   output?: string;
   running: boolean;
+  timestamp: Date;
 }
 
 interface ToolCallProps {

--- a/src/tui/components/ToolPanel.tsx
+++ b/src/tui/components/ToolPanel.tsx
@@ -1,5 +1,5 @@
-import { Box, Text, useInput } from "ink";
-import { useMemo, useState } from "react";
+import { Box, Text, useInput, useStdout } from "ink";
+import { useEffect, useMemo, useState } from "react";
 import { theme } from "../theme.ts";
 import type { ToolCallData } from "./ToolCall.tsx";
 
@@ -8,233 +8,172 @@ interface ToolPanelProps {
   isActive: boolean;
 }
 
-/** A flattened row in the JSON tree */
-interface TreeRow {
-  depth: number;
-  key: string;
-  value: string | null; // null = expandable parent
-  path: string;
-  hasChildren: boolean;
-}
+const SIDEBAR_WIDTH = 32;
 
-function flattenJson(
-  obj: unknown,
-  parentPath: string,
-  depth: number,
-  expanded: Set<string>,
-): TreeRow[] {
-  const rows: TreeRow[] = [];
-
-  if (obj === null || obj === undefined) {
-    return rows;
-  }
-
-  if (Array.isArray(obj)) {
-    for (let i = 0; i < obj.length; i++) {
-      const path = `${parentPath}[${i}]`;
-      const child = obj[i];
-      if (typeof child === "object" && child !== null) {
-        rows.push({
-          depth,
-          key: `[${i}]`,
-          value: expanded.has(path) ? null : `[…]`,
-          path,
-          hasChildren: true,
-        });
-        if (expanded.has(path)) {
-          rows.push(...flattenJson(child, path, depth + 1, expanded));
-        }
-      } else {
-        rows.push({
-          depth,
-          key: `[${i}]`,
-          value: formatValue(child),
-          path,
-          hasChildren: false,
-        });
-      }
-    }
-  } else if (typeof obj === "object") {
-    for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
-      const path = parentPath ? `${parentPath}.${k}` : k;
-      if (typeof v === "object" && v !== null) {
-        const childCount = Array.isArray(v) ? v.length : Object.keys(v).length;
-        const preview = Array.isArray(v)
-          ? `[${childCount} items]`
-          : `{${childCount} keys}`;
-        rows.push({
-          depth,
-          key: k,
-          value: expanded.has(path) ? null : preview,
-          path,
-          hasChildren: true,
-        });
-        if (expanded.has(path)) {
-          rows.push(...flattenJson(v, path, depth + 1, expanded));
-        }
-      } else {
-        rows.push({
-          depth,
-          key: k,
-          value: formatValue(v),
-          path,
-          hasChildren: false,
-        });
-      }
-    }
-  }
-
-  return rows;
-}
-
-function formatValue(v: unknown): string {
-  if (v === null) return "null";
-  if (v === undefined) return "undefined";
-  if (typeof v === "string") {
-    if (v.length > 80) return `"${v.slice(0, 77)}…"`;
-    return `"${v}"`;
-  }
-  return String(v);
-}
-
-function safeParseJson(str: string): unknown {
+// ANSI escape helpers
+const RESET = "\x1b[0m";
+const BOLD = "\x1b[1m";
+const DIM = "\x1b[2m";
+const CYAN = "\x1b[36m";
+const GREEN = "\x1b[32m";
+const YELLOW = "\x1b[33m";
+const MAGENTA = "\x1b[35m";
+const BLUE = "\x1b[34m";
+/** Colorize a JSON string with ANSI codes */
+function colorizeJson(str: string): string {
   try {
-    return JSON.parse(str);
+    const parsed = JSON.parse(str);
+    return colorizeValue(parsed, 0);
   } catch {
     return str;
   }
 }
 
-type PanelTab = "input" | "output";
+function colorizeValue(value: unknown, indent: number): string {
+  if (value === null) return `${MAGENTA}null${RESET}`;
+  if (typeof value === "boolean")
+    return `${MAGENTA}${value ? "true" : "false"}${RESET}`;
+  if (typeof value === "number") return `${YELLOW}${value}${RESET}`;
+  if (typeof value === "string") {
+    const escaped = JSON.stringify(value);
+    return `${GREEN}${escaped}${RESET}`;
+  }
+
+  const pad = "  ".repeat(indent);
+  const innerPad = "  ".repeat(indent + 1);
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) return "[]";
+    const items = value.map(
+      (v) => `${innerPad}${colorizeValue(v, indent + 1)}`,
+    );
+    return `[\n${items.join(",\n")}\n${pad}]`;
+  }
+
+  if (typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>);
+    if (entries.length === 0) return "{}";
+    const lines = entries.map(
+      ([k, v]) =>
+        `${innerPad}${CYAN}${JSON.stringify(k)}${RESET}: ${colorizeValue(v, indent + 1)}`,
+    );
+    return `{\n${lines.join(",\n")}\n${pad}}`;
+  }
+
+  return String(value);
+}
+
+function buildDetailAnsi(tool: ToolCallData): string {
+  const lines: string[] = [];
+
+  const time = tool.timestamp.toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+
+  lines.push(`${BOLD}${CYAN}${tool.name}${RESET}`);
+  lines.push(`${DIM}Time: ${time}${RESET}`);
+  if (tool.running) {
+    lines.push(`${YELLOW}⟳ running${RESET}`);
+  }
+  lines.push("");
+
+  lines.push(`${BOLD}${BLUE}Input${RESET}`);
+  lines.push(colorizeJson(tool.input));
+  lines.push("");
+
+  if (tool.output) {
+    lines.push(`${BOLD}${BLUE}Output${RESET}`);
+    lines.push(colorizeJson(tool.output));
+  } else if (!tool.running) {
+    lines.push(`${BOLD}${BLUE}Output${RESET}`);
+    lines.push(`${DIM}(no output)${RESET}`);
+  }
+
+  return lines.join("\n");
+}
 
 export function ToolPanel({ toolCalls, isActive }: ToolPanelProps) {
-  const [selectedTool, setSelectedTool] = useState(0);
-  const [tab, setTab] = useState<PanelTab>("input");
-  const [cursor, setCursor] = useState(0);
-  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const { stdout } = useStdout();
+  const termRows = stdout?.rows ?? 24;
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [detailScroll, setDetailScroll] = useState(0);
 
-  const tool = toolCalls[selectedTool];
+  // Reverse-chronological order (most recent first)
+  const reversedCalls = useMemo(() => [...toolCalls].reverse(), [toolCalls]);
 
-  const data = useMemo(() => {
-    if (!tool) return null;
-    return tab === "input"
-      ? safeParseJson(tool.input)
-      : safeParseJson(tool.output ?? "");
-  }, [tool, tab]);
-
-  const rows = useMemo(() => {
-    if (data === null || data === undefined) return [];
-    if (typeof data === "string") {
-      return data
-        .split("\n")
-        .filter((l) => l.trim())
-        .map(
-          (line, i): TreeRow => ({
-            depth: 0,
-            key: "",
-            value: line,
-            path: `line-${i}`,
-            hasChildren: false,
-          }),
-        );
+  // Keep selection in bounds when new calls arrive
+  useEffect(() => {
+    if (selectedIndex >= reversedCalls.length && reversedCalls.length > 0) {
+      setSelectedIndex(reversedCalls.length - 1);
     }
-    return flattenJson(data, "", 0, expanded);
-  }, [data, expanded]);
+  }, [reversedCalls.length, selectedIndex]);
+
+  const selectedTool = reversedCalls[selectedIndex];
+
+  const renderedDetail = useMemo(() => {
+    if (!selectedTool) return "";
+    return buildDetailAnsi(selectedTool);
+  }, [selectedTool]);
+
+  const detailLines = useMemo(
+    () => renderedDetail.split("\n"),
+    [renderedDetail],
+  );
+
+  // Visible area for sidebar and detail
+  const visibleRows = Math.max(1, termRows - 6); // chrome: tab bar, divider, status, input, borders
+  const sidebarScrollOffset = Math.max(
+    0,
+    Math.min(
+      selectedIndex - Math.floor(visibleRows / 2),
+      reversedCalls.length - visibleRows,
+    ),
+  );
+
+  // Reset detail scroll when selection changes
+  // biome-ignore lint/correctness/useExhaustiveDependencies: selectedIndex is the intentional trigger
+  useEffect(() => {
+    setDetailScroll(0);
+  }, [selectedIndex]);
 
   useInput(
     (input, key) => {
-      // Tab key switches input/output within the panel
-      // (global tab switching is handled by App)
-      if (key.tab) {
-        setTab((t) => (t === "input" ? "output" : "input"));
-        setCursor(0);
-        setExpanded(new Set());
-        return;
-      }
-
-      if (key.leftArrow) {
-        setSelectedTool((i) => Math.max(0, i - 1));
-        setCursor(0);
-        setExpanded(new Set());
-        return;
-      }
-      if (key.rightArrow) {
-        setSelectedTool((i) => Math.min(toolCalls.length - 1, i + 1));
-        setCursor(0);
-        setExpanded(new Set());
-        return;
-      }
-
       if (key.upArrow) {
-        setCursor((c) => Math.max(0, c - 1));
+        if (key.shift) {
+          // Shift+up scrolls detail
+          setDetailScroll((s) => Math.max(0, s - 1));
+        } else {
+          setSelectedIndex((i) => Math.max(0, i - 1));
+        }
         return;
       }
       if (key.downArrow) {
-        setCursor((c) => Math.min(rows.length - 1, c + 1));
-        return;
-      }
-
-      if (key.return) {
-        const row = rows[cursor];
-        if (row?.hasChildren) {
-          setExpanded((prev) => {
-            const next = new Set(prev);
-            if (next.has(row.path)) {
-              for (const p of next) {
-                if (
-                  p === row.path ||
-                  p.startsWith(`${row.path}.`) ||
-                  p.startsWith(`${row.path}[`)
-                ) {
-                  next.delete(p);
-                }
-              }
-            } else {
-              next.add(row.path);
-            }
-            return next;
-          });
+        if (key.shift) {
+          const maxScroll = Math.max(0, detailLines.length - visibleRows);
+          setDetailScroll((s) => Math.min(maxScroll, s + 1));
+        } else {
+          setSelectedIndex((i) => Math.min(reversedCalls.length - 1, i + 1));
         }
         return;
       }
 
-      if (input === "e") {
-        const allPaths = new Set<string>();
-        const expandAll = (obj: unknown, parentPath: string) => {
-          if (typeof obj === "object" && obj !== null) {
-            if (Array.isArray(obj)) {
-              for (let i = 0; i < obj.length; i++) {
-                const p = `${parentPath}[${i}]`;
-                if (typeof obj[i] === "object" && obj[i] !== null) {
-                  allPaths.add(p);
-                  expandAll(obj[i], p);
-                }
-              }
-            } else {
-              for (const [k, v] of Object.entries(obj)) {
-                const p = parentPath ? `${parentPath}.${k}` : k;
-                if (typeof v === "object" && v !== null) {
-                  allPaths.add(p);
-                  expandAll(v, p);
-                }
-              }
-            }
-          }
-        };
-        if (data && typeof data === "object") expandAll(data, "");
-        setExpanded(allPaths);
+      // j/k vim-style for detail scrolling
+      if (input === "j") {
+        const maxScroll = Math.max(0, detailLines.length - visibleRows);
+        setDetailScroll((s) => Math.min(maxScroll, s + 1));
         return;
       }
-
-      if (input === "c") {
-        setExpanded(new Set());
-        setCursor(0);
+      if (input === "k") {
+        setDetailScroll((s) => Math.max(0, s - 1));
+        return;
       }
     },
     { isActive },
   );
 
-  if (!tool) {
+  if (reversedCalls.length === 0) {
     return (
       <Box flexDirection="column" flexGrow={1} paddingX={1}>
         <Text dimColor>
@@ -245,92 +184,98 @@ export function ToolPanel({ toolCalls, isActive }: ToolPanelProps) {
     );
   }
 
-  const hasOutput = Boolean(tool.output);
+  // Sidebar visible window
+  const sidebarVisible = reversedCalls.slice(
+    sidebarScrollOffset,
+    sidebarScrollOffset + visibleRows,
+  );
+
+  // Detail visible window
+  const detailVisible = detailLines.slice(
+    detailScroll,
+    detailScroll + visibleRows,
+  );
 
   return (
-    <Box
-      flexDirection="column"
-      borderStyle="round"
-      borderColor="cyan"
-      paddingX={1}
-      flexGrow={1}
-    >
-      {/* Header */}
-      <Box justifyContent="space-between">
-        <Box>
-          <Text bold color="cyan">
-            🔍 Tool Inspector
-          </Text>
-          <Text dimColor>
-            {" "}
-            ({selectedTool + 1}/{toolCalls.length})
+    <Box flexGrow={1} overflow="hidden">
+      {/* Left sidebar: tool call list */}
+      <Box
+        flexDirection="column"
+        width={SIDEBAR_WIDTH}
+        borderStyle="single"
+        borderColor={theme.muted}
+        borderRight
+        borderTop={false}
+        borderBottom={false}
+        borderLeft={false}
+        overflow="hidden"
+      >
+        <Box paddingX={1}>
+          <Text bold dimColor>
+            Tool Calls ({reversedCalls.length})
           </Text>
         </Box>
-        <Text dimColor>
-          ←→ tools · tab input/output · ↑↓ navigate · enter expand · e/c all
-        </Text>
-      </Box>
-
-      {/* Tool name */}
-      <Box>
-        <Text bold color="magenta">
-          {tool.name}
-        </Text>
-        {tool.running && <Text color={theme.accent}> ⟳ running</Text>}
-      </Box>
-
-      {/* Tabs */}
-      <Box gap={2}>
-        <Text
-          bold={tab === "input"}
-          color={tab === "input" ? "green" : undefined}
-          dimColor={tab !== "input"}
-        >
-          {tab === "input" ? "▸ " : "  "}Input
-        </Text>
-        <Text
-          bold={tab === "output"}
-          color={tab === "output" ? "green" : undefined}
-          dimColor={tab !== "output" && !hasOutput}
-        >
-          {tab === "output" ? "▸ " : "  "}Output{!hasOutput ? " (none)" : ""}
-        </Text>
-      </Box>
-
-      {/* Tree content */}
-      <Box flexDirection="column" flexGrow={1} overflow="hidden">
-        {rows.length === 0 && <Text dimColor> (empty)</Text>}
-        {rows.map((row, i) => {
-          const isSelected = i === cursor;
-          const indent = "  ".repeat(row.depth);
-          const arrow = row.hasChildren
-            ? expanded.has(row.path)
-              ? "▾ "
-              : "▸ "
-            : "  ";
-
+        {sidebarVisible.map((tc, vi) => {
+          const i = vi + sidebarScrollOffset;
+          const isSelected = i === selectedIndex;
+          const icon = tc.running ? "⟳" : "✔";
+          const time = tc.timestamp.toLocaleTimeString([], {
+            hour: "2-digit",
+            minute: "2-digit",
+          });
+          const maxName = SIDEBAR_WIDTH - 12; // icon + time + padding
+          const nameDisplay =
+            tc.name.length > maxName
+              ? `${tc.name.slice(0, maxName - 1)}…`
+              : tc.name;
           return (
-            <Box key={row.path}>
+            <Box key={`${i}-${tc.name}`} paddingX={1}>
               <Text
                 backgroundColor={isSelected ? theme.selectionBg : undefined}
-                color={isSelected ? "cyan" : undefined}
+                bold={isSelected}
+                color={
+                  isSelected
+                    ? theme.info
+                    : tc.running
+                      ? theme.accent
+                      : undefined
+                }
+                wrap="truncate-end"
               >
-                {indent}
-                {arrow}
-                {row.key ? (
-                  <>
-                    <Text color="blue" bold={isSelected}>
-                      {row.key}
-                    </Text>
-                    {row.value !== null ? `: ${row.value}` : ""}
-                  </>
-                ) : (
-                  (row.value ?? "")
-                )}
+                {isSelected ? "▸" : " "}{" "}
+                <Text
+                  color={tc.running ? theme.accent : theme.muted}
+                  bold={false}
+                >
+                  {icon}
+                </Text>{" "}
+                {nameDisplay}
+                <Text dimColor> {time}</Text>
               </Text>
             </Box>
           );
         })}
+      </Box>
+
+      {/* Right detail pane */}
+      <Box flexDirection="column" flexGrow={1} paddingX={1} overflow="hidden">
+        {detailVisible.map((line, i) => {
+          const lineNum = detailScroll + i;
+          return <Text key={lineNum}>{line || " "}</Text>;
+        })}
+        {detailLines.length > visibleRows && (
+          <Box>
+            <Text dimColor>
+              ↑↓ select · shift+↑↓ or j/k scroll detail · [{detailScroll + 1}–
+              {Math.min(detailScroll + visibleRows, detailLines.length)} of{" "}
+              {detailLines.length}]
+            </Text>
+          </Box>
+        )}
+        {detailLines.length <= visibleRows && <Box flexGrow={1} />}
+        {detailLines.length <= visibleRows && (
+          <Text dimColor>↑↓ select tool calls</Text>
+        )}
       </Box>
     </Box>
   );

--- a/src/tui/components/ToolPanel.tsx
+++ b/src/tui/components/ToolPanel.tsx
@@ -5,7 +5,7 @@ import type { ToolCallData } from "./ToolCall.tsx";
 
 interface ToolPanelProps {
   toolCalls: ToolCallData[];
-  onClose: () => void;
+  isActive: boolean;
 }
 
 /** A flattened row in the JSON tree */
@@ -107,7 +107,7 @@ function safeParseJson(str: string): unknown {
 
 type PanelTab = "input" | "output";
 
-export function ToolPanel({ toolCalls, onClose }: ToolPanelProps) {
+export function ToolPanel({ toolCalls, isActive }: ToolPanelProps) {
   const [selectedTool, setSelectedTool] = useState(0);
   const [tab, setTab] = useState<PanelTab>("input");
   const [cursor, setCursor] = useState(0);
@@ -141,100 +141,109 @@ export function ToolPanel({ toolCalls, onClose }: ToolPanelProps) {
     return flattenJson(data, "", 0, expanded);
   }, [data, expanded]);
 
-  useInput((input, key) => {
-    if (key.escape) {
-      onClose();
-      return;
-    }
-
-    if (key.tab) {
-      setTab((t) => (t === "input" ? "output" : "input"));
-      setCursor(0);
-      setExpanded(new Set());
-      return;
-    }
-
-    if (key.leftArrow) {
-      setSelectedTool((i) => Math.max(0, i - 1));
-      setCursor(0);
-      setExpanded(new Set());
-      return;
-    }
-    if (key.rightArrow) {
-      setSelectedTool((i) => Math.min(toolCalls.length - 1, i + 1));
-      setCursor(0);
-      setExpanded(new Set());
-      return;
-    }
-
-    if (key.upArrow) {
-      setCursor((c) => Math.max(0, c - 1));
-      return;
-    }
-    if (key.downArrow) {
-      setCursor((c) => Math.min(rows.length - 1, c + 1));
-      return;
-    }
-
-    if (key.return) {
-      const row = rows[cursor];
-      if (row?.hasChildren) {
-        setExpanded((prev) => {
-          const next = new Set(prev);
-          if (next.has(row.path)) {
-            for (const p of next) {
-              if (
-                p === row.path ||
-                p.startsWith(`${row.path}.`) ||
-                p.startsWith(`${row.path}[`)
-              ) {
-                next.delete(p);
-              }
-            }
-          } else {
-            next.add(row.path);
-          }
-          return next;
-        });
+  useInput(
+    (input, key) => {
+      // Tab key switches input/output within the panel
+      // (global tab switching is handled by App)
+      if (key.tab) {
+        setTab((t) => (t === "input" ? "output" : "input"));
+        setCursor(0);
+        setExpanded(new Set());
+        return;
       }
-      return;
-    }
 
-    if (input === "e") {
-      const allPaths = new Set<string>();
-      const expandAll = (obj: unknown, parentPath: string) => {
-        if (typeof obj === "object" && obj !== null) {
-          if (Array.isArray(obj)) {
-            for (let i = 0; i < obj.length; i++) {
-              const p = `${parentPath}[${i}]`;
-              if (typeof obj[i] === "object" && obj[i] !== null) {
-                allPaths.add(p);
-                expandAll(obj[i], p);
+      if (key.leftArrow) {
+        setSelectedTool((i) => Math.max(0, i - 1));
+        setCursor(0);
+        setExpanded(new Set());
+        return;
+      }
+      if (key.rightArrow) {
+        setSelectedTool((i) => Math.min(toolCalls.length - 1, i + 1));
+        setCursor(0);
+        setExpanded(new Set());
+        return;
+      }
+
+      if (key.upArrow) {
+        setCursor((c) => Math.max(0, c - 1));
+        return;
+      }
+      if (key.downArrow) {
+        setCursor((c) => Math.min(rows.length - 1, c + 1));
+        return;
+      }
+
+      if (key.return) {
+        const row = rows[cursor];
+        if (row?.hasChildren) {
+          setExpanded((prev) => {
+            const next = new Set(prev);
+            if (next.has(row.path)) {
+              for (const p of next) {
+                if (
+                  p === row.path ||
+                  p.startsWith(`${row.path}.`) ||
+                  p.startsWith(`${row.path}[`)
+                ) {
+                  next.delete(p);
+                }
               }
+            } else {
+              next.add(row.path);
             }
-          } else {
-            for (const [k, v] of Object.entries(obj)) {
-              const p = parentPath ? `${parentPath}.${k}` : k;
-              if (typeof v === "object" && v !== null) {
-                allPaths.add(p);
-                expandAll(v, p);
+            return next;
+          });
+        }
+        return;
+      }
+
+      if (input === "e") {
+        const allPaths = new Set<string>();
+        const expandAll = (obj: unknown, parentPath: string) => {
+          if (typeof obj === "object" && obj !== null) {
+            if (Array.isArray(obj)) {
+              for (let i = 0; i < obj.length; i++) {
+                const p = `${parentPath}[${i}]`;
+                if (typeof obj[i] === "object" && obj[i] !== null) {
+                  allPaths.add(p);
+                  expandAll(obj[i], p);
+                }
+              }
+            } else {
+              for (const [k, v] of Object.entries(obj)) {
+                const p = parentPath ? `${parentPath}.${k}` : k;
+                if (typeof v === "object" && v !== null) {
+                  allPaths.add(p);
+                  expandAll(v, p);
+                }
               }
             }
           }
-        }
-      };
-      if (data && typeof data === "object") expandAll(data, "");
-      setExpanded(allPaths);
-      return;
-    }
+        };
+        if (data && typeof data === "object") expandAll(data, "");
+        setExpanded(allPaths);
+        return;
+      }
 
-    if (input === "c") {
-      setExpanded(new Set());
-      setCursor(0);
-    }
-  });
+      if (input === "c") {
+        setExpanded(new Set());
+        setCursor(0);
+      }
+    },
+    { isActive },
+  );
 
-  if (!tool) return null;
+  if (!tool) {
+    return (
+      <Box flexDirection="column" flexGrow={1} paddingX={1}>
+        <Text dimColor>
+          No tool calls to inspect yet. Tool calls will appear here as the agent
+          uses them.
+        </Text>
+      </Box>
+    );
+  }
 
   const hasOutput = Boolean(tool.output);
 
@@ -244,7 +253,7 @@ export function ToolPanel({ toolCalls, onClose }: ToolPanelProps) {
       borderStyle="round"
       borderColor="cyan"
       paddingX={1}
-      height={16}
+      flexGrow={1}
     >
       {/* Header */}
       <Box justifyContent="space-between">
@@ -258,8 +267,7 @@ export function ToolPanel({ toolCalls, onClose }: ToolPanelProps) {
           </Text>
         </Box>
         <Text dimColor>
-          esc close · ←→ tools · tab switch · ↑↓ navigate · enter expand · e/c
-          all
+          ←→ tools · tab input/output · ↑↓ navigate · enter expand · e/c all
         </Text>
       </Box>
 


### PR DESCRIPTION
## Summary

- Adds a 4-tab system to the chat TUI: Chat, Tools, Context, and Help — navigable via Tab key (cycle) or number keys 1-4 (direct jump from non-chat tabs)
- Replaces the tool inspector overlay with a two-column layout: reverse-chronological tool call sidebar + colorized JSON detail pane with syntax highlighting
- Adds a Context explorer tab with directory tree navigation, file preview, keyword search, scrollable viewports, and delete support (with confirmation)
- Adds a Help tab with complete keyboard shortcut reference and system info
- Adds an animated divider between tab bar and content that changes color when the agent is working, a visible text cursor with arrow-key movement in the input bar, and timestamps on all tool calls

## Test plan
- [x] `bun run lint` passes (tsc + biome)
- [x] `bun test` passes (356 tests)
- [ ] Manual: verify tab switching with Tab and number keys
- [ ] Manual: verify context tree browsing, search, delete
- [ ] Manual: verify tool inspector JSON colorization and scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)