### PR TITLE
Add parallel tool execution to daemon and chat agent loops

### DIFF
--- a/src/chat/agent.ts
+++ b/src/chat/agent.ts
@@ -152,9 +152,7 @@ export async function runChatTurn(input: {
     // Add assistant response to conversation
     messages.push({ role: "assistant", content: response.content });
 
-    // Execute tool calls
-    const toolResults: ToolResultBlockParam[] = [];
-
+    // Log all tool_use entries and notify UI
     for (const toolUse of toolUseBlocks) {
       const toolInput = JSON.stringify(toolUse.input);
       callbacks.onToolStart(toolUse.name, toolInput);
@@ -166,20 +164,29 @@ export async function runChatTurn(input: {
         toolName: toolUse.name,
         toolInput,
       });
+    }
 
-      const toolStart = Date.now();
-      const result = await executeChatToolCall(toolUse, toolCtx);
-      const toolDuration = Date.now() - toolStart;
+    // Execute all tools in parallel
+    const execResults = await Promise.all(
+      toolUseBlocks.map(async (toolUse) => {
+        const start = Date.now();
+        const result = await executeChatToolCall(toolUse, toolCtx);
+        const durationMs = Date.now() - start;
+        callbacks.onToolEnd(toolUse.name, result);
+        return { toolUse, result, durationMs };
+      }),
+    );
 
+    // Log results and collect tool_result messages
+    const toolResults: ToolResultBlockParam[] = [];
+    for (const { toolUse, result, durationMs } of execResults) {
       await logInteraction(conn, threadId, {
         role: "tool",
         kind: "tool_result",
         content: result,
         toolName: toolUse.name,
-        durationMs: toolDuration,
+        durationMs,
       });
-
-      callbacks.onToolEnd(toolUse.name, result);
 
       toolResults.push({
         type: "tool_result",

--- a/src/daemon/llm.ts
+++ b/src/daemon/llm.ts
@@ -102,32 +102,35 @@ export async function runAgentLoop(input: {
     // Add assistant response to conversation
     messages.push({ role: "assistant", content: response.content });
 
-    // Process each tool call
-    const toolResults: ToolResultBlockParam[] = [];
-
+    // Log all tool_use entries
     for (const toolUse of toolUseBlocks) {
-      const toolInput = JSON.stringify(toolUse.input);
-
-      // Log tool use
       await logInteraction(conn, threadId, {
         role: "assistant",
         kind: "tool_use",
         content: `Calling ${toolUse.name}`,
         toolName: toolUse.name,
-        toolInput,
+        toolInput: JSON.stringify(toolUse.input),
       });
+    }
 
-      const toolStart = Date.now();
-      const result = await executeToolCall(toolUse, toolCtx);
-      const toolDuration = Date.now() - toolStart;
+    // Execute all tools in parallel
+    const execResults = await Promise.all(
+      toolUseBlocks.map(async (toolUse) => {
+        const start = Date.now();
+        const result = await executeToolCall(toolUse, toolCtx);
+        return { toolUse, result, durationMs: Date.now() - start };
+      }),
+    );
 
-      // Log tool result
+    // Log results and collect tool_result messages
+    const toolResults: ToolResultBlockParam[] = [];
+    for (const { toolUse, result, durationMs } of execResults) {
       await logInteraction(conn, threadId, {
         role: "tool",
         kind: "tool_result",
         content: result.output,
         toolName: toolUse.name,
-        durationMs: toolDuration,
+        durationMs,
       });
 
       if (result.terminal && result.agentResult) {

--- a/test/daemon/llm.test.ts
+++ b/test/daemon/llm.test.ts
@@ -262,6 +262,78 @@ describe("runAgentLoop", () => {
     expect(result.status).toBe("complete");
   });
 
+  test("executes multiple tool calls in parallel", async () => {
+    const task = await createTask(conn, {
+      name: "Parallel task",
+      description: "Uses multiple tools at once",
+    });
+    const threadId = await createThread(conn, "daemon_tick", task.id);
+
+    let callCount = 0;
+    mockCreate.mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        // Return two non-terminal tool calls in one response
+        return {
+          content: [
+            {
+              type: "tool_use",
+              id: "tool_a",
+              name: "file_exists",
+              input: { path: "/a.txt" },
+            },
+            {
+              type: "tool_use",
+              id: "tool_b",
+              name: "file_exists",
+              input: { path: "/b.txt" },
+            },
+          ],
+          stop_reason: "tool_use",
+          usage: { input_tokens: 100, output_tokens: 50 },
+        };
+      }
+      // Second call: complete
+      return {
+        content: [
+          {
+            type: "tool_use",
+            id: "tool_done",
+            name: "complete_task",
+            input: { summary: "Both checked" },
+          },
+        ],
+        stop_reason: "tool_use",
+        usage: { input_tokens: 50, output_tokens: 30 },
+      };
+    });
+
+    const result = await runAgentLoop({
+      systemPrompt: "You are a test agent.",
+      task,
+      config: testConfig,
+      conn,
+      threadId,
+      projectDir: "/tmp/test",
+    });
+
+    expect(result.status).toBe("complete");
+    expect(result.reason).toBe("Both checked");
+
+    // Verify both tool results were logged
+    const threadData = await getThread(conn, threadId);
+    const toolResults = threadData?.interactions.filter(
+      (i) => i.kind === "tool_result" && i.tool_name === "file_exists",
+    );
+    expect(toolResults?.length).toBe(2);
+
+    // Verify both tool_use entries were logged
+    const toolUses = threadData?.interactions.filter(
+      (i) => i.kind === "tool_use" && i.tool_name === "file_exists",
+    );
+    expect(toolUses?.length).toBe(2);
+  });
+
   test("logs all interactions to thread", async () => {
     const task = await createTask(conn, {
       name: "Logged task",


### PR DESCRIPTION
## Summary
- Replace sequential `for` loop with `Promise.all()` in both `src/daemon/llm.ts` and `src/chat/agent.ts` so tool calls from a single LLM response execute concurrently
- Log all `tool_use` entries upfront, execute tools in parallel, then log results — preserving correct interaction ordering
- Add test for multi-tool parallel execution in the daemon agent loop

## Test plan
- [x] `bun run lint` passes
- [x] `bun test` — all 359 tests pass, including new parallel execution test

🤖 Generated with [Claude Code](https://claude.com/claude-code)