### PR TITLE
Show queued chat messages with edit/remove support

### DIFF
--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -13,6 +13,7 @@ import { Divider } from "./components/Divider.tsx";
 import { HelpPanel } from "./components/HelpPanel.tsx";
 import { InputBar } from "./components/InputBar.tsx";
 import { type ChatMessage, MessageList } from "./components/MessageList.tsx";
+import { QueuePanel } from "./components/QueuePanel.tsx";
 import { StatusBar } from "./components/StatusBar.tsx";
 import { TabBar, type TabId } from "./components/TabBar.tsx";
 import type { ToolCallData } from "./components/ToolCall.tsx";
@@ -99,6 +100,16 @@ export function App({
   const [daemonRunning, setDaemonRunning] = useState(false);
   const queueRef = useRef<string[]>([]);
   const processingRef = useRef(false);
+  const [queuedMessages, setQueuedMessages] = useState<string[]>([]);
+  const [selectedQueueIndex, setSelectedQueueIndex] = useState(0);
+
+  const syncQueue = useCallback(() => {
+    const snapshot = [...queueRef.current];
+    setQueuedMessages(snapshot);
+    setSelectedQueueIndex((prev) =>
+      snapshot.length === 0 ? 0 : Math.min(prev, snapshot.length - 1),
+    );
+  }, []);
 
   // Initialize session
   useEffect(() => {
@@ -166,6 +177,33 @@ export function App({
       return;
     }
 
+    // Queue manipulation keybindings (only when queue has items on Chat tab)
+    if (activeTab === 1 && queuedMessages.length > 0 && key.ctrl) {
+      if (input === "j") {
+        setSelectedQueueIndex((i) =>
+          Math.min(i + 1, queuedMessages.length - 1),
+        );
+        return;
+      }
+      if (input === "k") {
+        setSelectedQueueIndex((i) => Math.max(i - 1, 0));
+        return;
+      }
+      if (input === "x") {
+        queueRef.current.splice(selectedQueueIndex, 1);
+        syncQueue();
+        return;
+      }
+      if (input === "e") {
+        const [msg] = queueRef.current.splice(selectedQueueIndex, 1);
+        syncQueue();
+        if (msg) {
+          setInputValue(msg);
+        }
+        return;
+      }
+    }
+
     if (activeTab !== 1) {
       // Number keys jump to tab on non-chat tabs
       const num = Number.parseInt(input, 10);
@@ -187,6 +225,7 @@ export function App({
 
     while (queueRef.current.length > 0) {
       const trimmed = queueRef.current.shift();
+      syncQueue();
       if (!trimmed) break;
       setIsLoading(true);
       setStreamingText("");
@@ -269,7 +308,7 @@ export function App({
 
     setIsLoading(false);
     processingRef.current = false;
-  }, []);
+  }, [syncQueue]);
 
   // Auto-submit initial prompt once session is ready
   const initialPromptSent = useRef(false);
@@ -277,10 +316,11 @@ export function App({
     if (ready && initialPrompt && !initialPromptSent.current) {
       initialPromptSent.current = true;
       queueRef.current.push(initialPrompt);
+      syncQueue();
       setInputHistory((prev) => [...prev, initialPrompt]);
       processQueue();
     }
-  }, [ready, initialPrompt, processQueue]);
+  }, [ready, initialPrompt, processQueue, syncQueue]);
 
   const handleSubmit = useCallback(
     async (text: string) => {
@@ -341,9 +381,10 @@ export function App({
 
       setInputHistory((prev) => [...prev, trimmed]);
       queueRef.current.push(trimmed);
+      syncQueue();
       processQueue();
     },
-    [exit, processQueue],
+    [exit, processQueue, syncQueue],
   );
 
   const allToolCalls = useMemo(
@@ -395,6 +436,14 @@ export function App({
           projectDir={projectDir}
           threadId={threadId}
           daemonRunning={daemonRunning}
+        />
+      )}
+
+      {/* Queued messages (only on Chat tab) */}
+      {activeTab === 1 && queuedMessages.length > 0 && (
+        <QueuePanel
+          messages={queuedMessages}
+          selectedIndex={selectedQueueIndex}
         />
       )}
 

--- a/src/tui/components/QueuePanel.tsx
+++ b/src/tui/components/QueuePanel.tsx
@@ -1,0 +1,57 @@
+import { Box, Text, useStdout } from "ink";
+import { theme } from "../theme.ts";
+
+interface QueuePanelProps {
+  messages: string[];
+  selectedIndex: number;
+}
+
+function truncate(text: string, maxLen: number): string {
+  const oneLine = text.replace(/\n/g, " ").trim();
+  if (oneLine.length <= maxLen) return oneLine;
+  return `${oneLine.slice(0, maxLen - 1)}…`;
+}
+
+export function QueuePanel({ messages, selectedIndex }: QueuePanelProps) {
+  const { stdout } = useStdout();
+  const cols = (stdout?.columns ?? 80) - 8; // account for border + padding
+
+  if (messages.length === 0) return null;
+
+  const label = `Queue (${messages.length} pending)`;
+  const hints = "Ctrl+E edit · Ctrl+X remove";
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={theme.accent}
+      paddingX={1}
+    >
+      <Box justifyContent="space-between">
+        <Text color={theme.accent} bold>
+          {label}
+        </Text>
+        <Text dimColor>{hints}</Text>
+      </Box>
+      {messages.map((msg, i) => {
+        const isSelected = i === selectedIndex;
+        const prefix = isSelected ? "› " : "  ";
+        const content = truncate(msg, cols - 4);
+        return (
+          // biome-ignore lint/suspicious/noArrayIndexKey: queue items can be duplicates, index is the stable identity
+          <Box key={i}>
+            <Text
+              color={isSelected ? theme.accent : undefined}
+              backgroundColor={isSelected ? theme.selectionBg : undefined}
+              bold={isSelected}
+            >
+              {prefix}
+              {content}
+            </Text>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a `QueuePanel` component that displays pending messages between the message list and input bar when the LLM is processing
- Users can navigate queued messages (Ctrl+J/K), edit them by pulling back to the input bar (Ctrl+E), or remove them (Ctrl+X)
- Makes the internal message queue observable to React via a synced state snapshot, so the UI re-renders when the queue changes

## Test plan

- [ ] Start a chat session, send a message, and while it's processing submit 2+ more messages — verify QueuePanel appears with the queued items
- [ ] Use Ctrl+J/K to navigate selection, Ctrl+E to edit (message moves to input bar), Ctrl+X to remove
- [ ] Verify panel disappears when queue empties
- [ ] `bun run lint` and `bun test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)