### PR TITLE
Ensure CI complete job fails instead of being skipped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
 
   complete:
     runs-on: ubuntu-latest
+    if: always()
     needs: [build, lint, test]
     steps:
+      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1
       - run: echo "All checks passed"

--- a/test/tui/theme.test.ts
+++ b/test/tui/theme.test.ts
@@ -90,7 +90,7 @@ describe("theme", () => {
     process.env.COLORFGBG = "15;0"; // force dark
     const { theme } = loadTheme();
     expect(theme.accent).toBe("yellow");
-    expect(theme.userBg).toBe("#1a3a5c");
+    expect(theme.userBg).toBe("#2a4a6c");
     expect(theme.selectionBg).toBe("#333");
   });
 


### PR DESCRIPTION
## Summary
- Add `if: always()` to the `complete` CI job so it always runs, even when upstream jobs (`build`, `lint`, `test`) fail
- Explicitly `exit 1` when any dependency failed or was cancelled, so the check reports as **failed** rather than **skipped**
- Configured branch protection on `main` requiring the `complete` check to pass (with `strict: true` and enforce for admins)
- Fix theme test to match updated dark mode `userBg` color (`#1a3a5c` → `#2a4a6c`) from the contrast fix in d8b71af

🤖 Generated with [Claude Code](https://claude.com/claude-code)