### PR TITLE
Show thinking spinner between tool turns

### DIFF
--- a/src/tui/components/MessageList.tsx
+++ b/src/tui/components/MessageList.tsx
@@ -223,7 +223,8 @@ export function MessageList({
       {isAtBottom &&
         isLoading &&
         !streamingText &&
-        activeToolCalls.length === 0 && (
+        (activeToolCalls.length === 0 ||
+          activeToolCalls.every((tc) => !tc.running)) && (
           <Box marginTop={1}>
             <Text color={theme.accent}>
               <Spinner type="dots" />


### PR DESCRIPTION
## Summary
- The "Thinking..." spinner in the chat TUI was only shown when `activeToolCalls` was empty. After tools completed but before the next streaming response began, no loading indicator appeared.
- Now the spinner also shows when all tool calls have `running: false`, closing the feedback gap between tool completion and the next LLM turn.

## Test plan
- [x] `bun run lint` passes
- [x] `bun test` passes (384 tests)
- [ ] Manual: send a message that triggers tool calls, verify spinner appears after tools complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)