### PR TITLE
Fix TUI context delete and input handling bugs

### DIFF
--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -153,29 +153,31 @@ export function App({
   // Tab switching via useInput at the App level
   // On the Chat tab (1), only Tab key switches — number keys go to InputBar.
   // On other tabs, both Tab and number keys switch tabs, Escape returns to Chat.
-  useInput(
-    (input, key) => {
-      if (activeTab !== 1) {
-        // Number keys jump to tab on non-chat tabs
-        const num = Number.parseInt(input, 10);
-        if (num >= 1 && num <= 4) {
-          setActiveTab(num as TabId);
-          return;
-        }
-        // Escape returns to chat
-        if (key.escape) {
-          setActiveTab(1);
-          return;
-        }
-      }
-    },
-    { isActive: activeTab !== 1 },
-  );
+  useInput((input, key) => {
+    // Ctrl+C exits
+    if (input === "c" && key.ctrl) {
+      exit();
+      return;
+    }
 
-  // Tab key cycles tabs — always active (InputBar ignores tab)
-  useInput((_input, key) => {
+    // Tab key cycles tabs — always active (InputBar ignores tab)
     if (key.tab && !key.shift) {
       setActiveTab((t) => ((t % 4) + 1) as TabId);
+      return;
+    }
+
+    if (activeTab !== 1) {
+      // Number keys jump to tab on non-chat tabs
+      const num = Number.parseInt(input, 10);
+      if (num >= 1 && num <= 4) {
+        setActiveTab(num as TabId);
+        return;
+      }
+      // Escape returns to chat
+      if (key.escape) {
+        setActiveTab(1);
+        return;
+      }
     }
   });
 

--- a/src/tui/components/ContextPanel.tsx
+++ b/src/tui/components/ContextPanel.tsx
@@ -165,7 +165,7 @@ export function ContextPanel({ conn, isActive }: ContextPanelProps) {
 
       // Delete confirmation mode
       if (confirmDelete) {
-        if (input === "y") {
+        if (input === "y" || input === "d") {
           const entry = entries[cursor];
           if (entry) {
             if (entry.type === "directory") {


### PR DESCRIPTION
## Summary
- Accept "d" key (in addition to "y") to confirm context deletion in the Context panel — previously pressing "d" to initiate then "d" to confirm would cancel instead of deleting
- Consolidate two `useInput` hooks in App.tsx into one to prevent double character input on the chat tab
- Add explicit Ctrl+C exit handling since the always-active input hook could interfere with Ink's default behavior

## Test plan
- [ ] Run `bun test` and `bun run lint`
- [ ] In TUI Context tab: press "d" on an item, verify "d" confirms deletion
- [ ] In TUI Chat tab: type normally, verify no doubled characters
- [ ] Press Ctrl+C to verify clean exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)