### PR TITLE
Fix dark mode user message background contrast

### DIFF
--- a/src/tui/theme.ts
+++ b/src/tui/theme.ts
@@ -44,7 +44,7 @@ const isDark = detectDarkBackground();
 export const theme = {
   accent: isDark ? "yellow" : "#B8860B",
   accentBorder: isDark ? "yellow" : "#B8860B",
-  userBg: isDark ? "#1a3a5c" : "#d0e0f0",
+  userBg: isDark ? "#2a4a6c" : "#d0e0f0",
   selectionBg: isDark ? "#333" : "#ddd",
   success: "green",
   error: "red",


### PR DESCRIPTION
## Summary
- Brighten the dark-mode `userBg` color from `#1a3a5c` to `#2a4a6c` in `src/tui/theme.ts`
- User chat bubbles were nearly invisible against common dark terminal backgrounds — the new value provides clear contrast while staying on-theme

## Test plan
- [ ] Run `bun run dev` in a dark terminal, send a message, confirm the user bubble is clearly visible
- [ ] Verify light mode is unchanged (`#d0e0f0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)