### PR TITLE
Display tool call errors with distinct styling in TUI

### DIFF
--- a/src/chat/agent.ts
+++ b/src/chat/agent.ts
@@ -82,7 +82,7 @@ export async function buildChatSystemPrompt(
 export interface ChatTurnCallbacks {
   onToken: (text: string) => void;
   onToolStart: (name: string, input: string) => void;
-  onToolEnd: (name: string, output: string) => void;
+  onToolEnd: (name: string, output: string, isError: boolean) => void;
 }
 
 /**
@@ -183,7 +183,7 @@ export async function runChatTurn(input: {
         const start = Date.now();
         const result = await executeChatToolCall(toolUse, toolCtx);
         const durationMs = Date.now() - start;
-        callbacks.onToolEnd(toolUse.name, result);
+        callbacks.onToolEnd(toolUse.name, result.output, result.isError);
         return { toolUse, result, durationMs };
       }),
     );
@@ -194,7 +194,7 @@ export async function runChatTurn(input: {
       await logInteraction(conn, threadId, {
         role: "tool",
         kind: "tool_result",
-        content: result,
+        content: result.output,
         toolName: toolUse.name,
         durationMs,
       });
@@ -202,7 +202,8 @@ export async function runChatTurn(input: {
       toolResults.push({
         type: "tool_result",
         tool_use_id: toolUse.id,
-        content: maybeStoreResult(toolUse.name, result),
+        content: maybeStoreResult(toolUse.name, result.output),
+        is_error: result.isError || undefined,
       });
     }
 
@@ -214,21 +215,32 @@ export async function runChatTurn(input: {
 async function executeChatToolCall(
   toolUse: ToolUseBlock,
   ctx: ToolContext,
-): Promise<string> {
+): Promise<{ output: string; isError: boolean }> {
   const tool = getTool(toolUse.name);
-  if (!tool) return `Unknown tool: ${toolUse.name}`;
+  if (!tool) return { output: `Unknown tool: ${toolUse.name}`, isError: true };
   if (!CHAT_TOOL_NAMES.has(tool.name))
-    return `Tool not available in chat mode: ${tool.name}`;
+    return {
+      output: `Tool not available in chat mode: ${tool.name}`,
+      isError: true,
+    };
 
   const parsed = tool.inputSchema.safeParse(toolUse.input);
   if (!parsed.success) {
-    return `Invalid input: ${JSON.stringify(parsed.error)}`;
+    return {
+      output: `Invalid input: ${JSON.stringify(parsed.error)}`,
+      isError: true,
+    };
   }
 
   try {
     const result = await tool.execute(parsed.data, ctx);
-    return typeof result === "string" ? result : JSON.stringify(result);
+    const isError =
+      typeof result === "object" && result !== null && "is_error" in result
+        ? (result as { is_error: boolean }).is_error
+        : false;
+    const output = typeof result === "string" ? result : JSON.stringify(result);
+    return { output, isError };
   } catch (err) {
-    return `Tool error: ${err}`;
+    return { output: `Tool error: ${err}`, isError: true };
   }
 }

--- a/src/daemon/llm.ts
+++ b/src/daemon/llm.ts
@@ -149,6 +149,7 @@ export async function runAgentLoop(input: {
         type: "tool_result",
         tool_use_id: toolUse.id,
         content: maybeStoreResult(toolUse.name, result.output),
+        is_error: result.isError || undefined,
       });
     }
 
@@ -161,6 +162,7 @@ export async function runAgentLoop(input: {
 interface ToolCallResult {
   output: string;
   terminal: boolean;
+  isError: boolean;
   agentResult?: AgentLoopResult;
 }
 
@@ -170,7 +172,11 @@ async function executeToolCall(
 ): Promise<ToolCallResult> {
   const tool = getTool(toolUse.name);
   if (!tool) {
-    return { output: `Unknown tool: ${toolUse.name}`, terminal: false };
+    return {
+      output: `Unknown tool: ${toolUse.name}`,
+      terminal: false,
+      isError: true,
+    };
   }
 
   const parsed = tool.inputSchema.safeParse(toolUse.input);
@@ -178,10 +184,15 @@ async function executeToolCall(
     return {
       output: `Invalid input: ${JSON.stringify(parsed.error)}`,
       terminal: false,
+      isError: true,
     };
   }
 
   const result = await tool.execute(parsed.data, ctx);
+  const isError =
+    typeof result === "object" && result !== null && "is_error" in result
+      ? (result as { is_error: boolean }).is_error
+      : false;
   const output = typeof result === "string" ? result : JSON.stringify(result);
 
   // Check if this is a terminal tool (complete/fail/wait)
@@ -195,10 +206,11 @@ async function executeToolCall(
       return {
         output,
         terminal: true,
+        isError,
         agentResult: { status, reason: String(reason) },
       };
     }
   }
 
-  return { output, terminal: false };
+  return { output, terminal: false, isError };
 }

--- a/src/tools/context/read-large-result.ts
+++ b/src/tools/context/read-large-result.ts
@@ -11,6 +11,7 @@ const outputSchema = z.object({
   content: z.string(),
   page: z.number(),
   totalPages: z.number(),
+  is_error: z.boolean(),
 });
 
 export const readLargeResultTool = {
@@ -27,6 +28,6 @@ export const readLargeResultTool = {
         `No result found for id="${input.id}" page=${input.page}. The id may be invalid or the page may be out of range.`,
       );
     }
-    return result;
+    return { ...result, is_error: false };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/context/search.ts
+++ b/src/tools/context/search.ts
@@ -19,6 +19,7 @@ const outputSchema = z.object({
     }),
   ),
   count: z.number(),
+  is_error: z.boolean(),
 });
 
 export const searchContextTool = {
@@ -41,6 +42,7 @@ export const searchContextTool = {
         content_preview: (item.content ?? "").slice(0, 500),
       })),
       count: items.length,
+      is_error: false,
     };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/context/update-beliefs.ts
+++ b/src/tools/context/update-beliefs.ts
@@ -19,6 +19,7 @@ const inputSchema = z.object({
 const outputSchema = z.object({
   message: z.string(),
   path: z.string(),
+  is_error: z.boolean(),
 });
 
 export const updateBeliefsTool = {
@@ -49,6 +50,7 @@ export const updateBeliefsTool = {
     return {
       message: "Updated beliefs.md",
       path: filePath,
+      is_error: false,
     };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/context/update-goals.ts
+++ b/src/tools/context/update-goals.ts
@@ -19,6 +19,7 @@ const inputSchema = z.object({
 const outputSchema = z.object({
   message: z.string(),
   path: z.string(),
+  is_error: z.boolean(),
 });
 
 export const updateGoalsTool = {
@@ -49,6 +50,7 @@ export const updateGoalsTool = {
     return {
       message: "Updated goals.md",
       path: filePath,
+      is_error: false,
     };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/dir/create.ts
+++ b/src/tools/dir/create.ts
@@ -13,6 +13,7 @@ const inputSchema = z.object({
 const outputSchema = z.object({
   created: z.boolean(),
   path: z.string(),
+  is_error: z.boolean(),
 });
 
 export const dirCreateTool = {
@@ -24,7 +25,7 @@ export const dirCreateTool = {
   execute: async (input, ctx) => {
     const exists = await contextPathExists(ctx.conn, input.path);
     if (exists) {
-      return { created: false, path: input.path };
+      return { created: false, path: input.path, is_error: false };
     }
 
     await createContextItem(ctx.conn, {
@@ -34,6 +35,6 @@ export const dirCreateTool = {
       isTextual: false,
     });
 
-    return { created: true, path: input.path };
+    return { created: true, path: input.path, is_error: false };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/dir/list.ts
+++ b/src/tools/dir/list.ts
@@ -33,6 +33,7 @@ const inputSchema = z.object({
 const outputSchema = z.object({
   entries: z.array(DirEntrySchema),
   total: z.number(),
+  is_error: z.boolean(),
 });
 
 export const dirListTool = {
@@ -82,6 +83,6 @@ export const dirListTool = {
     const total = entries.length;
     const paginated = entries.slice(offset, offset + limit);
 
-    return { entries: paginated, total };
+    return { entries: paginated, total, is_error: false };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/dir/size.ts
+++ b/src/tools/dir/size.ts
@@ -21,6 +21,7 @@ const inputSchema = z.object({
 const outputSchema = z.object({
   bytes: z.number(),
   formatted: z.string(),
+  is_error: z.boolean(),
 });
 
 export const dirSizeTool = {
@@ -40,6 +41,6 @@ export const dirSizeTool = {
       if (item.content != null) bytes += item.content.length;
     }
 
-    return { bytes, formatted: formatBytes(bytes) };
+    return { bytes, formatted: formatBytes(bytes), is_error: false };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/dir/tree.ts
+++ b/src/tools/dir/tree.ts
@@ -20,6 +20,7 @@ const inputSchema = z.object({
 
 const outputSchema = z.object({
   tree: z.string(),
+  is_error: z.boolean(),
 });
 
 export const dirTreeTool = {
@@ -38,7 +39,7 @@ export const dirTreeTool = {
     });
 
     if (items.length === 0) {
-      return { tree: `${path}\n  (empty)` };
+      return { tree: `${path}\n  (empty)`, is_error: false };
     }
 
     const normalizedPath = path.endsWith("/") ? path : `${path}/`;
@@ -86,6 +87,6 @@ export const dirTreeTool = {
       lines.push(`... (truncated at ${maxItems} items)`);
     }
 
-    return { tree: lines.join("\n") };
+    return { tree: lines.join("\n"), is_error: false };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/file/copy.ts
+++ b/src/tools/file/copy.ts
@@ -15,6 +15,7 @@ const inputSchema = z.object({
 const outputSchema = z.object({
   id: z.string(),
   path: z.string(),
+  is_error: z.boolean(),
 });
 
 export const fileCopyTool = {
@@ -33,6 +34,6 @@ export const fileCopyTool = {
     }
 
     const item = await copyContextItem(ctx.conn, input.src, input.dst);
-    return { id: item.id, path: item.context_path };
+    return { id: item.id, path: item.context_path, is_error: false };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/file/count-lines.ts
+++ b/src/tools/file/count-lines.ts
@@ -8,6 +8,7 @@ const inputSchema = z.object({
 
 const outputSchema = z.object({
   lines: z.number(),
+  is_error: z.boolean(),
 });
 
 export const fileCountLinesTool = {
@@ -21,6 +22,6 @@ export const fileCountLinesTool = {
     if (!item) throw new Error(`Not found: ${input.path}`);
     if (item.content == null) throw new Error(`No text content: ${input.path}`);
 
-    return { lines: item.content.split("\n").length };
+    return { lines: item.content.split("\n").length, is_error: false };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/file/delete.ts
+++ b/src/tools/file/delete.ts
@@ -19,6 +19,7 @@ const inputSchema = z.object({
 
 const outputSchema = z.object({
   deleted: z.number(),
+  is_error: z.boolean(),
 });
 
 export const fileDeleteTool = {
@@ -31,13 +32,13 @@ export const fileDeleteTool = {
     if (input.recursive) {
       const count = await deleteContextItemsByPrefix(ctx.conn, input.path);
       const exact = await deleteContextItemByPath(ctx.conn, input.path);
-      return { deleted: count + (exact ? 1 : 0) };
+      return { deleted: count + (exact ? 1 : 0), is_error: false };
     }
 
     const deleted = await deleteContextItemByPath(ctx.conn, input.path);
     if (!deleted && !input.force) {
       throw new Error(`Not found: ${input.path}`);
     }
-    return { deleted: deleted ? 1 : 0 };
+    return { deleted: deleted ? 1 : 0, is_error: false };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/file/edit.ts
+++ b/src/tools/file/edit.ts
@@ -21,6 +21,7 @@ const inputSchema = z.object({
 const outputSchema = z.object({
   applied: z.number(),
   content: z.string(),
+  is_error: z.boolean(),
 });
 
 export const fileEditTool = {
@@ -38,6 +39,6 @@ export const fileEditTool = {
     );
 
     await ingestByPath(ctx.conn, input.path, ctx.config, ctx.embedFn);
-    return { applied, content: item.content ?? "" };
+    return { applied, content: item.content ?? "", is_error: false };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/file/exists.ts
+++ b/src/tools/file/exists.ts
@@ -8,6 +8,7 @@ const inputSchema = z.object({
 
 const outputSchema = z.object({
   exists: z.boolean(),
+  is_error: z.boolean(),
 });
 
 export const fileExistsTool = {
@@ -18,6 +19,6 @@ export const fileExistsTool = {
   outputSchema,
   execute: async (input, ctx) => {
     const exists = await contextPathExists(ctx.conn, input.path);
-    return { exists };
+    return { exists, is_error: false };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/file/info.ts
+++ b/src/tools/file/info.ts
@@ -19,6 +19,7 @@ const outputSchema = z.object({
   indexed_at: z.string().nullable(),
   created_at: z.string(),
   updated_at: z.string(),
+  is_error: z.boolean(),
 });
 
 export const fileInfoTool = {
@@ -45,6 +46,7 @@ export const fileInfoTool = {
       indexed_at: item.indexed_at?.toISOString() ?? null,
       created_at: item.created_at.toISOString(),
       updated_at: item.updated_at.toISOString(),
+      is_error: false,
     };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/file/move.ts
+++ b/src/tools/file/move.ts
@@ -14,6 +14,7 @@ const inputSchema = z.object({
 
 const outputSchema = z.object({
   path: z.string(),
+  is_error: z.boolean(),
 });
 
 export const fileMoveTool = {
@@ -38,6 +39,6 @@ export const fileMoveTool = {
       .query("UPDATE embeddings SET source_path = ?1 WHERE source_path = ?2")
       .run(input.dst, input.src);
 
-    return { path: input.dst };
+    return { path: input.dst, is_error: false };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/file/read.ts
+++ b/src/tools/file/read.ts
@@ -13,6 +13,7 @@ const inputSchema = z.object({
 
 const outputSchema = z.object({
   content: z.string(),
+  is_error: z.boolean(),
 });
 
 export const fileReadTool = {
@@ -35,6 +36,6 @@ export const fileReadTool = {
       content = lines.slice(start, end).join("\n");
     }
 
-    return { content };
+    return { content, is_error: false };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/file/write.ts
+++ b/src/tools/file/write.ts
@@ -40,6 +40,7 @@ const inputSchema = z.object({
 const outputSchema = z.object({
   id: z.string(),
   path: z.string(),
+  is_error: z.boolean(),
 });
 
 export const fileWriteTool = {
@@ -72,7 +73,7 @@ export const fileWriteTool = {
         });
       }
       await ingestByPath(ctx.conn, input.path, ctx.config, ctx.embedFn);
-      return { id: existing.id, path: input.path };
+      return { id: existing.id, path: input.path, is_error: false };
     }
 
     const title =
@@ -88,6 +89,6 @@ export const fileWriteTool = {
     });
 
     await ingestByPath(ctx.conn, input.path, ctx.config, ctx.embedFn);
-    return { id: item.id, path: item.context_path };
+    return { id: item.id, path: item.context_path, is_error: false };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/mcp/info.ts
+++ b/src/tools/mcp/info.ts
@@ -11,6 +11,7 @@ const outputSchema = z.object({
   name: z.string(),
   description: z.string(),
   input_schema: z.string(),
+  is_error: z.boolean(),
 });
 
 export const mcpInfoTool = {
@@ -27,6 +28,7 @@ export const mcpInfoTool = {
         name: input.tool,
         description: "No MCP servers configured.",
         input_schema: "{}",
+        is_error: true,
       };
     }
 
@@ -37,6 +39,7 @@ export const mcpInfoTool = {
         name: input.tool,
         description: `Tool "${input.tool}" not found on server "${input.server}".`,
         input_schema: "{}",
+        is_error: true,
       };
     }
 
@@ -45,6 +48,7 @@ export const mcpInfoTool = {
       name: tool.name,
       description: tool.description ?? "",
       input_schema: JSON.stringify(tool.inputSchema ?? {}, null, 2),
+      is_error: false,
     };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/mcp/list-tools.ts
+++ b/src/tools/mcp/list-tools.ts
@@ -16,6 +16,7 @@ const ToolEntrySchema = z.object({
 
 const outputSchema = z.object({
   tools: z.array(ToolEntrySchema),
+  is_error: z.boolean(),
 });
 
 export const mcpListToolsTool = {
@@ -27,7 +28,7 @@ export const mcpListToolsTool = {
   outputSchema,
   execute: async (input, ctx) => {
     if (!ctx.mcpxClient) {
-      return { tools: [] };
+      return { tools: [], is_error: false };
     }
 
     const toolsWithServer = await ctx.mcpxClient.listTools(input.server);
@@ -37,6 +38,7 @@ export const mcpListToolsTool = {
         name: t.tool.name,
         description: t.tool.description ?? "",
       })),
+      is_error: false,
     };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/mcp/search.ts
+++ b/src/tools/mcp/search.ts
@@ -23,6 +23,7 @@ const SearchResultSchema = z.object({
 
 const outputSchema = z.object({
   results: z.array(SearchResultSchema),
+  is_error: z.boolean(),
 });
 
 export const mcpSearchTool = {
@@ -34,7 +35,7 @@ export const mcpSearchTool = {
   outputSchema,
   execute: async (input, ctx) => {
     if (!ctx.mcpxClient) {
-      return { results: [] };
+      return { results: [], is_error: false };
     }
 
     try {
@@ -50,9 +51,10 @@ export const mcpSearchTool = {
           score: r.score,
           match_type: r.matchType ?? "keyword",
         })),
+        is_error: false,
       };
     } catch {
-      return { results: [] };
+      return { results: [], is_error: true };
     }
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/schedule/create.ts
+++ b/src/tools/schedule/create.ts
@@ -17,6 +17,7 @@ const outputSchema = z.object({
   id: z.string(),
   name: z.string(),
   message: z.string(),
+  is_error: z.boolean(),
 });
 
 export const createScheduleTool = {
@@ -37,6 +38,7 @@ export const createScheduleTool = {
       id: schedule.id,
       name: schedule.name,
       message: `Created schedule "${schedule.name}" with frequency "${schedule.frequency}"`,
+      is_error: false,
     };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/schedule/list.ts
+++ b/src/tools/schedule/list.ts
@@ -17,6 +17,7 @@ const outputSchema = z.object({
     }),
   ),
   count: z.number(),
+  is_error: z.boolean(),
 });
 
 export const listSchedulesTool = {
@@ -38,6 +39,7 @@ export const listSchedulesTool = {
         last_run_at: s.last_run_at?.toISOString() ?? null,
       })),
       count: schedules.length,
+      is_error: false,
     };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/search/grep.ts
+++ b/src/tools/search/grep.ts
@@ -32,6 +32,7 @@ const inputSchema = z.object({
 
 const outputSchema = z.object({
   matches: z.array(GrepMatchSchema),
+  is_error: z.boolean(),
 });
 
 export const searchGrepTool = {
@@ -76,12 +77,12 @@ export const searchGrepTool = {
             content: line,
             context_lines: lines.slice(start, end),
           });
-          if (matches.length >= maxResults) return { matches };
+          if (matches.length >= maxResults) return { matches, is_error: false };
         }
       }
     }
 
-    return { matches };
+    return { matches, is_error: false };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;
 

--- a/src/tools/search/semantic.ts
+++ b/src/tools/search/semantic.ts
@@ -25,6 +25,7 @@ const outputSchema = z.object({
       snippet: z.string(),
     }),
   ),
+  is_error: z.boolean(),
 });
 
 export const searchSemanticTool = {
@@ -55,6 +56,7 @@ export const searchSemanticTool = {
           snippet: (r.chunk_content || "").slice(0, 300),
         }))
         .sort((a, b) => b.score - a.score),
+      is_error: false,
     };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/task/complete.ts
+++ b/src/tools/task/complete.ts
@@ -7,6 +7,7 @@ const inputSchema = z.object({
 
 const outputSchema = z.object({
   message: z.string(),
+  is_error: z.boolean(),
 });
 
 export const completeTaskTool = {
@@ -19,5 +20,6 @@ export const completeTaskTool = {
   outputSchema,
   execute: async (input) => ({
     message: `Task completed: ${input.summary}`,
+    is_error: false,
   }),
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/task/create.ts
+++ b/src/tools/task/create.ts
@@ -17,6 +17,7 @@ const outputSchema = z.object({
   id: z.string(),
   name: z.string(),
   message: z.string(),
+  is_error: z.boolean(),
 });
 
 export const createTaskTool = {
@@ -37,6 +38,7 @@ export const createTaskTool = {
       id: newTask.id,
       name: newTask.name,
       message: `Created task "${newTask.name}" with ID ${newTask.id}`,
+      is_error: false,
     };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/task/fail.ts
+++ b/src/tools/task/fail.ts
@@ -7,6 +7,7 @@ const inputSchema = z.object({
 
 const outputSchema = z.object({
   message: z.string(),
+  is_error: z.boolean(),
 });
 
 export const failTaskTool = {
@@ -18,5 +19,6 @@ export const failTaskTool = {
   outputSchema,
   execute: async (input) => ({
     message: `Task failed: ${input.reason}`,
+    is_error: false,
   }),
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/task/list.ts
+++ b/src/tools/task/list.ts
@@ -20,6 +20,7 @@ const outputSchema = z.object({
     }),
   ),
   count: z.number(),
+  is_error: z.boolean(),
 });
 
 export const listTasksTool = {
@@ -44,6 +45,7 @@ export const listTasksTool = {
         created_at: t.created_at.toISOString(),
       })),
       count: tasks.length,
+      is_error: false,
     };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/task/view.ts
+++ b/src/tools/task/view.ts
@@ -22,6 +22,7 @@ const outputSchema = z.object({
       updated_at: z.string(),
     })
     .nullable(),
+  is_error: z.boolean(),
 });
 
 export const viewTaskTool = {
@@ -32,7 +33,7 @@ export const viewTaskTool = {
   outputSchema,
   execute: async (input, ctx) => {
     const task = await getTask(ctx.conn, input.id);
-    if (!task) return { task: null };
+    if (!task) return { task: null, is_error: true };
     return {
       task: {
         id: task.id,
@@ -47,6 +48,7 @@ export const viewTaskTool = {
         created_at: task.created_at.toISOString(),
         updated_at: task.updated_at.toISOString(),
       },
+      is_error: false,
     };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/task/wait.ts
+++ b/src/tools/task/wait.ts
@@ -7,6 +7,7 @@ const inputSchema = z.object({
 
 const outputSchema = z.object({
   message: z.string(),
+  is_error: z.boolean(),
 });
 
 export const waitTaskTool = {
@@ -19,5 +20,6 @@ export const waitTaskTool = {
   outputSchema,
   execute: async (input) => ({
     message: `Task waiting: ${input.reason}`,
+    is_error: false,
   }),
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/thread/list.ts
+++ b/src/tools/thread/list.ts
@@ -22,6 +22,7 @@ const outputSchema = z.object({
     }),
   ),
   count: z.number(),
+  is_error: z.boolean(),
 });
 
 export const listThreadsTool = {
@@ -45,6 +46,7 @@ export const listThreadsTool = {
         ended_at: t.ended_at?.toISOString() ?? null,
       })),
       count: threads.length,
+      is_error: false,
     };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/thread/view.ts
+++ b/src/tools/thread/view.ts
@@ -28,6 +28,7 @@ const outputSchema = z.object({
       created_at: z.string(),
     }),
   ),
+  is_error: z.boolean(),
 });
 
 export const viewThreadTool = {
@@ -39,7 +40,7 @@ export const viewThreadTool = {
   outputSchema,
   execute: async (input, ctx) => {
     const result = await getThread(ctx.conn, input.id);
-    if (!result) return { thread: null, interactions: [] };
+    if (!result) return { thread: null, interactions: [], is_error: false };
     return {
       thread: {
         id: result.thread.id,
@@ -58,6 +59,7 @@ export const viewThreadTool = {
         tool_name: i.tool_name,
         created_at: i.created_at.toISOString(),
       })),
+      is_error: false,
     };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -13,9 +13,11 @@ export interface ToolContext {
   embedFn?: EmbedFn;
 }
 
+type ToolOutputBase = { is_error: z.ZodBoolean };
+
 export interface ToolDefinition<
   TInput extends z.ZodObject<z.ZodRawShape>,
-  TOutput extends z.ZodType,
+  TOutput extends z.ZodObject<z.ZodRawShape & ToolOutputBase>,
 > {
   name: string;
   description: string;
@@ -33,14 +35,14 @@ export interface ToolDefinition<
 
 export type AnyToolDefinition = ToolDefinition<
   z.ZodObject<z.ZodRawShape>,
-  z.ZodType
+  z.ZodObject<z.ZodRawShape & ToolOutputBase>
 >;
 
 const tools = new Map<string, AnyToolDefinition>();
 
 export function registerTool<
   TInput extends z.ZodObject<z.ZodRawShape>,
-  TOutput extends z.ZodType,
+  TOutput extends z.ZodObject<z.ZodRawShape & ToolOutputBase>,
 >(tool: ToolDefinition<TInput, TOutput>): void {
   tools.set(tool.name, tool as unknown as AnyToolDefinition);
 }

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -31,6 +31,17 @@ function msgId(): string {
   return `msg-${++nextMsgId}`;
 }
 
+function detectToolError(output: string | undefined): boolean {
+  if (!output) return false;
+  try {
+    const parsed = JSON.parse(output);
+    if (typeof parsed === "object" && parsed?.is_error === true) return true;
+  } catch {
+    /* not JSON */
+  }
+  return false;
+}
+
 function restoreMessagesFromInteractions(
   interactions: Interaction[],
 ): ChatMessage[] {
@@ -49,6 +60,7 @@ function restoreMessagesFromInteractions(
       const tc = pendingTools.find((t) => t.name === ix.tool_name && !t.output);
       if (tc) {
         tc.output = ix.content;
+        tc.isError = detectToolError(ix.content);
       }
     } else if (ix.kind === "message" && ix.role === "user") {
       result.push({
@@ -287,13 +299,14 @@ export function App({
             pendingToolCalls.push(tc);
             setActiveToolCalls([...pendingToolCalls]);
           },
-          onToolEnd: (name, output) => {
+          onToolEnd: (name, output, isError) => {
             const tc = pendingToolCalls.find(
               (t) => t.name === name && t.running,
             );
             if (tc) {
               tc.running = false;
               tc.output = output;
+              tc.isError = isError;
             }
             setActiveToolCalls([...pendingToolCalls]);
           },

--- a/src/tui/components/ToolCall.tsx
+++ b/src/tui/components/ToolCall.tsx
@@ -30,6 +30,7 @@ export interface ToolCallData {
   output?: string;
   running: boolean;
   timestamp: Date;
+  isError?: boolean;
 }
 
 interface ToolCallProps {
@@ -48,10 +49,27 @@ export function ToolCall({ tool }: ToolCallProps) {
   return (
     <Box flexDirection="column">
       <Box>
-        <Text color={tool.running ? theme.accent : theme.muted}>
-          {tool.running ? "  ⟳ " : "  ✔ "}
+        <Text
+          color={
+            tool.running
+              ? theme.accent
+              : tool.isError
+                ? theme.error
+                : theme.muted
+          }
+        >
+          {tool.running ? "  ⟳ " : tool.isError ? "  ✘ " : "  ✔ "}
         </Text>
-        <Text color={tool.running ? theme.accent : theme.toolName} bold>
+        <Text
+          color={
+            tool.running
+              ? theme.accent
+              : tool.isError
+                ? theme.error
+                : theme.toolName
+          }
+          bold
+        >
           {displayName}
         </Text>
         {tool.name === "mcp_exec" && <Text dimColor> (exec)</Text>}

--- a/src/tui/components/ToolPanel.tsx
+++ b/src/tui/components/ToolPanel.tsx
@@ -19,6 +19,7 @@ const GREEN = "\x1b[32m";
 const YELLOW = "\x1b[33m";
 const MAGENTA = "\x1b[35m";
 const BLUE = "\x1b[34m";
+const RED = "\x1b[31m";
 
 /** Try to parse a string as JSON; returns the parsed value or undefined on failure */
 function tryParseJson(str: string): unknown | undefined {
@@ -103,8 +104,13 @@ function buildDetailAnsi(tool: ToolCallData): string {
   lines.push("");
 
   if (tool.output) {
-    lines.push(`${BOLD}${BLUE}Output${RESET}`);
-    lines.push(colorizeJson(tool.output));
+    if (tool.isError) {
+      lines.push(`${BOLD}${RED}Error${RESET}`);
+      lines.push(`${RED}${colorizeJson(tool.output)}${RESET}`);
+    } else {
+      lines.push(`${BOLD}${BLUE}Output${RESET}`);
+      lines.push(colorizeJson(tool.output));
+    }
   } else if (!tool.running) {
     lines.push(`${BOLD}${BLUE}Output${RESET}`);
     lines.push(`${DIM}(no output)${RESET}`);
@@ -261,7 +267,7 @@ export function ToolPanel({ toolCalls, isActive }: ToolPanelProps) {
         {sidebarVisible.map((tc, vi) => {
           const i = vi + sidebarScrollOffset;
           const isSelected = i === selectedIndex;
-          const icon = tc.running ? "⟳" : "✔";
+          const icon = tc.running ? "⟳" : tc.isError ? "✘" : "✔";
           const time = tc.timestamp.toLocaleTimeString([], {
             hour: "2-digit",
             minute: "2-digit",
@@ -288,7 +294,13 @@ export function ToolPanel({ toolCalls, isActive }: ToolPanelProps) {
               >
                 {isSelected ? "▸" : " "}{" "}
                 <Text
-                  color={tc.running ? theme.accent : theme.muted}
+                  color={
+                    tc.running
+                      ? theme.accent
+                      : tc.isError
+                        ? theme.error
+                        : theme.muted
+                  }
                   bold={false}
                 >
                   {icon}

--- a/test/tools/tool.test.ts
+++ b/test/tools/tool.test.ts
@@ -31,8 +31,9 @@ function makeTool(overrides: Partial<Parameters<typeof registerTool>[0]> = {}) {
     }),
     outputSchema: z.object({
       content: z.string(),
+      is_error: z.boolean(),
     }),
-    execute: async () => ({ content: "ok" }),
+    execute: async () => ({ content: "ok", is_error: false }),
     ...overrides,
   };
 }
@@ -109,10 +110,12 @@ describe("Tool execution", () => {
       outputSchema: z.object({
         content: z.string(),
         lines: z.number(),
+        is_error: z.boolean(),
       }),
       execute: async (input) => ({
         content: `read: ${input.path}`,
         lines: input.offset ?? 0,
+        is_error: false,
       }),
     });
 


### PR DESCRIPTION
## Summary
- Adds a `ToolOutputBase` type constraint requiring all tool output schemas to include `is_error: z.boolean()`, enforced at compile time via TypeScript generics on `ToolDefinition`
- Updates all 30+ tool files to include `is_error` in their output schemas and return values, with `true` on failure paths and `false` on success
- Tool errors now display with a red ✘ icon and red "Error" header in the Tool Panel sidebar and detail pane, instead of the green ✔ and blue "Output" used for successes
- Passes `is_error` through to the Anthropic API `ToolResultBlockParam` so the LLM can recognize and retry failed tool calls
- History restoration parses stored JSON to recover error state from past tool results

## Test plan
- [x] `bun run lint` passes (type-check catches any tool missing `is_error`)
- [x] `bun test` — all 361 tests pass
- [ ] Manual: trigger an MCP tool error in chat, verify red ✘ in sidebar and red "Error" header in detail pane
- [ ] Manual: resume a thread with past tool errors, verify history shows errors correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)