### PR TITLE
Display mcp_exec tool calls with server/tool name prominently

### DIFF
--- a/src/tui/components/ToolCall.tsx
+++ b/src/tui/components/ToolCall.tsx
@@ -1,6 +1,29 @@
 import { Box, Text } from "ink";
 import { theme } from "../theme.ts";
 
+/**
+ * For mcp_exec calls, extract server/tool into a top-level display name
+ * and strip them from the displayed input. Other tools pass through unchanged.
+ */
+export function resolveToolDisplay(
+  name: string,
+  input: string,
+): { displayName: string; displayInput: string } {
+  if (name !== "mcp_exec") return { displayName: name, displayInput: input };
+  try {
+    const parsed = JSON.parse(input);
+    const server = parsed.server ?? "mcp";
+    const tool = parsed.tool ?? "unknown";
+    const { server: _s, tool: _t, ...rest } = parsed;
+    return {
+      displayName: `${server} / ${tool}`,
+      displayInput: Object.keys(rest).length > 0 ? JSON.stringify(rest) : "{}",
+    };
+  } catch {
+    return { displayName: name, displayInput: input };
+  }
+}
+
 export interface ToolCallData {
   name: string;
   input: string;
@@ -14,8 +37,12 @@ interface ToolCallProps {
 }
 
 export function ToolCall({ tool }: ToolCallProps) {
+  const { displayName, displayInput } = resolveToolDisplay(
+    tool.name,
+    tool.input,
+  );
   const truncatedInput =
-    tool.input.length > 60 ? `${tool.input.slice(0, 60)}…` : tool.input;
+    displayInput.length > 60 ? `${displayInput.slice(0, 60)}…` : displayInput;
   const truncatedOutput = tool.output ? tool.output.slice(0, 120) : "";
 
   return (
@@ -25,8 +52,9 @@ export function ToolCall({ tool }: ToolCallProps) {
           {tool.running ? "  ⟳ " : "  ✔ "}
         </Text>
         <Text color={tool.running ? theme.accent : theme.toolName} bold>
-          {tool.name}
+          {displayName}
         </Text>
+        {tool.name === "mcp_exec" && <Text dimColor> (exec)</Text>}
         <Text dimColor> ({truncatedInput})</Text>
       </Box>
       {truncatedOutput && !tool.running && (

--- a/src/tui/components/ToolPanel.tsx
+++ b/src/tui/components/ToolPanel.tsx
@@ -1,14 +1,14 @@
 import { Box, Text, useInput, useStdout } from "ink";
 import { useEffect, useMemo, useState } from "react";
 import { theme } from "../theme.ts";
-import type { ToolCallData } from "./ToolCall.tsx";
+import { resolveToolDisplay, type ToolCallData } from "./ToolCall.tsx";
 
 interface ToolPanelProps {
   toolCalls: ToolCallData[];
   isActive: boolean;
 }
 
-const SIDEBAR_WIDTH = 32;
+const SIDEBAR_WIDTH = 42;
 
 // ANSI escape helpers
 const RESET = "\x1b[0m";
@@ -72,7 +72,14 @@ function buildDetailAnsi(tool: ToolCallData): string {
     second: "2-digit",
   });
 
-  lines.push(`${BOLD}${CYAN}${tool.name}${RESET}`);
+  const { displayName, displayInput } = resolveToolDisplay(
+    tool.name,
+    tool.input,
+  );
+  lines.push(`${BOLD}${CYAN}${displayName}${RESET}`);
+  if (tool.name === "mcp_exec") {
+    lines.push(`${DIM}via mcp_exec${RESET}`);
+  }
   lines.push(`${DIM}Time: ${time}${RESET}`);
   if (tool.running) {
     lines.push(`${YELLOW}⟳ running${RESET}`);
@@ -80,7 +87,7 @@ function buildDetailAnsi(tool: ToolCallData): string {
   lines.push("");
 
   lines.push(`${BOLD}${BLUE}Input${RESET}`);
-  lines.push(colorizeJson(tool.input));
+  lines.push(colorizeJson(displayInput));
   lines.push("");
 
   if (tool.output) {
@@ -223,11 +230,12 @@ export function ToolPanel({ toolCalls, isActive }: ToolPanelProps) {
             hour: "2-digit",
             minute: "2-digit",
           });
+          const { displayName } = resolveToolDisplay(tc.name, tc.input);
           const maxName = SIDEBAR_WIDTH - 12; // icon + time + padding
           const nameDisplay =
-            tc.name.length > maxName
-              ? `${tc.name.slice(0, maxName - 1)}…`
-              : tc.name;
+            displayName.length > maxName
+              ? `${displayName.slice(0, maxName - 1)}…`
+              : displayName;
           return (
             <Box key={`${i}-${tc.name}`} paddingX={1}>
               <Text


### PR DESCRIPTION
## Summary
- When the agent uses `mcp_exec`, the chat UI and tool panel now display the server/tool name prominently (e.g. `google-slack-tools / Slack_WhoAmI`) instead of just `mcp_exec` with details buried in truncated input JSON
- A dim `(exec)` label and `via mcp_exec` subtitle preserve visibility that the exec tool is being used
- Widened tool panel sidebar from 32 to 42 columns so longer server/tool names aren't truncated

## Test plan
- [x] `bun run lint` passes
- [x] `bun test` passes (1 pre-existing timeout in search_semantic)
- [ ] Manual: trigger mcp_exec calls and verify display in chat inline and tool panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)