### PR TITLE
Fix context add: deduplicate on existing context_path

### DIFF
--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -9,9 +9,12 @@ import { embedSingle, warmupEmbedder } from "../context/embedder.ts";
 import { ingestContextItem } from "../context/ingest.ts";
 import type { DbConnection } from "../db/connection.ts";
 import {
+  type ContextItem,
   createContextItem,
+  getContextItemByPath,
   listContextItems,
   listContextItemsByPrefix,
+  updateContextItem,
 } from "../db/context.ts";
 import { hybridSearch, initVectorSearch } from "../db/embeddings.ts";
 import { logger } from "../utils/logger.ts";
@@ -184,14 +187,27 @@ async function addFile(
 
     const content = textual ? await bunFile.text() : null;
 
-    const item = await createContextItem(conn, {
-      title: filename,
-      content: content ?? undefined,
-      mimeType,
-      sourcePath: filePath,
-      contextPath,
-      isTextual: textual,
-    });
+    const existing = await getContextItemByPath(conn, contextPath);
+    let item: ContextItem;
+
+    if (existing) {
+      const updated = await updateContextItem(conn, existing.id, {
+        title: filename,
+        content: content ?? undefined,
+        mime_type: mimeType,
+      });
+      if (!updated) throw new Error(`Failed to update: ${contextPath}`);
+      item = updated;
+    } else {
+      item = await createContextItem(conn, {
+        title: filename,
+        content: content ?? undefined,
+        mimeType,
+        sourcePath: filePath,
+        contextPath,
+        isTextual: textual,
+      });
+    }
 
     if (textual && content) {
       return await ingestContextItem(conn, item.id, config);

--- a/src/db/sql/4-unique_context_path.sql
+++ b/src/db/sql/4-unique_context_path.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX IF NOT EXISTS idx_context_items_context_path ON context_items(context_path);

--- a/src/tools/file/copy.ts
+++ b/src/tools/file/copy.ts
@@ -1,5 +1,9 @@
 import { z } from "zod";
-import { contextPathExists, copyContextItem } from "../../db/context.ts";
+import {
+  contextPathExists,
+  copyContextItem,
+  deleteContextItemByPath,
+} from "../../db/context.ts";
 import type { ToolDefinition } from "../tool.ts";
 
 const inputSchema = z.object({
@@ -20,8 +24,12 @@ export const fileCopyTool = {
   inputSchema,
   outputSchema,
   execute: async (input, ctx) => {
-    if (!input.overwrite && (await contextPathExists(ctx.conn, input.dst))) {
+    const dstExists = await contextPathExists(ctx.conn, input.dst);
+    if (dstExists && !input.overwrite) {
       throw new Error(`Destination already exists: ${input.dst}`);
+    }
+    if (dstExists) {
+      await deleteContextItemByPath(ctx.conn, input.dst);
     }
 
     const item = await copyContextItem(ctx.conn, input.src, input.dst);

--- a/src/tools/file/move.ts
+++ b/src/tools/file/move.ts
@@ -1,5 +1,9 @@
 import { z } from "zod";
-import { contextPathExists, moveContextItem } from "../../db/context.ts";
+import {
+  contextPathExists,
+  deleteContextItemByPath,
+  moveContextItem,
+} from "../../db/context.ts";
 import type { ToolDefinition } from "../tool.ts";
 
 const inputSchema = z.object({
@@ -19,8 +23,12 @@ export const fileMoveTool = {
   inputSchema,
   outputSchema,
   execute: async (input, ctx) => {
-    if (!input.overwrite && (await contextPathExists(ctx.conn, input.dst))) {
+    const dstExists = await contextPathExists(ctx.conn, input.dst);
+    if (dstExists && !input.overwrite) {
       throw new Error(`Destination already exists: ${input.dst}`);
+    }
+    if (dstExists) {
+      await deleteContextItemByPath(ctx.conn, input.dst);
     }
 
     await moveContextItem(ctx.conn, input.src, input.dst);

--- a/test/db/context.test.ts
+++ b/test/db/context.test.ts
@@ -44,6 +44,56 @@ describe("context CRUD", () => {
     expect(fetched?.title).toBe("Test");
   });
 
+  test("duplicate context_path is rejected by unique index", async () => {
+    await createContextItem(conn, {
+      title: "First",
+      content: "v1",
+      contextPath: "/docs/test.md",
+    });
+
+    expect(() =>
+      createContextItem(conn, {
+        title: "Second",
+        content: "v2",
+        contextPath: "/docs/test.md",
+      }),
+    ).toThrow();
+
+    const items = await listContextItems(conn);
+    expect(items.length).toBe(1);
+    expect(items[0]?.content).toBe("v1");
+  });
+
+  test("upsert: adding same path twice updates instead of duplicating", async () => {
+    const path = "/docs/test.md";
+
+    // First add
+    await createContextItem(conn, {
+      title: "Original",
+      content: "v1",
+      contextPath: path,
+    });
+
+    // Simulate the upsert pattern from addFile()
+    const existing = await getContextItemByPath(conn, path);
+    expect(existing).not.toBeNull();
+
+    const updated = await updateContextItem(conn, existing!.id, {
+      title: "Updated",
+      content: "v2",
+      mime_type: "text/markdown",
+    });
+
+    expect(updated).not.toBeNull();
+    expect(updated?.content).toBe("v2");
+    expect(updated?.title).toBe("Updated");
+    expect(updated?.mime_type).toBe("text/markdown");
+    expect(updated?.id).toBe(existing!.id);
+
+    const items = await listContextItems(conn);
+    expect(items.length).toBe(1);
+  });
+
   test("get by path", async () => {
     await createContextItem(conn, {
       title: "Notes",

--- a/test/db/schema.test.ts
+++ b/test/db/schema.test.ts
@@ -33,7 +33,7 @@ describe("schema migrations", () => {
     const row = db.query("SELECT COUNT(*) AS count FROM _migrations").get() as {
       count: number;
     };
-    expect(row.count).toBe(3);
+    expect(row.count).toBe(4);
 
     db.close();
   });


### PR DESCRIPTION
## Summary
- Running `context add` on the same file multiple times created duplicate `context_items` rows instead of updating the existing entry
- `addFile()` now checks for an existing item by path and updates it (upsert) rather than always inserting
- Adds a `UNIQUE` index on `context_items.context_path` (new migration) to enforce uniqueness at the DB level
- Fixes `file_copy` and `file_move` overwrite mode to delete the destination before writing, avoiding unique constraint violations
- Adds tests for duplicate rejection and upsert behavior

## Test plan
- [x] `bun run lint` passes
- [x] `bun test` passes (358 tests)
- [ ] Manual: run `context add <file>` twice, verify `context list` shows one entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)