### PR TITLE
Fix duplicate React keys for concurrent tool calls

### DIFF
--- a/src/chat/agent.ts
+++ b/src/chat/agent.ts
@@ -85,8 +85,9 @@ export interface ToolEndMeta {
 
 export interface ChatTurnCallbacks {
   onToken: (text: string) => void;
-  onToolStart: (name: string, input: string) => void;
+  onToolStart: (id: string, name: string, input: string) => void;
   onToolEnd: (
+    id: string,
     name: string,
     output: string,
     isError: boolean,
@@ -175,7 +176,7 @@ export async function runChatTurn(input: {
     // Log all tool_use entries and notify UI
     for (const toolUse of toolUseBlocks) {
       const toolInput = JSON.stringify(toolUse.input);
-      callbacks.onToolStart(toolUse.name, toolInput);
+      callbacks.onToolStart(toolUse.id, toolUse.name, toolInput);
 
       await logInteraction(conn, threadId, {
         role: "assistant",
@@ -196,7 +197,13 @@ export async function runChatTurn(input: {
         const meta: ToolEndMeta | undefined = stored.stored
           ? { largeResult: stored.stored }
           : undefined;
-        callbacks.onToolEnd(toolUse.name, result.output, result.isError, meta);
+        callbacks.onToolEnd(
+          toolUse.id,
+          toolUse.name,
+          result.output,
+          result.isError,
+          meta,
+        );
         return { toolUse, result, durationMs, stored };
       }),
     );

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -51,9 +51,11 @@ function restoreMessagesFromInteractions(
   const result: ChatMessage[] = [];
   let pendingTools: ToolCallData[] = [];
 
+  let restoredIdx = 0;
   for (const ix of interactions) {
     if (ix.kind === "tool_use") {
       pendingTools.push({
+        id: `restored-${restoredIdx++}`,
         name: ix.tool_name ?? "unknown",
         input: ix.tool_input ?? "{}",
         running: false,
@@ -302,11 +304,12 @@ export function App({
               lastStreamFlush = now;
             }
           },
-          onToolStart: (name, input) => {
+          onToolStart: (id, name, input) => {
             if (currentText) {
               finalizeSegment();
             }
             const tc: ToolCallData = {
+              id,
               name,
               input,
               running: true,
@@ -315,10 +318,8 @@ export function App({
             pendingToolCalls.push(tc);
             setActiveToolCalls([...pendingToolCalls]);
           },
-          onToolEnd: (name, output, isError, meta) => {
-            const tc = pendingToolCalls.find(
-              (t) => t.name === name && t.running,
-            );
+          onToolEnd: (id, _name, output, isError, meta) => {
+            const tc = pendingToolCalls.find((t) => t.id === id);
             if (tc) {
               tc.running = false;
               tc.output = output;

--- a/src/tui/components/MessageList.tsx
+++ b/src/tui/components/MessageList.tsx
@@ -117,9 +117,8 @@ const MessageBubble = memo(function MessageBubble({
             marginBottom={0}
             width="100%"
           >
-            {message.toolCalls.map((tc, i) => (
-              // biome-ignore lint/suspicious/noArrayIndexKey: tool calls are append-only
-              <ToolCall key={`${i}-${tc.name}`} tool={tc} />
+            {message.toolCalls.map((tc) => (
+              <ToolCall key={tc.id} tool={tc} />
             ))}
           </Box>
         )}
@@ -160,7 +159,7 @@ export function MessageList({
               paddingX={1}
             >
               {activeToolCalls.map((tc) => (
-                <ToolCall key={`active-${tc.name}`} tool={tc} />
+                <ToolCall key={tc.id} tool={tc} />
               ))}
             </Box>
           )}

--- a/src/tui/components/ToolCall.tsx
+++ b/src/tui/components/ToolCall.tsx
@@ -31,6 +31,7 @@ export interface LargeResultMeta {
 }
 
 export interface ToolCallData {
+  id: string;
   name: string;
   input: string;
   output?: string;

--- a/src/tui/components/ToolPanel.tsx
+++ b/src/tui/components/ToolPanel.tsx
@@ -273,7 +273,7 @@ export function ToolPanel({ toolCalls, isActive }: ToolPanelProps) {
               ? `${displayName.slice(0, maxName - 1)}…`
               : displayName;
           return (
-            <Box key={`${i}-${tc.name}`} paddingX={1}>
+            <Box key={tc.id} paddingX={1}>
               <Text
                 backgroundColor={isSelected ? theme.selectionBg : undefined}
                 bold={isSelected}


### PR DESCRIPTION
## Summary
- Thread the Anthropic SDK's unique `toolUse.id` through `onToolStart`/`onToolEnd` callbacks and add `id` to `ToolCallData`
- Use `tc.id` as the React key in MessageList and ToolPanel, fixing duplicate key warnings when multiple tool calls share the same name (e.g. concurrent `mcp_exec` calls)
- Fix `onToolEnd` matching to use ID instead of name, preventing misattribution when multiple same-name tools run in parallel

## Test plan
- [x] `bun run lint` passes
- [x] `bun test` passes (389 tests)
- [ ] Manual: trigger multiple concurrent tool calls with the same name, verify no React key warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)