### PR TITLE
Add Threads tab to TUI and consolidate ANSI theme constants

### DIFF
--- a/src/db/threads.ts
+++ b/src/db/threads.ts
@@ -175,6 +175,15 @@ export async function getThread(
   };
 }
 
+export async function deleteThread(
+  db: DbConnection,
+  threadId: string,
+): Promise<boolean> {
+  db.query("DELETE FROM interactions WHERE thread_id = ?1").run(threadId);
+  const result = db.query("DELETE FROM threads WHERE id = ?1").run(threadId);
+  return result.changes > 0;
+}
+
 export async function listThreads(
   db: DbConnection,
   filters?: {

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -19,8 +19,10 @@ import { QueuePanel } from "./components/QueuePanel.tsx";
 import { StatusBar } from "./components/StatusBar.tsx";
 import { TabBar, type TabId } from "./components/TabBar.tsx";
 import { TaskPanel } from "./components/TaskPanel.tsx";
+import { ThreadPanel } from "./components/ThreadPanel.tsx";
 import type { ToolCallData } from "./components/ToolCall.tsx";
 import { ToolPanel } from "./components/ToolPanel.tsx";
+import { ansi } from "./theme.ts";
 
 interface AppProps {
   projectDir: string;
@@ -178,7 +180,7 @@ export function App({
         const threadId = sessionRef.current.threadId;
         endChatSession(sessionRef.current);
         process.stderr.write(
-          `\nThread: ${threadId}\nResume with: \x1b[32mbotholomew chat --thread-id ${threadId}\x1b[0m\n`,
+          `\nThread: ${threadId}\nResume with: ${ansi.success}botholomew chat --thread-id ${threadId}${ansi.reset}\n`,
         );
       }
     };
@@ -202,7 +204,7 @@ export function App({
 
     // Tab key cycles tabs — always active (InputBar ignores tab)
     if (key.tab && !key.shift) {
-      setActiveTab((t) => ((t % 5) + 1) as TabId);
+      setActiveTab((t) => ((t % 6) + 1) as TabId);
       return;
     }
 
@@ -236,7 +238,7 @@ export function App({
     if (activeTab !== 1) {
       // Number keys jump to tab on non-chat tabs
       const num = Number.parseInt(input, 10);
-      if (num >= 1 && num <= 5) {
+      if (num >= 1 && num <= 6) {
         setActiveTab(num as TabId);
         return;
       }
@@ -369,7 +371,7 @@ export function App({
           content: [
             "Navigation:",
             "  Tab            Cycle between panels",
-            "  1-5            Jump to panel (when not in Chat)",
+            "  1-6            Jump to panel (when not in Chat)",
             "  Escape         Return to Chat",
             "",
             "Chat (Tab 1):",
@@ -397,6 +399,14 @@ export function App({
             "  f              Cycle status filter",
             "  p              Cycle priority filter",
             "  r              Refresh tasks",
+            "",
+            "Threads (Tab 5):",
+            "  ↑/↓            Navigate thread list",
+            "  Shift+↑/↓      Scroll detail pane",
+            "  j/k            Scroll detail pane",
+            "  f              Cycle type filter",
+            "  d              Delete thread (with confirmation)",
+            "  r              Refresh threads",
             "",
             "Commands:",
             "  /help           Show this help",
@@ -474,6 +484,13 @@ export function App({
       )}
       {activeTab === 4 && <TaskPanel conn={conn} isActive={activeTab === 4} />}
       {activeTab === 5 && (
+        <ThreadPanel
+          conn={conn}
+          activeThreadId={threadId}
+          isActive={activeTab === 5}
+        />
+      )}
+      {activeTab === 6 && (
         <HelpPanel
           projectDir={projectDir}
           threadId={threadId}

--- a/src/tui/components/HelpPanel.tsx
+++ b/src/tui/components/HelpPanel.tsx
@@ -21,7 +21,7 @@ export function HelpPanel({
           {"  "}Tab{"            "}Cycle between tabs
         </Text>
         <Text>
-          {"  "}1-5{"            "}Jump to tab (non-chat tabs)
+          {"  "}1-6{"            "}Jump to tab (non-chat tabs)
         </Text>
         <Text>
           {"  "}Escape{"         "}Return to Chat tab
@@ -100,6 +100,30 @@ export function HelpPanel({
         </Text>
         <Text>
           {"  "}r{"              "}Refresh tasks
+        </Text>
+      </Box>
+
+      <Box marginTop={1} flexDirection="column">
+        <Text bold color="cyan">
+          Threads (Tab 5)
+        </Text>
+        <Text>
+          {"  "}↑/↓{"            "}Navigate thread list
+        </Text>
+        <Text>
+          {"  "}Shift+↑/↓{"      "}Scroll detail pane
+        </Text>
+        <Text>
+          {"  "}j / k{"          "}Scroll detail pane
+        </Text>
+        <Text>
+          {"  "}f{"              "}Cycle type filter
+        </Text>
+        <Text>
+          {"  "}d{"              "}Delete thread (with confirmation)
+        </Text>
+        <Text>
+          {"  "}r{"              "}Refresh threads
         </Text>
       </Box>
 

--- a/src/tui/components/TabBar.tsx
+++ b/src/tui/components/TabBar.tsx
@@ -1,13 +1,14 @@
 import { Box, Text } from "ink";
 
-export type TabId = 1 | 2 | 3 | 4 | 5;
+export type TabId = 1 | 2 | 3 | 4 | 5 | 6;
 
 const TABS: { id: TabId; label: string }[] = [
   { id: 1, label: "Chat" },
   { id: 2, label: "Tools" },
   { id: 3, label: "Context" },
   { id: 4, label: "Tasks" },
-  { id: 5, label: "Help" },
+  { id: 5, label: "Threads" },
+  { id: 6, label: "Help" },
 ];
 
 interface TabBarProps {

--- a/src/tui/components/TaskPanel.tsx
+++ b/src/tui/components/TaskPanel.tsx
@@ -8,7 +8,7 @@ import {
   TASK_STATUSES,
   type Task,
 } from "../../db/tasks.ts";
-import { theme } from "../theme.ts";
+import { ansi, theme } from "../theme.ts";
 
 interface TaskPanelProps {
   conn: DbConnection;
@@ -17,16 +17,6 @@ interface TaskPanelProps {
 
 const SIDEBAR_WIDTH = 42;
 const PAGE_SCROLL_LINES = 10;
-
-// ANSI escape helpers (same as ToolPanel)
-const RESET = "\x1b[0m";
-const BOLD = "\x1b[1m";
-const DIM = "\x1b[2m";
-const CYAN = "\x1b[36m";
-const GREEN = "\x1b[32m";
-const YELLOW = "\x1b[33m";
-const RED = "\x1b[31m";
-const BLUE = "\x1b[34m";
 
 const STATUS_ICONS: Record<Task["status"], string> = {
   pending: "○",
@@ -45,11 +35,11 @@ const STATUS_COLORS: Record<Task["status"], string> = {
 };
 
 const STATUS_ANSI: Record<Task["status"], string> = {
-  pending: DIM,
-  in_progress: YELLOW,
-  waiting: CYAN,
-  failed: RED,
-  complete: GREEN,
+  pending: ansi.muted,
+  in_progress: ansi.accent,
+  waiting: ansi.info,
+  failed: ansi.error,
+  complete: ansi.success,
 };
 
 const PRIORITY_LABELS: Record<Task["priority"], string> = {
@@ -65,29 +55,29 @@ const PRIORITY_COLORS: Record<Task["priority"], string> = {
 };
 
 const PRIORITY_ANSI: Record<Task["priority"], string> = {
-  high: RED,
-  medium: YELLOW,
-  low: DIM,
+  high: ansi.error,
+  medium: ansi.accent,
+  low: ansi.muted,
 };
 
 function buildTaskDetailAnsi(task: Task): string {
   const lines: string[] = [];
 
-  lines.push(`${BOLD}${CYAN}${task.name}${RESET}`);
+  lines.push(`${ansi.bold}${ansi.info}${task.name}${ansi.reset}`);
   lines.push("");
 
   const statusAnsi = STATUS_ANSI[task.status];
   lines.push(
-    `${BOLD}${BLUE}Status${RESET}    ${statusAnsi}${STATUS_ICONS[task.status]} ${task.status}${RESET}`,
+    `${ansi.bold}${ansi.primary}Status${ansi.reset}    ${statusAnsi}${STATUS_ICONS[task.status]} ${task.status}${ansi.reset}`,
   );
 
   const priorityAnsi = PRIORITY_ANSI[task.priority];
   lines.push(
-    `${BOLD}${BLUE}Priority${RESET}  ${priorityAnsi}${task.priority}${RESET}`,
+    `${ansi.bold}${ansi.primary}Priority${ansi.reset}  ${priorityAnsi}${task.priority}${ansi.reset}`,
   );
 
   lines.push(
-    `${BOLD}${BLUE}Claimed${RESET}   ${task.claimed_by ? task.claimed_by : `${DIM}(unclaimed)${RESET}`}`,
+    `${ansi.bold}${ansi.primary}Claimed${ansi.reset}   ${task.claimed_by ? task.claimed_by : `${ansi.dim}(unclaimed)${ansi.reset}`}`,
   );
 
   const created = task.created_at.toLocaleString([], {
@@ -102,34 +92,38 @@ function buildTaskDetailAnsi(task: Task): string {
     hour: "2-digit",
     minute: "2-digit",
   });
-  lines.push(`${BOLD}${BLUE}Created${RESET}   ${DIM}${created}${RESET}`);
-  lines.push(`${BOLD}${BLUE}Updated${RESET}   ${DIM}${updated}${RESET}`);
+  lines.push(
+    `${ansi.bold}${ansi.primary}Created${ansi.reset}   ${ansi.dim}${created}${ansi.reset}`,
+  );
+  lines.push(
+    `${ansi.bold}${ansi.primary}Updated${ansi.reset}   ${ansi.dim}${updated}${ansi.reset}`,
+  );
   lines.push("");
 
   if (task.description) {
-    lines.push(`${BOLD}${BLUE}Description${RESET}`);
+    lines.push(`${ansi.bold}${ansi.primary}Description${ansi.reset}`);
     lines.push(task.description);
     lines.push("");
   }
 
   if (task.status === "waiting" && task.waiting_reason) {
-    lines.push(`${BOLD}${BLUE}Waiting Reason${RESET}`);
-    lines.push(`${YELLOW}${task.waiting_reason}${RESET}`);
+    lines.push(`${ansi.bold}${ansi.primary}Waiting Reason${ansi.reset}`);
+    lines.push(`${ansi.accent}${task.waiting_reason}${ansi.reset}`);
     lines.push("");
   }
 
   if (task.blocked_by.length > 0) {
-    lines.push(`${BOLD}${BLUE}Blocked By${RESET}`);
+    lines.push(`${ansi.bold}${ansi.primary}Blocked By${ansi.reset}`);
     for (const id of task.blocked_by) {
-      lines.push(`  ${DIM}• ${id}${RESET}`);
+      lines.push(`  ${ansi.dim}• ${id}${ansi.reset}`);
     }
     lines.push("");
   }
 
   if (task.context_ids.length > 0) {
-    lines.push(`${BOLD}${BLUE}Context IDs${RESET}`);
+    lines.push(`${ansi.bold}${ansi.primary}Context IDs${ansi.reset}`);
     for (const id of task.context_ids) {
-      lines.push(`  ${DIM}• ${id}${RESET}`);
+      lines.push(`  ${ansi.dim}• ${id}${ansi.reset}`);
     }
   }
 

--- a/src/tui/components/ThreadPanel.tsx
+++ b/src/tui/components/ThreadPanel.tsx
@@ -1,0 +1,491 @@
+import { Box, Text, useInput, useStdout } from "ink";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { DbConnection } from "../../db/connection.ts";
+import {
+  deleteThread,
+  getThread,
+  type Interaction,
+  listThreads,
+  type Thread,
+} from "../../db/threads.ts";
+import { ansi, theme } from "../theme.ts";
+
+interface ThreadPanelProps {
+  conn: DbConnection;
+  activeThreadId: string;
+  isActive: boolean;
+}
+
+const SIDEBAR_WIDTH = 42;
+const PAGE_SCROLL_LINES = 10;
+
+const THREAD_TYPES: readonly Thread["type"][] = [
+  "daemon_tick",
+  "chat_session",
+] as const;
+
+const TYPE_LABELS: Record<Thread["type"], string> = {
+  daemon_tick: "daemon",
+  chat_session: "agent",
+};
+
+const TYPE_ICONS: Record<Thread["type"], string> = {
+  daemon_tick: "⚙",
+  chat_session: "💬",
+};
+
+const TYPE_COLORS: Record<Thread["type"], string> = {
+  daemon_tick: theme.accent,
+  chat_session: theme.info,
+};
+
+const TYPE_ANSI: Record<Thread["type"], string> = {
+  daemon_tick: ansi.accent,
+  chat_session: ansi.info,
+};
+
+const ROLE_ANSI: Record<string, string> = {
+  user: ansi.success,
+  assistant: ansi.info,
+  system: ansi.toolName,
+  tool: ansi.accent,
+};
+
+function formatDuration(start: Date, end: Date | null): string {
+  const endTime = end ?? new Date();
+  const ms = endTime.getTime() - start.getTime();
+  if (ms < 1000) return `${ms}ms`;
+  const secs = Math.floor(ms / 1000);
+  if (secs < 60) return `${secs}s`;
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ${secs % 60}s`;
+  const hrs = Math.floor(mins / 60);
+  return `${hrs}h ${mins % 60}m`;
+}
+
+function formatDate(d: Date): string {
+  return d.toLocaleString([], {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function buildThreadDetailAnsi(
+  thread: Thread,
+  interactions: Interaction[],
+  isActiveThread: boolean,
+): string {
+  const lines: string[] = [];
+
+  lines.push(
+    `${ansi.bold}${ansi.info}${thread.title || "(untitled)"}${ansi.reset}`,
+  );
+  lines.push("");
+
+  const typeAnsi = TYPE_ANSI[thread.type];
+  lines.push(
+    `${ansi.bold}${ansi.primary}Type${ansi.reset}      ${typeAnsi}${TYPE_ICONS[thread.type]} ${TYPE_LABELS[thread.type]}${ansi.reset}`,
+  );
+
+  if (thread.task_id) {
+    lines.push(
+      `${ansi.bold}${ansi.primary}Task${ansi.reset}      ${ansi.dim}${thread.task_id}${ansi.reset}`,
+    );
+  }
+
+  lines.push(
+    `${ansi.bold}${ansi.primary}Started${ansi.reset}   ${ansi.dim}${formatDate(thread.started_at)}${ansi.reset}`,
+  );
+  lines.push(
+    `${ansi.bold}${ansi.primary}Ended${ansi.reset}     ${thread.ended_at ? `${ansi.dim}${formatDate(thread.ended_at)}${ansi.reset}` : `${ansi.success}ongoing${ansi.reset}`}`,
+  );
+  lines.push(
+    `${ansi.bold}${ansi.primary}Duration${ansi.reset}  ${ansi.dim}${formatDuration(thread.started_at, thread.ended_at)}${ansi.reset}`,
+  );
+
+  if (isActiveThread) {
+    lines.push("");
+    lines.push(
+      `${ansi.bold}${ansi.success}★ Current session thread${ansi.reset}`,
+    );
+  }
+
+  lines.push("");
+  lines.push(
+    `${ansi.bold}${ansi.primary}Interactions${ansi.reset}  ${interactions.length} total`,
+  );
+
+  // Breakdown by role
+  const byRole: Record<string, number> = {};
+  const byKind: Record<string, number> = {};
+  for (const ix of interactions) {
+    byRole[ix.role] = (byRole[ix.role] ?? 0) + 1;
+    byKind[ix.kind] = (byKind[ix.kind] ?? 0) + 1;
+  }
+
+  const roleSummary = Object.entries(byRole)
+    .map(
+      ([role, count]) =>
+        `${ROLE_ANSI[role] ?? ansi.dim}${role}${ansi.reset}: ${count}`,
+    )
+    .join("  ");
+  if (roleSummary) {
+    lines.push(`  ${roleSummary}`);
+  }
+
+  const kindSummary = Object.entries(byKind)
+    .map(([kind, count]) => `${ansi.dim}${kind}${ansi.reset}: ${count}`)
+    .join("  ");
+  if (kindSummary) {
+    lines.push(`  ${kindSummary}`);
+  }
+
+  // Condensed interaction timeline
+  if (interactions.length > 0) {
+    lines.push("");
+    lines.push(`${ansi.bold}${ansi.primary}Timeline${ansi.reset}`);
+    for (const ix of interactions) {
+      const roleColor = ROLE_ANSI[ix.role] ?? ansi.dim;
+      const time = ix.created_at.toLocaleTimeString([], {
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+      });
+      const preview =
+        ix.content.length > 60 ? `${ix.content.slice(0, 57)}...` : ix.content;
+      const firstLine = preview.split("\n")[0] ?? "";
+      const toolTag = ix.tool_name
+        ? ` ${ansi.toolName}[${ix.tool_name}]${ansi.reset}`
+        : "";
+      lines.push(
+        `  ${ansi.dim}${String(ix.sequence).padStart(3)}${ansi.reset} ${roleColor}${ix.role}${ansi.reset} ${ansi.dim}${ix.kind}${ansi.reset}${toolTag} ${ansi.dim}${time}${ansi.reset}`,
+      );
+      if (firstLine) {
+        lines.push(`      ${ansi.dim}${firstLine}${ansi.reset}`);
+      }
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function cycleFilter<T>(current: T | null, values: readonly T[]): T | null {
+  if (current === null) return values[0] ?? null;
+  const idx = values.indexOf(current);
+  if (idx === -1 || idx === values.length - 1) return null;
+  return values[idx + 1] ?? null;
+}
+
+export function ThreadPanel({
+  conn,
+  activeThreadId,
+  isActive,
+}: ThreadPanelProps) {
+  const { stdout } = useStdout();
+  const termRows = stdout?.rows ?? 24;
+  const [threads, setThreads] = useState<Thread[]>([]);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [detailScroll, setDetailScroll] = useState(0);
+  const [typeFilter, setTypeFilter] = useState<Thread["type"] | null>(null);
+  const [refreshTick, setRefreshTick] = useState(0);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [selectedDetail, setSelectedDetail] = useState<{
+    thread: Thread;
+    interactions: Interaction[];
+  } | null>(null);
+
+  // Fetch thread list
+  // biome-ignore lint/correctness/useExhaustiveDependencies: refreshTick triggers manual refresh
+  useEffect(() => {
+    let mounted = true;
+
+    const refresh = async () => {
+      const filters: { type?: Thread["type"] } = {};
+      if (typeFilter) filters.type = typeFilter;
+      const result = await listThreads(conn, filters);
+      if (mounted) {
+        setThreads(result);
+        setSelectedIndex((prev) =>
+          Math.min(prev, Math.max(0, result.length - 1)),
+        );
+      }
+    };
+
+    refresh();
+    const interval = setInterval(refresh, 5000);
+    return () => {
+      mounted = false;
+      clearInterval(interval);
+    };
+  }, [conn, typeFilter, refreshTick]);
+
+  // Fetch detail for selected thread
+  const selectedThread = threads[selectedIndex];
+  // biome-ignore lint/correctness/useExhaustiveDependencies: selectedThread?.id is the intentional trigger
+  useEffect(() => {
+    let mounted = true;
+    if (!selectedThread) {
+      setSelectedDetail(null);
+      return;
+    }
+
+    getThread(conn, selectedThread.id).then((result) => {
+      if (mounted && result) {
+        setSelectedDetail(result);
+      }
+    });
+
+    return () => {
+      mounted = false;
+    };
+  }, [conn, selectedThread?.id]);
+
+  const isActiveSelected = selectedThread?.id === activeThreadId;
+
+  const renderedDetail = useMemo(() => {
+    if (!selectedDetail) return "";
+    return buildThreadDetailAnsi(
+      selectedDetail.thread,
+      selectedDetail.interactions,
+      selectedDetail.thread.id === activeThreadId,
+    );
+  }, [selectedDetail, activeThreadId]);
+
+  const detailLines = useMemo(
+    () => renderedDetail.split("\n"),
+    [renderedDetail],
+  );
+
+  const visibleRows = Math.max(1, termRows - 6);
+  const maxDetailScroll = Math.max(0, detailLines.length - visibleRows);
+  const sidebarScrollOffset = Math.max(
+    0,
+    Math.min(
+      selectedIndex - Math.floor(visibleRows / 2),
+      threads.length - visibleRows,
+    ),
+  );
+
+  // Reset detail scroll when selection changes
+  // biome-ignore lint/correctness/useExhaustiveDependencies: selectedIndex is the intentional trigger
+  useEffect(() => {
+    setDetailScroll(0);
+  }, [selectedIndex]);
+
+  const forceRefresh = useCallback(() => {
+    setRefreshTick((t) => t + 1);
+  }, []);
+
+  useInput(
+    (input, key) => {
+      // Delete confirmation mode
+      if (confirmDelete) {
+        if (input === "y" || input === "d") {
+          if (selectedThread && !isActiveSelected) {
+            deleteThread(conn, selectedThread.id).then(() => {
+              forceRefresh();
+            });
+          }
+          setConfirmDelete(false);
+        } else {
+          setConfirmDelete(false);
+        }
+        return;
+      }
+
+      if (key.upArrow) {
+        if (key.shift) {
+          setDetailScroll((s) => Math.max(0, s - 1));
+        } else {
+          setSelectedIndex((i) => Math.max(0, i - 1));
+        }
+        return;
+      }
+      if (key.downArrow) {
+        if (key.shift) {
+          setDetailScroll((s) => Math.min(maxDetailScroll, s + 1));
+        } else {
+          setSelectedIndex((i) => Math.min(threads.length - 1, i + 1));
+        }
+        return;
+      }
+
+      if (input === "j") {
+        setDetailScroll((s) => Math.min(maxDetailScroll, s + 1));
+        return;
+      }
+      if (input === "k") {
+        setDetailScroll((s) => Math.max(0, s - 1));
+        return;
+      }
+      if (input === "J") {
+        setDetailScroll((s) =>
+          Math.min(maxDetailScroll, s + PAGE_SCROLL_LINES),
+        );
+        return;
+      }
+      if (input === "K") {
+        setDetailScroll((s) => Math.max(0, s - PAGE_SCROLL_LINES));
+        return;
+      }
+      if (input === "g") {
+        setDetailScroll(0);
+        return;
+      }
+      if (input === "G") {
+        setDetailScroll(maxDetailScroll);
+        return;
+      }
+
+      if (input === "f") {
+        setTypeFilter((f) => cycleFilter(f, THREAD_TYPES));
+        return;
+      }
+      if (input === "d" && selectedThread) {
+        if (isActiveSelected) return; // Can't delete active thread
+        setConfirmDelete(true);
+        return;
+      }
+      if (input === "r") {
+        forceRefresh();
+        return;
+      }
+    },
+    { isActive },
+  );
+
+  if (threads.length === 0) {
+    return (
+      <Box flexDirection="column" flexGrow={1} paddingX={1}>
+        <Text dimColor>
+          {typeFilter
+            ? "No threads match the current filter. Press f to change filter."
+            : "No threads found. Threads will appear as chat sessions and daemon ticks occur."}
+        </Text>
+        {typeFilter && (
+          <Box marginTop={1}>
+            <Text color={TYPE_COLORS[typeFilter]}>
+              {TYPE_ICONS[typeFilter]} {TYPE_LABELS[typeFilter]}
+            </Text>
+          </Box>
+        )}
+      </Box>
+    );
+  }
+
+  const sidebarVisible = threads.slice(
+    sidebarScrollOffset,
+    sidebarScrollOffset + visibleRows,
+  );
+
+  const detailVisible = detailLines.slice(
+    detailScroll,
+    detailScroll + visibleRows,
+  );
+
+  return (
+    <Box flexGrow={1} height={visibleRows + 1} overflow="hidden">
+      {/* Left sidebar: thread list */}
+      <Box
+        flexDirection="column"
+        width={SIDEBAR_WIDTH}
+        height={visibleRows + 1}
+        borderStyle="single"
+        borderColor={theme.muted}
+        borderRight
+        borderTop={false}
+        borderBottom={false}
+        borderLeft={false}
+        overflow="hidden"
+      >
+        <Box paddingX={1} gap={1}>
+          <Text bold dimColor>
+            Threads ({threads.length})
+          </Text>
+          {typeFilter && (
+            <Text color={TYPE_COLORS[typeFilter]}>
+              [{TYPE_ICONS[typeFilter]} {TYPE_LABELS[typeFilter]}]
+            </Text>
+          )}
+        </Box>
+        {confirmDelete && selectedThread && (
+          <Box paddingX={1}>
+            <Text color="red" bold>
+              Delete thread? (y/n)
+            </Text>
+          </Box>
+        )}
+        {sidebarVisible.map((thread, vi) => {
+          const i = vi + sidebarScrollOffset;
+          const isSelected = i === selectedIndex;
+          const icon = TYPE_ICONS[thread.type];
+          const isActive = thread.id === activeThreadId;
+          const dateStr = thread.started_at.toLocaleDateString([], {
+            month: "short",
+            day: "numeric",
+          });
+          const maxName = SIDEBAR_WIDTH - 15; // icon + date + padding
+          const title = thread.title || "(untitled)";
+          const nameDisplay =
+            title.length > maxName ? `${title.slice(0, maxName - 1)}…` : title;
+          return (
+            <Box key={thread.id} paddingX={1}>
+              <Text
+                backgroundColor={isSelected ? theme.selectionBg : undefined}
+                bold={isSelected}
+                color={isSelected ? theme.info : undefined}
+                wrap="truncate-end"
+              >
+                {isSelected ? "▸" : " "}{" "}
+                <Text color={TYPE_COLORS[thread.type]} bold={false}>
+                  {icon}
+                </Text>{" "}
+                {nameDisplay}
+                {isActive && (
+                  <Text color={theme.success} bold={false}>
+                    {" "}
+                    ★
+                  </Text>
+                )}
+                <Text dimColor bold={false}>
+                  {" "}
+                  {dateStr}
+                </Text>
+              </Text>
+            </Box>
+          );
+        })}
+      </Box>
+
+      {/* Right detail pane */}
+      <Box
+        flexDirection="column"
+        flexGrow={1}
+        height={visibleRows + 1}
+        paddingX={1}
+        overflow="hidden"
+      >
+        {detailVisible.map((line, i) => {
+          const lineNum = detailScroll + i;
+          return <Text key={lineNum}>{line || " "}</Text>;
+        })}
+        {detailLines.length > visibleRows && (
+          <Box>
+            <Text dimColor>
+              f filter · ↑↓ select · j/k scroll · d delete · r refresh · [
+              {detailScroll + 1}–
+              {Math.min(detailScroll + visibleRows, detailLines.length)} of{" "}
+              {detailLines.length}]
+            </Text>
+          </Box>
+        )}
+        {detailLines.length <= visibleRows && <Box flexGrow={1} />}
+        {detailLines.length <= visibleRows && (
+          <Text dimColor>f filter · ↑↓ select · d delete · r refresh</Text>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/src/tui/components/ToolPanel.tsx
+++ b/src/tui/components/ToolPanel.tsx
@@ -1,6 +1,6 @@
 import { Box, Text, useInput, useStdout } from "ink";
 import { useEffect, useMemo, useState } from "react";
-import { theme } from "../theme.ts";
+import { ansi, theme } from "../theme.ts";
 import { resolveToolDisplay, type ToolCallData } from "./ToolCall.tsx";
 
 interface ToolPanelProps {
@@ -9,17 +9,6 @@ interface ToolPanelProps {
 }
 
 const SIDEBAR_WIDTH = 42;
-
-// ANSI escape helpers
-const RESET = "\x1b[0m";
-const BOLD = "\x1b[1m";
-const DIM = "\x1b[2m";
-const CYAN = "\x1b[36m";
-const GREEN = "\x1b[32m";
-const YELLOW = "\x1b[33m";
-const MAGENTA = "\x1b[35m";
-const BLUE = "\x1b[34m";
-const RED = "\x1b[31m";
 
 /** Try to parse a string as JSON; returns the parsed value or undefined on failure */
 function tryParseJson(str: string): unknown | undefined {
@@ -38,10 +27,10 @@ function colorizeJson(str: string): string {
 }
 
 function colorizeValue(value: unknown, indent: number): string {
-  if (value === null) return `${MAGENTA}null${RESET}`;
+  if (value === null) return `${ansi.toolName}null${ansi.reset}`;
   if (typeof value === "boolean")
-    return `${MAGENTA}${value ? "true" : "false"}${RESET}`;
-  if (typeof value === "number") return `${YELLOW}${value}${RESET}`;
+    return `${ansi.toolName}${value ? "true" : "false"}${ansi.reset}`;
+  if (typeof value === "number") return `${ansi.accent}${value}${ansi.reset}`;
   if (typeof value === "string") {
     // Try to unwrap stringified JSON (common in tool results)
     const inner = tryParseJson(value);
@@ -49,7 +38,7 @@ function colorizeValue(value: unknown, indent: number): string {
       return colorizeValue(inner, indent);
     }
     const escaped = JSON.stringify(value);
-    return `${GREEN}${escaped}${RESET}`;
+    return `${ansi.success}${escaped}${ansi.reset}`;
   }
 
   const pad = "  ".repeat(indent);
@@ -68,7 +57,7 @@ function colorizeValue(value: unknown, indent: number): string {
     if (entries.length === 0) return "{}";
     const lines = entries.map(
       ([k, v]) =>
-        `${innerPad}${CYAN}${JSON.stringify(k)}${RESET}: ${colorizeValue(v, indent + 1)}`,
+        `${innerPad}${ansi.info}${JSON.stringify(k)}${ansi.reset}: ${colorizeValue(v, indent + 1)}`,
     );
     return `{\n${lines.join(",\n")}\n${pad}}`;
   }
@@ -89,36 +78,36 @@ function buildDetailAnsi(tool: ToolCallData): string {
     tool.name,
     tool.input,
   );
-  lines.push(`${BOLD}${CYAN}${displayName}${RESET}`);
+  lines.push(`${ansi.bold}${ansi.info}${displayName}${ansi.reset}`);
   if (tool.name === "mcp_exec") {
-    lines.push(`${DIM}via mcp_exec${RESET}`);
+    lines.push(`${ansi.dim}via mcp_exec${ansi.reset}`);
   }
-  lines.push(`${DIM}Time: ${time}${RESET}`);
+  lines.push(`${ansi.dim}Time: ${time}${ansi.reset}`);
   if (tool.running) {
-    lines.push(`${YELLOW}⟳ running${RESET}`);
+    lines.push(`${ansi.accent}⟳ running${ansi.reset}`);
   }
   lines.push("");
 
-  lines.push(`${BOLD}${BLUE}Input${RESET}`);
+  lines.push(`${ansi.bold}${ansi.primary}Input${ansi.reset}`);
   lines.push(colorizeJson(displayInput));
   lines.push("");
 
   if (tool.output) {
     if (tool.isError) {
-      lines.push(`${BOLD}${RED}Error${RESET}`);
-      lines.push(`${RED}${colorizeJson(tool.output)}${RESET}`);
+      lines.push(`${ansi.bold}${ansi.error}Error${ansi.reset}`);
+      lines.push(`${ansi.error}${colorizeJson(tool.output)}${ansi.reset}`);
     } else {
-      lines.push(`${BOLD}${BLUE}Output${RESET}`);
+      lines.push(`${ansi.bold}${ansi.primary}Output${ansi.reset}`);
       if (tool.largeResult) {
         lines.push(
-          `${YELLOW}Paginated for LLM: ${tool.largeResult.chars.toLocaleString()} chars, ${tool.largeResult.pages} page(s) — stored as ${tool.largeResult.id}${RESET}`,
+          `${ansi.accent}Paginated for LLM: ${tool.largeResult.chars.toLocaleString()} chars, ${tool.largeResult.pages} page(s) — stored as ${tool.largeResult.id}${ansi.reset}`,
         );
       }
       lines.push(colorizeJson(tool.output));
     }
   } else if (!tool.running) {
-    lines.push(`${BOLD}${BLUE}Output${RESET}`);
-    lines.push(`${DIM}(no output)${RESET}`);
+    lines.push(`${ansi.bold}${ansi.primary}Output${ansi.reset}`);
+    lines.push(`${ansi.dim}(no output)${ansi.reset}`);
   }
 
   return lines.join("\n");

--- a/src/tui/theme.ts
+++ b/src/tui/theme.ts
@@ -57,5 +57,19 @@ export const theme = {
   muted: "gray",
 } as const;
 
+/** ANSI escape codes for raw string building (detail panes, etc.) */
+export const ansi = {
+  reset: "\x1b[0m",
+  bold: "\x1b[1m",
+  dim: "\x1b[2m",
+  success: "\x1b[32m",
+  error: "\x1b[31m",
+  info: "\x1b[36m",
+  primary: "\x1b[34m",
+  accent: "\x1b[33m",
+  toolName: "\x1b[35m",
+  muted: "\x1b[2m",
+} as const;
+
 // Exported for testing
 export { detectDarkBackground };

--- a/test/db/threads.test.ts
+++ b/test/db/threads.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test } from "bun:test";
 import type { DbConnection } from "../../src/db/connection.ts";
 import {
   createThread,
+  deleteThread,
   endThread,
   getThread,
   listThreads,
@@ -128,6 +129,52 @@ describe("interaction logging", () => {
     expect(result?.interactions[0]?.content).toBe(
       "What's the user's name? It's O'Brien.",
     );
+  });
+});
+
+describe("deleteThread", () => {
+  test("deletes thread and its interactions", async () => {
+    const threadId = await createThread(
+      conn,
+      "chat_session",
+      undefined,
+      "To delete",
+    );
+    await logInteraction(conn, threadId, {
+      role: "user",
+      kind: "message",
+      content: "Hello",
+    });
+    await logInteraction(conn, threadId, {
+      role: "assistant",
+      kind: "message",
+      content: "Hi there",
+    });
+
+    const deleted = await deleteThread(conn, threadId);
+    expect(deleted).toBe(true);
+
+    const result = await getThread(conn, threadId);
+    expect(result).toBeNull();
+  });
+
+  test("returns false for nonexistent thread", async () => {
+    const deleted = await deleteThread(conn, "nonexistent-id");
+    expect(deleted).toBe(false);
+  });
+
+  test("deletes thread with no interactions", async () => {
+    const threadId = await createThread(
+      conn,
+      "daemon_tick",
+      undefined,
+      "Empty",
+    );
+    const deleted = await deleteThread(conn, threadId);
+    expect(deleted).toBe(true);
+
+    const result = await getThread(conn, threadId);
+    expect(result).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds a new **Threads** tab (Tab 5, Help moves to Tab 6) for browsing chat thread history with a two-pane layout: thread list sidebar with type icons (⚙ daemon / 💬 agent) and a detail pane showing metadata, duration, and full interaction timeline
- Threads can be filtered by type (`f`), deleted with confirmation (`d`), and the active session thread is protected from deletion
- Adds `deleteThread` to the DB layer (cascades to interactions) with tests
- Consolidates all duplicated ANSI escape codes from ToolPanel, TaskPanel, and ThreadPanel into a shared `ansi` export in `theme.ts`

## Test plan
- [x] `bun run lint` passes
- [x] `bun test` passes (389 tests, including 3 new deleteThread tests)
- [ ] Manual: `bun run dev` → Tab through all 6 tabs, verify Threads tab renders
- [ ] Manual: Filter threads by type with `f`, delete a non-active thread with `d`+`y`