### PR TITLE
Add delete task action to TUI task viewer

### DIFF
--- a/src/tui/components/TaskPanel.tsx
+++ b/src/tui/components/TaskPanel.tsx
@@ -2,6 +2,7 @@ import { Box, Text, useInput, useStdout } from "ink";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { DbConnection } from "../../db/connection.ts";
 import {
+  deleteTask,
   listTasks,
   TASK_PRIORITIES,
   TASK_STATUSES,
@@ -270,6 +271,12 @@ export function TaskPanel({ conn, isActive }: TaskPanelProps) {
         setPriorityFilter((f) => cycleFilter(f, TASK_PRIORITIES));
         return;
       }
+      if (input === "d" && selectedTask) {
+        deleteTask(conn, selectedTask.id).then(() => {
+          forceRefresh();
+        });
+        return;
+      }
       if (input === "r") {
         forceRefresh();
         return;
@@ -386,8 +393,8 @@ export function TaskPanel({ conn, isActive }: TaskPanelProps) {
         {detailLines.length > visibleRows && (
           <Box>
             <Text dimColor>
-              f filter · p priority · ↑↓ select · j/k scroll · r refresh · [
-              {detailScroll + 1}–
+              f filter · p priority · ↑↓ select · j/k scroll · d delete · r
+              refresh · [{detailScroll + 1}–
               {Math.min(detailScroll + visibleRows, detailLines.length)} of{" "}
               {detailLines.length}]
             </Text>
@@ -395,7 +402,9 @@ export function TaskPanel({ conn, isActive }: TaskPanelProps) {
         )}
         {detailLines.length <= visibleRows && <Box flexGrow={1} />}
         {detailLines.length <= visibleRows && (
-          <Text dimColor>f filter · p priority · ↑↓ select · r refresh</Text>
+          <Text dimColor>
+            f filter · p priority · ↑↓ select · d delete · r refresh
+          </Text>
         )}
       </Box>
     </Box>

--- a/test/db/tasks.test.ts
+++ b/test/db/tasks.test.ts
@@ -3,6 +3,7 @@ import type { DbConnection } from "../../src/db/connection.ts";
 import {
   claimNextTask,
   createTask,
+  deleteTask,
   getTask,
   listTasks,
   updateTaskStatus,
@@ -68,6 +69,20 @@ describe("task CRUD", () => {
   test("get nonexistent task returns null", async () => {
     const task = await getTask(conn, "nonexistent-id");
     expect(task).toBeNull();
+  });
+
+  test("delete a task", async () => {
+    const task = await createTask(conn, { name: "To delete" });
+    const deleted = await deleteTask(conn, task.id);
+    expect(deleted).toBe(true);
+
+    const fetched = await getTask(conn, task.id);
+    expect(fetched).toBeNull();
+  });
+
+  test("delete nonexistent task returns false", async () => {
+    const deleted = await deleteTask(conn, "nonexistent-id");
+    expect(deleted).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds `d` key binding in the TUI Tasks tab to delete the currently selected task
- Wires the existing `deleteTask()` DB function into the TaskPanel component
- Updates help text in both scrollable and non-scrollable footers
- Adds tests for `deleteTask` (success and nonexistent ID cases)

## Test plan
- [x] `bun run lint` passes
- [x] `bun test` passes (386 tests, including 2 new delete tests)
- [ ] Manual: run TUI, navigate to Tasks tab, select a task, press `d` to delete

🤖 Generated with [Claude Code](https://claude.com/claude-code)