### PR TITLE
Fix dark mode detection for Ghostty terminal

### DIFF
--- a/src/tui/theme.ts
+++ b/src/tui/theme.ts
@@ -29,8 +29,11 @@ function detectDarkBackground(): boolean {
         ["read", "-g", "AppleInterfaceStyle"],
         { encoding: "utf-8", timeout: 500 },
       );
-      // Returns "Dark" in dark mode; exits non-zero in light mode
-      return result.stdout?.trim() === "Dark";
+      // Returns "Dark" in dark mode, "Light" or exit 1 in light mode
+      // Only trust the result if the command succeeded (status 0)
+      if (result.status === 0) {
+        return result.stdout?.trim() === "Dark";
+      }
     } catch {
       // fall through to default
     }
@@ -44,7 +47,7 @@ const isDark = detectDarkBackground();
 export const theme = {
   accent: isDark ? "yellow" : "#B8860B",
   accentBorder: isDark ? "yellow" : "#B8860B",
-  userBg: isDark ? "#2a4a6c" : "#d0e0f0",
+  userBg: isDark ? "#2a5a8c" : "#d0e0f0",
   selectionBg: isDark ? "#333" : "#ddd",
   success: "green",
   error: "red",

--- a/test/tui/theme.test.ts
+++ b/test/tui/theme.test.ts
@@ -78,7 +78,8 @@ describe("theme", () => {
       ["read", "-g", "AppleInterfaceStyle"],
       { encoding: "utf-8", timeout: 500 },
     );
-    const systemIsDark = result.stdout?.trim() === "Dark";
+    const systemIsDark =
+      result.status === 0 ? result.stdout?.trim() === "Dark" : true;
 
     const { detectDarkBackground } = loadTheme();
     expect(detectDarkBackground()).toBe(systemIsDark);
@@ -90,7 +91,7 @@ describe("theme", () => {
     process.env.COLORFGBG = "15;0"; // force dark
     const { theme } = loadTheme();
     expect(theme.accent).toBe("yellow");
-    expect(theme.userBg).toBe("#2a4a6c");
+    expect(theme.userBg).toBe("#2a5a8c");
     expect(theme.selectionBg).toBe("#333");
   });
 


### PR DESCRIPTION
## Summary
- Fix `detectDarkBackground()` to only trust macOS `defaults read` when it exits successfully (status 0). Previously, when `AppleInterfaceStyle` didn't exist (common with Ghostty), the non-zero exit was treated as "light mode" instead of falling through to the dark default.
- Lighten the dark-mode user message background from `#2a4a6c` to `#2a5a8c` for better readability.

## Test plan
- [x] `bun run lint` passes
- [x] `bun test` passes (384 tests, 0 failures)
- [ ] Visually confirm user messages are readable in Ghostty dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)