### PR TITLE
Fix file tool tests by injecting mock embedder

### DIFF
--- a/src/tools/file/edit.ts
+++ b/src/tools/file/edit.ts
@@ -37,7 +37,7 @@ export const fileEditTool = {
       input.patches,
     );
 
-    await ingestByPath(ctx.conn, input.path, ctx.config);
+    await ingestByPath(ctx.conn, input.path, ctx.config, ctx.embedFn);
     return { applied, content: item.content ?? "" };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/file/write.ts
+++ b/src/tools/file/write.ts
@@ -71,7 +71,7 @@ export const fileWriteTool = {
           description: input.description,
         });
       }
-      await ingestByPath(ctx.conn, input.path, ctx.config);
+      await ingestByPath(ctx.conn, input.path, ctx.config, ctx.embedFn);
       return { id: existing.id, path: input.path };
     }
 
@@ -87,7 +87,7 @@ export const fileWriteTool = {
       isTextual,
     });
 
-    await ingestByPath(ctx.conn, input.path, ctx.config);
+    await ingestByPath(ctx.conn, input.path, ctx.config, ctx.embedFn);
     return { id: item.id, path: item.context_path };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -2,6 +2,7 @@ import type { Tool as AnthropicTool } from "@anthropic-ai/sdk/resources/messages
 import type { McpxClient } from "@evantahler/mcpx";
 import { z } from "zod";
 import type { BotholomewConfig } from "../config/schemas.ts";
+import type { EmbedFn } from "../context/embedder.ts";
 import type { DbConnection } from "../db/connection.ts";
 
 export interface ToolContext {
@@ -9,6 +10,7 @@ export interface ToolContext {
   projectDir: string;
   config: Required<BotholomewConfig>;
   mcpxClient: McpxClient | null;
+  embedFn?: EmbedFn;
 }
 
 export interface ToolDefinition<

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,8 +1,14 @@
 import { DEFAULT_CONFIG } from "../src/config/schemas.ts";
+import { EMBEDDING_DIMENSION } from "../src/constants.ts";
+import type { EmbedFn } from "../src/context/embedder.ts";
 import { type DbConnection, getConnection } from "../src/db/connection.ts";
 import { createContextItem } from "../src/db/context.ts";
 import { migrate } from "../src/db/schema.ts";
 import type { ToolContext } from "../src/tools/tool.ts";
+
+/** Mock embedder that returns zero vectors without loading a real model. */
+export const mockEmbed: EmbedFn = async (texts: string[]) =>
+  texts.map(() => new Array(EMBEDDING_DIMENSION).fill(0));
 
 /** Create a fresh in-memory database with migrations applied. */
 export function setupTestDb(): DbConnection {
@@ -19,6 +25,7 @@ export function setupToolContext(): { conn: DbConnection; ctx: ToolContext } {
     projectDir: "/tmp/test",
     config: { ...DEFAULT_CONFIG },
     mcpxClient: null,
+    embedFn: mockEmbed,
   };
   return { conn, ctx };
 }


### PR DESCRIPTION
## Summary

- Since M2 (#25), `file_write` and `file_edit` tools call `ingestByPath()` which loads the real HuggingFace embedding model (~33MB), causing 14 test timeouts/failures on every run
- Adds optional `embedFn` to `ToolContext` so tools can pass it through to `ingestByPath()` — production behavior unchanged (defaults to real embedder)
- Test helper `setupToolContext()` now provides a mock embedder that returns zero vectors instantly

## Test plan

- [x] `bun test test/tools/file.test.ts` — all 40 tests pass in ~71ms (previously timing out at 5000ms each)
- [x] `bun test` — 360 pass, 0 fail
- [x] `bun run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)