### PR TITLE
Fix /exit not showing context resume message

### DIFF
--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -367,14 +367,6 @@ export function App({
       }
 
       if (trimmed === "/quit" || trimmed === "/exit") {
-        if (sessionRef.current) {
-          const threadId = sessionRef.current.threadId;
-          await endChatSession(sessionRef.current);
-          sessionRef.current = null;
-          process.stderr.write(
-            `\nThread: ${threadId}\nResume with: \x1b[32mbotholomew chat --thread-id ${threadId}\x1b[0m\n`,
-          );
-        }
         exit();
         return;
       }


### PR DESCRIPTION
## Summary
- The `/exit` command handler was writing the resume message to stderr before calling Ink's `exit()`, which overwrote it during teardown
- Removed the duplicate cleanup logic from the `/exit` handler so it just calls `exit()`, letting the existing React useEffect cleanup function handle session teardown and the resume message — the same path Ctrl-C already uses successfully

## Test plan
- [ ] Run `bun run dev chat`, type `/exit`, verify resume message appears
- [ ] Run `bun run dev chat`, press Ctrl-C, verify resume message still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)