### PR TITLE
Fix Ctrl-C exit and double-keystroke bugs with Kitty keyboard

### DIFF
--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -28,9 +28,10 @@ export function registerChatCommand(program: Command) {
           initialPrompt: opts.prompt,
         }),
         {
+          exitOnCtrlC: false,
           kittyKeyboard: {
             mode: "enabled",
-            flags: ["disambiguateEscapeCodes", "reportEventTypes"],
+            flags: ["disambiguateEscapeCodes"],
           },
         },
       );


### PR DESCRIPTION
## Summary
- **Ctrl-C now exits the app again.** With Kitty keyboard protocol, Ctrl-C arrives as a CSI-u escape sequence, not raw `\x03`. Ink's built-in `exitOnCtrlC` handler never matched, and simultaneously blocked the custom `useInput` handler. Setting `exitOnCtrlC: false` lets the existing App.tsx handler work.
- **Fixes double-letter input in Ghostty.** The `reportEventTypes` flag caused both key-press and key-release events to fire, doubling every keystroke. Nothing uses `eventType`, so the flag is removed.

## Test plan
- [ ] `bun run lint` and `bun test` pass (verified)
- [ ] Run `bun run dev -- chat` in Ghostty, type text — no doubled characters
- [ ] Press Ctrl-C — app exits cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)