### PR TITLE
Show large result indicator in chat and tool explorer

### DIFF
--- a/src/chat/agent.ts
+++ b/src/chat/agent.ts
@@ -79,10 +79,14 @@ export async function buildChatSystemPrompt(
   return parts.join("\n");
 }
 
+export interface ToolEndMeta {
+  largeResult?: { id: string; chars: number; pages: number };
+}
+
 export interface ChatTurnCallbacks {
   onToken: (text: string) => void;
   onToolStart: (name: string, input: string) => void;
-  onToolEnd: (name: string, output: string) => void;
+  onToolEnd: (name: string, output: string, meta?: ToolEndMeta) => void;
 }
 
 /**
@@ -183,14 +187,18 @@ export async function runChatTurn(input: {
         const start = Date.now();
         const result = await executeChatToolCall(toolUse, toolCtx);
         const durationMs = Date.now() - start;
-        callbacks.onToolEnd(toolUse.name, result);
-        return { toolUse, result, durationMs };
+        const stored = maybeStoreResult(toolUse.name, result);
+        const meta: ToolEndMeta | undefined = stored.stored
+          ? { largeResult: stored.stored }
+          : undefined;
+        callbacks.onToolEnd(toolUse.name, result, meta);
+        return { toolUse, result, durationMs, stored };
       }),
     );
 
     // Log results and collect tool_result messages
     const toolResults: ToolResultBlockParam[] = [];
-    for (const { toolUse, result, durationMs } of execResults) {
+    for (const { toolUse, result, durationMs, stored } of execResults) {
       await logInteraction(conn, threadId, {
         role: "tool",
         kind: "tool_result",
@@ -202,7 +210,7 @@ export async function runChatTurn(input: {
       toolResults.push({
         type: "tool_result",
         tool_use_id: toolUse.id,
-        content: maybeStoreResult(toolUse.name, result),
+        content: stored.text,
       });
     }
 

--- a/src/daemon/large-results.ts
+++ b/src/daemon/large-results.ts
@@ -71,15 +71,27 @@ export function buildResultStub(
   ].join("\n");
 }
 
+export interface MaybeStoreResultOutput {
+  text: string;
+  stored?: { id: string; chars: number; pages: number };
+}
+
 /**
  * If the tool output exceeds MAX_INLINE_CHARS, store it and return a stub.
  * Otherwise return the original output unchanged.
  */
-export function maybeStoreResult(toolName: string, output: string): string {
-  if (output.length <= MAX_INLINE_CHARS) return output;
+export function maybeStoreResult(
+  toolName: string,
+  output: string,
+): MaybeStoreResultOutput {
+  if (output.length <= MAX_INLINE_CHARS) return { text: output };
 
   const id = storeLargeResult(toolName, output);
-  return buildResultStub(id, toolName, output);
+  const pages = Math.ceil(output.length / PAGE_SIZE_CHARS);
+  return {
+    text: buildResultStub(id, toolName, output),
+    stored: { id, chars: output.length, pages },
+  };
 }
 
 /** Clear all stored results (useful between agent loop runs or for cleanup) */

--- a/src/daemon/llm.ts
+++ b/src/daemon/llm.ts
@@ -148,7 +148,7 @@ export async function runAgentLoop(input: {
       toolResults.push({
         type: "tool_result",
         tool_use_id: toolUse.id,
-        content: maybeStoreResult(toolUse.name, result.output),
+        content: maybeStoreResult(toolUse.name, result.output).text,
       });
     }
 

--- a/src/tools/task/update.ts
+++ b/src/tools/task/update.ts
@@ -27,6 +27,7 @@ const outputSchema = z.object({
     })
     .nullable(),
   message: z.string(),
+  is_error: z.boolean(),
 });
 
 export const updateTaskTool = {
@@ -39,12 +40,17 @@ export const updateTaskTool = {
   execute: async (input, ctx) => {
     const existing = await getTask(ctx.conn, input.id);
     if (!existing) {
-      return { task: null, message: `Task ${input.id} not found` };
+      return {
+        task: null,
+        message: `Task ${input.id} not found`,
+        is_error: true,
+      };
     }
     if (existing.status !== "pending") {
       return {
         task: null,
         message: `Cannot update task ${input.id}: only pending tasks can be updated (current status: ${existing.status})`,
+        is_error: true,
       };
     }
 
@@ -56,7 +62,11 @@ export const updateTaskTool = {
     });
 
     if (!updated) {
-      return { task: null, message: `Failed to update task ${input.id}` };
+      return {
+        task: null,
+        message: `Failed to update task ${input.id}`,
+        is_error: true,
+      };
     }
 
     logger.info(`Updated task: ${updated.name} (${updated.id})`);
@@ -71,6 +81,7 @@ export const updateTaskTool = {
         updated_at: updated.updated_at.toISOString(),
       },
       message: `Updated task "${updated.name}"`,
+      is_error: false,
     };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -6,6 +6,7 @@ import {
   sendMessage,
   startChatSession,
 } from "../chat/session.ts";
+import { MAX_INLINE_CHARS, PAGE_SIZE_CHARS } from "../daemon/large-results.ts";
 import type { Interaction } from "../db/threads.ts";
 import { getThread } from "../db/threads.ts";
 import { ContextPanel } from "./components/ContextPanel.tsx";
@@ -49,6 +50,13 @@ function restoreMessagesFromInteractions(
       const tc = pendingTools.find((t) => t.name === ix.tool_name && !t.output);
       if (tc) {
         tc.output = ix.content;
+        if (ix.content.length > MAX_INLINE_CHARS) {
+          tc.largeResult = {
+            id: "(restored)",
+            chars: ix.content.length,
+            pages: Math.ceil(ix.content.length / PAGE_SIZE_CHARS),
+          };
+        }
       }
     } else if (ix.kind === "message" && ix.role === "user") {
       result.push({
@@ -287,13 +295,16 @@ export function App({
             pendingToolCalls.push(tc);
             setActiveToolCalls([...pendingToolCalls]);
           },
-          onToolEnd: (name, output) => {
+          onToolEnd: (name, output, meta) => {
             const tc = pendingToolCalls.find(
               (t) => t.name === name && t.running,
             );
             if (tc) {
               tc.running = false;
               tc.output = output;
+              if (meta?.largeResult) {
+                tc.largeResult = meta.largeResult;
+              }
             }
             setActiveToolCalls([...pendingToolCalls]);
           },

--- a/src/tui/components/ToolCall.tsx
+++ b/src/tui/components/ToolCall.tsx
@@ -24,12 +24,19 @@ export function resolveToolDisplay(
   }
 }
 
+export interface LargeResultMeta {
+  id: string;
+  chars: number;
+  pages: number;
+}
+
 export interface ToolCallData {
   name: string;
   input: string;
   output?: string;
   running: boolean;
   timestamp: Date;
+  largeResult?: LargeResultMeta;
 }
 
 interface ToolCallProps {
@@ -61,6 +68,13 @@ export function ToolCall({ tool }: ToolCallProps) {
         <Text dimColor wrap="truncate-end">
           {"    → "}
           {truncatedOutput}
+        </Text>
+      )}
+      {tool.largeResult && !tool.running && (
+        <Text color="yellow" wrap="truncate-end">
+          {"    ⚡ "}
+          Paginated for LLM [{Math.round(tool.largeResult.chars / 1000)}K,{" "}
+          {tool.largeResult.pages}pg]
         </Text>
       )}
     </Box>

--- a/src/tui/components/ToolPanel.tsx
+++ b/src/tui/components/ToolPanel.tsx
@@ -104,6 +104,11 @@ function buildDetailAnsi(tool: ToolCallData): string {
 
   if (tool.output) {
     lines.push(`${BOLD}${BLUE}Output${RESET}`);
+    if (tool.largeResult) {
+      lines.push(
+        `${YELLOW}Paginated for LLM: ${tool.largeResult.chars.toLocaleString()} chars, ${tool.largeResult.pages} page(s) — stored as ${tool.largeResult.id}${RESET}`,
+      );
+    }
     lines.push(colorizeJson(tool.output));
   } else if (!tool.running) {
     lines.push(`${BOLD}${BLUE}Output${RESET}`);

--- a/test/daemon/large-results.test.ts
+++ b/test/daemon/large-results.test.ts
@@ -53,35 +53,43 @@ describe("large-results store", () => {
   describe("maybeStoreResult", () => {
     it("returns small results unchanged", () => {
       const small = "x".repeat(100);
-      expect(maybeStoreResult("test_tool", small)).toBe(small);
+      const result = maybeStoreResult("test_tool", small);
+      expect(result.text).toBe(small);
+      expect(result.stored).toBeUndefined();
     });
 
     it("returns results at exactly MAX_INLINE_CHARS unchanged", () => {
       const exact = "x".repeat(MAX_INLINE_CHARS);
-      expect(maybeStoreResult("test_tool", exact)).toBe(exact);
+      const result = maybeStoreResult("test_tool", exact);
+      expect(result.text).toBe(exact);
+      expect(result.stored).toBeUndefined();
     });
 
     it("stores results exceeding MAX_INLINE_CHARS and returns a stub", () => {
       const big = "x".repeat(MAX_INLINE_CHARS + 1);
       const result = maybeStoreResult("my_tool", big);
 
-      expect(result).toContain("[Large result from my_tool");
-      expect(result).toContain("read_large_result");
-      expect(result.length).toBeLessThan(big.length);
+      expect(result.text).toContain("[Large result from my_tool");
+      expect(result.text).toContain("read_large_result");
+      expect(result.text.length).toBeLessThan(big.length);
+      expect(result.stored).toBeDefined();
+      expect(result.stored?.chars).toBe(big.length);
+      expect(result.stored?.pages).toBeGreaterThan(0);
+      expect(result.stored?.id).toMatch(/^lr_\d+$/);
     });
 
     it("stub includes a preview of the content", () => {
       const big = `HELLO_PREFIX${"x".repeat(MAX_INLINE_CHARS)}`;
       const result = maybeStoreResult("my_tool", big);
-      expect(result).toContain("HELLO_PREFIX");
+      expect(result.text).toContain("HELLO_PREFIX");
     });
 
     it("stored result is readable via readLargeResultPage", () => {
       const big = "abcdef".repeat(5000);
-      const stub = maybeStoreResult("my_tool", big);
+      const result = maybeStoreResult("my_tool", big);
 
       // Extract the id from the stub
-      const match = stub.match(/lr_\d+/);
+      const match = result.text.match(/lr_\d+/);
       expect(match).not.toBeNull();
       const id = match?.[0] ?? "";
 


### PR DESCRIPTION
When a tool output exceeds 10K chars and gets paginated via LargeResults, the chat message list and tool explorer panel now display a visible indicator. The chat inline view shows a yellow `⚡ Paginated for LLM [45K, 6pg]` line, while the tool panel detail view shows the char count, page count, and storage ID above the full output. Session restoration from the database also detects and displays the indicator by checking content length against the threshold.

- `maybeStoreResult` returns structured `{ text, stored? }` metadata instead of a plain string
- `onToolEnd` callback carries optional `ToolEndMeta` with large result info
- `ToolCallData` gains a `largeResult` field rendered in both ToolCall and ToolPanel components