### PR TITLE
Encourage parallel tool calls in agent prompts

### DIFF
--- a/src/chat/agent.ts
+++ b/src/chat/agent.ts
@@ -63,6 +63,9 @@ export async function buildChatSystemPrompt(
     "Use the available tools to look up tasks, threads, schedules, and context when the user asks about them.",
   );
   parts.push(
+    "When multiple tool calls are independent of each other (i.e., one does not depend on the result of another), call them all in a single response. They will be executed in parallel, which is faster than calling them one at a time.",
+  );
+  parts.push(
     "You can update the agent's beliefs and goals files when the user asks you to.",
   );
   parts.push(

--- a/src/daemon/prompt.ts
+++ b/src/daemon/prompt.ts
@@ -130,6 +130,9 @@ export async function buildSystemPrompt(
     "Always call complete_task, fail_task, or wait_task when you are done.",
   );
   parts.push("If you need to create subtasks, use create_task.");
+  parts.push(
+    "When multiple tool calls are independent of each other (i.e., one does not depend on the result of another), call them all in a single response. They will be executed in parallel, which is faster than calling them one at a time. Only sequence tool calls when a later call depends on an earlier result.",
+  );
   if (options?.hasMcpTools) {
     parts.push("");
     parts.push("## External Tools (MCP)");


### PR DESCRIPTION
## Summary
- Adds explicit instructions to both the daemon and chat agent system prompts encouraging the LLM to emit multiple independent tool calls in a single response
- Both agent loops already execute tool calls in parallel via `Promise.all()`, but the prompts never told the model to take advantage of this — now they do
- The daemon prompt additionally notes to only sequence calls when there are dependencies

## Test plan
- [x] `bun run lint` passes
- [x] `bun test` passes (361 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)