### PR TITLE
Improve agent prompts and add update_task tool

### DIFF
--- a/src/daemon/llm.ts
+++ b/src/daemon/llm.ts
@@ -49,7 +49,7 @@ export async function runAgentLoop(input: {
     mcpxClient: input.mcpxClient ?? null,
   };
 
-  const userMessage = `Please work on this task:\n\nName: ${task.name}\nDescription: ${task.description}\nPriority: ${task.priority}\n\nUse the available tools to complete this task, then call complete_task, fail_task, or wait_task to indicate the outcome.`;
+  const userMessage = `Task:\nName: ${task.name}\nDescription: ${task.description}\nPriority: ${task.priority}`;
 
   const messages: MessageParam[] = [{ role: "user", content: userMessage }];
 

--- a/src/daemon/prompt.ts
+++ b/src/daemon/prompt.ts
@@ -123,15 +123,7 @@ export async function buildSystemPrompt(
   // Instructions
   parts.push("## Instructions");
   parts.push(
-    "You are the Botholomew daemon, personified by a wise owl. You wake up periodically to work through tasks.",
-  );
-  parts.push("When given a task, use the available tools to complete it.");
-  parts.push(
-    "Always call complete_task, fail_task, or wait_task when you are done.",
-  );
-  parts.push("If you need to create subtasks, use create_task.");
-  parts.push(
-    "When multiple tool calls are independent of each other (i.e., one does not depend on the result of another), call them all in a single response. They will be executed in parallel, which is faster than calling them one at a time. Only sequence tool calls when a later call depends on an earlier result.",
+    "You are Botholomew, a wise-owl daemon that works through tasks. Use available tools to complete your assigned task, then call complete_task, fail_task, or wait_task. Use create_task for subtasks and update_task to refine pending tasks. Batch independent tool calls in a single response for parallel execution.",
   );
   if (options?.hasMcpTools) {
     parts.push("");

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -34,6 +34,7 @@ import { completeTaskTool } from "./task/complete.ts";
 import { createTaskTool } from "./task/create.ts";
 import { failTaskTool } from "./task/fail.ts";
 import { listTasksTool } from "./task/list.ts";
+import { updateTaskTool } from "./task/update.ts";
 import { viewTaskTool } from "./task/view.ts";
 import { waitTaskTool } from "./task/wait.ts";
 // Thread tools
@@ -47,6 +48,7 @@ export function registerAllTools(): void {
   registerTool(failTaskTool);
   registerTool(waitTaskTool);
   registerTool(createTaskTool);
+  registerTool(updateTaskTool);
   registerTool(listTasksTool);
   registerTool(viewTaskTool);
 

--- a/src/tools/task/create.ts
+++ b/src/tools/task/create.ts
@@ -4,9 +4,19 @@ import { logger } from "../../utils/logger.ts";
 import type { ToolDefinition } from "../tool.ts";
 
 const inputSchema = z.object({
-  name: z.string().describe("Task name"),
-  description: z.string().optional().describe("Task description"),
-  priority: z.enum(TASK_PRIORITIES).optional().describe("Task priority"),
+  name: z
+    .string()
+    .describe("Concise but descriptive task name summarizing the goal"),
+  description: z
+    .string()
+    .optional()
+    .describe(
+      "Detailed description including relevant file paths, what needs to change, why, and any constraints. Rich descriptions reduce redundant tool calls when the task is picked up later.",
+    ),
+  priority: z
+    .enum(TASK_PRIORITIES)
+    .optional()
+    .describe("Task priority (default: medium)"),
   blocked_by: z
     .array(z.string())
     .optional()
@@ -21,7 +31,8 @@ const outputSchema = z.object({
 
 export const createTaskTool = {
   name: "create_task",
-  description: "Create a new task to be worked on later.",
+  description:
+    "Create a new task. Include as much context as possible in the description so the agent picking it up can start immediately without redundant lookups.",
   group: "task",
   inputSchema,
   outputSchema,

--- a/src/tools/task/update.ts
+++ b/src/tools/task/update.ts
@@ -1,0 +1,76 @@
+import { z } from "zod";
+import { getTask, TASK_PRIORITIES, updateTask } from "../../db/tasks.ts";
+import { logger } from "../../utils/logger.ts";
+import type { ToolDefinition } from "../tool.ts";
+
+const inputSchema = z.object({
+  id: z.string().describe("ID of the task to update"),
+  name: z.string().optional().describe("Updated task name"),
+  description: z.string().optional().describe("Updated task description"),
+  priority: z.enum(TASK_PRIORITIES).optional().describe("Updated priority"),
+  blocked_by: z
+    .array(z.string())
+    .optional()
+    .describe("Replacement list of task IDs that must complete first"),
+});
+
+const outputSchema = z.object({
+  task: z
+    .object({
+      id: z.string(),
+      name: z.string(),
+      description: z.string(),
+      status: z.string(),
+      priority: z.string(),
+      blocked_by: z.array(z.string()),
+      updated_at: z.string(),
+    })
+    .nullable(),
+  message: z.string(),
+});
+
+export const updateTaskTool = {
+  name: "update_task",
+  description:
+    "Update a pending task's name, description, priority, or dependencies. Only pending tasks can be updated.",
+  group: "task",
+  inputSchema,
+  outputSchema,
+  execute: async (input, ctx) => {
+    const existing = await getTask(ctx.conn, input.id);
+    if (!existing) {
+      return { task: null, message: `Task ${input.id} not found` };
+    }
+    if (existing.status !== "pending") {
+      return {
+        task: null,
+        message: `Cannot update task ${input.id}: only pending tasks can be updated (current status: ${existing.status})`,
+      };
+    }
+
+    const updated = await updateTask(ctx.conn, input.id, {
+      name: input.name,
+      description: input.description,
+      priority: input.priority,
+      blocked_by: input.blocked_by,
+    });
+
+    if (!updated) {
+      return { task: null, message: `Failed to update task ${input.id}` };
+    }
+
+    logger.info(`Updated task: ${updated.name} (${updated.id})`);
+    return {
+      task: {
+        id: updated.id,
+        name: updated.name,
+        description: updated.description,
+        status: updated.status,
+        priority: updated.priority,
+        blocked_by: updated.blocked_by,
+        updated_at: updated.updated_at.toISOString(),
+      },
+      message: `Updated task "${updated.name}"`,
+    };
+  },
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/test/daemon/prompt.test.ts
+++ b/test/daemon/prompt.test.ts
@@ -47,7 +47,7 @@ describe("buildSystemPrompt", () => {
   test("includes instructions section", async () => {
     const prompt = await buildSystemPrompt(projectDir);
     expect(prompt).toContain("## Instructions");
-    expect(prompt).toContain("Botholomew daemon");
+    expect(prompt).toContain("Botholomew");
     expect(prompt).toContain("complete_task");
     expect(prompt).toContain("fail_task");
     expect(prompt).toContain("wait_task");

--- a/test/tools/task.test.ts
+++ b/test/tools/task.test.ts
@@ -1,15 +1,19 @@
 import { beforeEach, describe, expect, test } from "bun:test";
+import type { DbConnection } from "../../src/db/connection.ts";
+import { updateTaskStatus } from "../../src/db/tasks.ts";
 import { completeTaskTool } from "../../src/tools/task/complete.ts";
 import { createTaskTool } from "../../src/tools/task/create.ts";
 import { failTaskTool } from "../../src/tools/task/fail.ts";
+import { updateTaskTool } from "../../src/tools/task/update.ts";
 import { waitTaskTool } from "../../src/tools/task/wait.ts";
 import type { ToolContext } from "../../src/tools/tool.ts";
 import { setupToolContext } from "../helpers.ts";
 
 let ctx: ToolContext;
+let conn: DbConnection;
 
 beforeEach(() => {
-  ({ ctx } = setupToolContext());
+  ({ ctx, conn } = setupToolContext());
 });
 
 // ── create_task ─────────────────────────────────────────────
@@ -53,6 +57,74 @@ describe("create_task", () => {
   test("validates input schema rejects invalid priority", () => {
     const result = createTaskTool.inputSchema.safeParse({
       name: "test",
+      priority: "urgent",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ── update_task ────────────────────────────────────────────
+
+describe("update_task", () => {
+  test("updates name of a pending task", async () => {
+    const created = await createTaskTool.execute({ name: "Original" }, ctx);
+    const result = await updateTaskTool.execute(
+      { id: created.id, name: "Renamed" },
+      ctx,
+    );
+    expect(result.task).not.toBeNull();
+    expect(result.task?.name).toBe("Renamed");
+    expect(result.message).toContain("Renamed");
+  });
+
+  test("updates description and priority together", async () => {
+    const created = await createTaskTool.execute({ name: "Task" }, ctx);
+    const result = await updateTaskTool.execute(
+      { id: created.id, description: "New desc", priority: "high" },
+      ctx,
+    );
+    expect(result.task?.description).toBe("New desc");
+    expect(result.task?.priority).toBe("high");
+  });
+
+  test("updates blocked_by", async () => {
+    const a = await createTaskTool.execute({ name: "A" }, ctx);
+    const b = await createTaskTool.execute({ name: "B" }, ctx);
+    const result = await updateTaskTool.execute(
+      { id: b.id, blocked_by: [a.id] },
+      ctx,
+    );
+    expect(result.task?.blocked_by).toEqual([a.id]);
+  });
+
+  test("rejects update of non-pending task", async () => {
+    const created = await createTaskTool.execute({ name: "Task" }, ctx);
+    await updateTaskStatus(conn, created.id, "in_progress");
+    const result = await updateTaskTool.execute(
+      { id: created.id, name: "Nope" },
+      ctx,
+    );
+    expect(result.task).toBeNull();
+    expect(result.message).toContain("only pending");
+  });
+
+  test("returns error for non-existent task", async () => {
+    const result = await updateTaskTool.execute(
+      { id: "nonexistent", name: "Nope" },
+      ctx,
+    );
+    expect(result.task).toBeNull();
+    expect(result.message).toContain("not found");
+  });
+
+  test("validates input schema rejects missing id", () => {
+    const result = updateTaskTool.inputSchema.safeParse({ name: "test" });
+    expect(result.success).toBe(false);
+  });
+
+  test("validates input schema rejects invalid priority", () => {
+    const result = updateTaskTool.inputSchema.safeParse({
+      id: "abc",
       priority: "urgent",
     });
     expect(result.success).toBe(false);


### PR DESCRIPTION
## Summary
- **New `update_task` tool**: Agents can now update name, description, priority, and dependencies on pending tasks, with a guard preventing modifications to non-pending tasks.
- **Enriched `create_task` descriptions**: Tool and field descriptions now encourage agents to include file paths, context, and constraints so the next agent can start immediately without redundant lookups.
- **Concise agent prompts**: Collapsed verbose system prompt instructions into a single sentence and removed duplicated instructions from the user message template.

## Test plan
- [x] All 384 existing tests pass
- [x] 7 new tests for `update_task` (update fields, blocked_by, reject non-pending, reject missing, schema validation)
- [x] `bun run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)