### PR TITLE
Add auto-generated titles for chat and daemon threads

### DIFF
--- a/src/chat/session.ts
+++ b/src/chat/session.ts
@@ -77,12 +77,7 @@ export async function startChatSession(
       void generateThreadTitle(config, conn, threadId, firstUserMessage);
     }
   } else {
-    threadId = await createThread(
-      conn,
-      "chat_session",
-      undefined,
-      "New chat",
-    );
+    threadId = await createThread(conn, "chat_session", undefined, "New chat");
   }
 
   const systemPrompt = await buildChatSystemPrompt(projectDir);

--- a/src/chat/session.ts
+++ b/src/chat/session.ts
@@ -14,6 +14,7 @@ import {
 } from "../db/threads.ts";
 import { createMcpxClient } from "../mcpx/client.ts";
 import type { ToolContext } from "../tools/tool.ts";
+import { generateThreadTitle } from "../utils/title.ts";
 import {
   buildChatSystemPrompt,
   type ChatTurnCallbacks,
@@ -60,20 +61,27 @@ export async function startChatSession(
     await reopenThread(conn, threadId);
 
     // Rebuild message history from interactions
+    let firstUserMessage: string | undefined;
     for (const interaction of result.interactions) {
       if (interaction.kind !== "message") continue;
       if (interaction.role === "user") {
+        if (!firstUserMessage) firstUserMessage = interaction.content;
         messages.push({ role: "user", content: interaction.content });
       } else if (interaction.role === "assistant") {
         messages.push({ role: "assistant", content: interaction.content });
       }
+    }
+
+    // Backfill title for threads that still have the default
+    if (result.thread.title === "New chat" && firstUserMessage) {
+      void generateThreadTitle(config, conn, threadId, firstUserMessage);
     }
   } else {
     threadId = await createThread(
       conn,
       "chat_session",
       undefined,
-      "Interactive chat",
+      "New chat",
     );
   }
 
@@ -117,6 +125,16 @@ export async function sendMessage(
   });
 
   session.messages.push({ role: "user", content: userMessage });
+
+  // Auto-generate title after first user message in a new thread
+  if (session.messages.length === 1) {
+    void generateThreadTitle(
+      session.config,
+      session.conn,
+      session.threadId,
+      userMessage,
+    );
+  }
 
   await runChatTurn({
     messages: session.messages,

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -11,7 +11,7 @@ export interface BotholomewConfig {
 export const DEFAULT_CONFIG: Required<BotholomewConfig> = {
   anthropic_api_key: "",
   model: "claude-opus-4-20250514",
-  chunker_model: "claude-haiku-4-20250514",
+  chunker_model: "claude-haiku-4-5-20251001",
   tick_interval_seconds: 300,
   max_tick_duration_seconds: 120,
   system_prompt_override: "",

--- a/src/daemon/tick.ts
+++ b/src/daemon/tick.ts
@@ -8,6 +8,7 @@ import {
 } from "../db/tasks.ts";
 import { createThread, endThread, logInteraction } from "../db/threads.ts";
 import { logger } from "../utils/logger.ts";
+import { generateThreadTitle } from "../utils/title.ts";
 import { runAgentLoop } from "./llm.ts";
 import { buildSystemPrompt } from "./prompt.ts";
 import { processSchedules } from "./schedules.ts";
@@ -82,6 +83,14 @@ export async function tick(
     });
 
     logger.info(`Task ${task.id} -> ${result.status}`);
+
+    // Generate a descriptive title for the thread
+    void generateThreadTitle(
+      config,
+      conn,
+      threadId,
+      `Task: ${task.name}\nDescription: ${task.description}\nOutcome: ${result.status}${result.reason ? ` — ${result.reason}` : ""}`,
+    );
   } catch (err) {
     await updateTaskStatus(conn, task.id, "failed", String(err));
 

--- a/src/db/threads.ts
+++ b/src/db/threads.ts
@@ -154,6 +154,14 @@ export async function reopenThread(
   db.query("UPDATE threads SET ended_at = NULL WHERE id = ?1").run(threadId);
 }
 
+export async function updateThreadTitle(
+  db: DbConnection,
+  threadId: string,
+  title: string,
+): Promise<void> {
+  db.query("UPDATE threads SET title = ?2 WHERE id = ?1").run(threadId, title);
+}
+
 export async function getThread(
   db: DbConnection,
   threadId: string,

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -123,6 +123,7 @@ export function App({
   const sessionRef = useRef<ChatSession | null>(null);
   const [activeTab, setActiveTab] = useState<TabId>(1);
   const [daemonRunning, setDaemonRunning] = useState(false);
+  const [chatTitle, setChatTitle] = useState<string | undefined>(undefined);
   const queueRef = useRef<string[]>([]);
   const processingRef = useRef(false);
   const [queuedMessages, setQueuedMessages] = useState<string[]>([]);
@@ -362,6 +363,28 @@ export function App({
     }
   }, [ready, initialPrompt, processQueue, syncQueue]);
 
+  // Poll for chat thread title updates
+  useEffect(() => {
+    if (!ready || !sessionRef.current) return;
+    let mounted = true;
+
+    const refreshTitle = async () => {
+      const session = sessionRef.current;
+      if (!session) return;
+      const result = await getThread(session.conn, session.threadId);
+      if (mounted && result?.thread.title) {
+        setChatTitle(result.thread.title);
+      }
+    };
+
+    refreshTitle();
+    const interval = setInterval(refreshTitle, 5000);
+    return () => {
+      mounted = false;
+      clearInterval(interval);
+    };
+  }, [ready]);
+
   const handleSubmit = useCallback(
     async (text: string) => {
       const trimmed = text.trim();
@@ -517,6 +540,7 @@ export function App({
           <StatusBar
             projectDir={projectDir}
             conn={conn}
+            chatTitle={chatTitle}
             onDaemonStatusChange={setDaemonRunning}
           />
         }

--- a/src/tui/components/StatusBar.tsx
+++ b/src/tui/components/StatusBar.tsx
@@ -8,6 +8,7 @@ import { LogoChar } from "./Logo.tsx";
 interface StatusBarProps {
   projectDir: string;
   conn: DbConnection;
+  chatTitle?: string;
   onDaemonStatusChange?: (running: boolean) => void;
 }
 
@@ -20,6 +21,7 @@ interface Status {
 export function StatusBar({
   projectDir,
   conn,
+  chatTitle,
   onDaemonStatusChange,
 }: StatusBarProps) {
   const [status, setStatus] = useState<Status>({
@@ -60,6 +62,14 @@ export function StatusBar({
       <Text bold color="blue">
         Botholomew
       </Text>
+      {chatTitle && (
+        <>
+          <Text dimColor> | </Text>
+          <Text color="cyan" bold>
+            {chatTitle.length > 30 ? `${chatTitle.slice(0, 29)}…` : chatTitle}
+          </Text>
+        </>
+      )}
       <Text dimColor> | </Text>
       {status.daemonRunning ? (
         <Text color="green">Daemon</Text>

--- a/src/tui/components/ThreadPanel.tsx
+++ b/src/tui/components/ThreadPanel.tsx
@@ -191,6 +191,8 @@ export function ThreadPanel({
   const [typeFilter, setTypeFilter] = useState<Thread["type"] | null>(null);
   const [refreshTick, setRefreshTick] = useState(0);
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [searching, setSearching] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
   const [selectedDetail, setSelectedDetail] = useState<{
     thread: Thread;
     interactions: Interaction[];
@@ -221,8 +223,15 @@ export function ThreadPanel({
     };
   }, [conn, typeFilter, refreshTick]);
 
+  // Filter threads by search query
+  const filteredThreads = useMemo(() => {
+    if (!searchQuery) return threads;
+    const q = searchQuery.toLowerCase();
+    return threads.filter((t) => t.title.toLowerCase().includes(q));
+  }, [threads, searchQuery]);
+
   // Fetch detail for selected thread
-  const selectedThread = threads[selectedIndex];
+  const selectedThread = filteredThreads[selectedIndex];
   // biome-ignore lint/correctness/useExhaustiveDependencies: selectedThread?.id is the intentional trigger
   useEffect(() => {
     let mounted = true;
@@ -264,7 +273,7 @@ export function ThreadPanel({
     0,
     Math.min(
       selectedIndex - Math.floor(visibleRows / 2),
-      threads.length - visibleRows,
+      filteredThreads.length - visibleRows,
     ),
   );
 
@@ -280,6 +289,30 @@ export function ThreadPanel({
 
   useInput(
     (input, key) => {
+      // Search mode: capture typed characters
+      if (searching) {
+        if (key.escape) {
+          setSearching(false);
+          setSearchQuery("");
+          return;
+        }
+        if (key.return) {
+          setSearching(false);
+          return;
+        }
+        if (key.backspace || key.delete) {
+          setSearchQuery((q) => q.slice(0, -1));
+          setSelectedIndex(0);
+          return;
+        }
+        if (input && !key.ctrl && !key.meta) {
+          setSearchQuery((q) => q + input);
+          setSelectedIndex(0);
+          return;
+        }
+        return;
+      }
+
       // Delete confirmation mode
       if (confirmDelete) {
         if (input === "y" || input === "d") {
@@ -307,7 +340,7 @@ export function ThreadPanel({
         if (key.shift) {
           setDetailScroll((s) => Math.min(maxDetailScroll, s + 1));
         } else {
-          setSelectedIndex((i) => Math.min(threads.length - 1, i + 1));
+          setSelectedIndex((i) => Math.min(filteredThreads.length - 1, i + 1));
         }
         return;
       }
@@ -352,17 +385,24 @@ export function ThreadPanel({
         forceRefresh();
         return;
       }
+      if (input === "s" || input === "/") {
+        setSearching(true);
+        setSearchQuery("");
+        return;
+      }
     },
     { isActive },
   );
 
-  if (threads.length === 0) {
+  if (filteredThreads.length === 0) {
     return (
       <Box flexDirection="column" flexGrow={1} paddingX={1}>
         <Text dimColor>
-          {typeFilter
-            ? "No threads match the current filter. Press f to change filter."
-            : "No threads found. Threads will appear as chat sessions and daemon ticks occur."}
+          {searchQuery
+            ? `No threads match "${searchQuery}". Press Escape to clear search.`
+            : typeFilter
+              ? "No threads match the current filter. Press f to change filter."
+              : "No threads found. Threads will appear as chat sessions and daemon ticks occur."}
         </Text>
         {typeFilter && (
           <Box marginTop={1}>
@@ -375,7 +415,7 @@ export function ThreadPanel({
     );
   }
 
-  const sidebarVisible = threads.slice(
+  const sidebarVisible = filteredThreads.slice(
     sidebarScrollOffset,
     sidebarScrollOffset + visibleRows,
   );
@@ -402,14 +442,22 @@ export function ThreadPanel({
       >
         <Box paddingX={1} gap={1}>
           <Text bold dimColor>
-            Threads ({threads.length})
+            Threads ({filteredThreads.length})
           </Text>
           {typeFilter && (
             <Text color={TYPE_COLORS[typeFilter]}>
               [{TYPE_ICONS[typeFilter]} {TYPE_LABELS[typeFilter]}]
             </Text>
           )}
+          {!searching && searchQuery && <Text dimColor>🔍 {searchQuery}</Text>}
         </Box>
+        {searching && (
+          <Box paddingX={1}>
+            <Text color={theme.info}>🔍 </Text>
+            <Text color={theme.info}>{searchQuery}</Text>
+            <Text color={theme.info}>▌</Text>
+          </Box>
+        )}
         {confirmDelete && selectedThread && (
           <Box paddingX={1}>
             <Text color="red" bold>
@@ -474,8 +522,8 @@ export function ThreadPanel({
         {detailLines.length > visibleRows && (
           <Box>
             <Text dimColor>
-              f filter · ↑↓ select · j/k scroll · d delete · r refresh · [
-              {detailScroll + 1}–
+              s search · f filter · ↑↓ select · j/k scroll · d delete · r
+              refresh · [{detailScroll + 1}–
               {Math.min(detailScroll + visibleRows, detailLines.length)} of{" "}
               {detailLines.length}]
             </Text>
@@ -483,7 +531,9 @@ export function ThreadPanel({
         )}
         {detailLines.length <= visibleRows && <Box flexGrow={1} />}
         {detailLines.length <= visibleRows && (
-          <Text dimColor>f filter · ↑↓ select · d delete · r refresh</Text>
+          <Text dimColor>
+            s search · f filter · ↑↓ select · d delete · r refresh
+          </Text>
         )}
       </Box>
     </Box>

--- a/src/utils/title.ts
+++ b/src/utils/title.ts
@@ -1,0 +1,47 @@
+import Anthropic from "@anthropic-ai/sdk";
+import type { BotholomewConfig } from "../config/schemas.ts";
+import type { DbConnection } from "../db/connection.ts";
+import { updateThreadTitle } from "../db/threads.ts";
+import { logger } from "./logger.ts";
+
+/**
+ * Generate a short title for a thread using the chunker model (Haiku).
+ * Fire-and-forget — errors are logged at debug level and never propagated.
+ */
+export async function generateThreadTitle(
+  config: Required<BotholomewConfig>,
+  conn: DbConnection,
+  threadId: string,
+  context: string,
+): Promise<void> {
+  try {
+    const client = new Anthropic({
+      apiKey: config.anthropic_api_key || undefined,
+    });
+
+    const response = await client.messages.create({
+      model: config.chunker_model,
+      max_tokens: 50,
+      system:
+        "You are a title generator. The user will provide the first message from a conversation. Output a short descriptive title (5-8 words). Output ONLY the title, nothing else.",
+      messages: [
+        {
+          role: "user",
+          content: `Generate a title for this message:\n\n"${context}"`,
+        },
+      ],
+    });
+
+    const title = response.content
+      .filter((b) => b.type === "text")
+      .map((b) => b.text)
+      .join("")
+      .trim();
+
+    if (title) {
+      await updateThreadTitle(conn, threadId, title);
+    }
+  } catch (err) {
+    logger.warn(`Failed to generate thread title: ${err}`);
+  }
+}

--- a/test/db/threads.test.ts
+++ b/test/db/threads.test.ts
@@ -7,6 +7,7 @@ import {
   getThread,
   listThreads,
   logInteraction,
+  updateThreadTitle,
 } from "../../src/db/threads.ts";
 import { setupTestDb } from "../helpers.ts";
 
@@ -51,6 +52,20 @@ describe("thread CRUD", () => {
 
     const result = await getThread(conn, threadId);
     expect(result?.thread.ended_at).not.toBeNull();
+  });
+
+  test("update thread title", async () => {
+    const threadId = await createThread(
+      conn,
+      "chat_session",
+      undefined,
+      "Interactive chat",
+    );
+
+    await updateThreadTitle(conn, threadId, "Discussing project architecture");
+
+    const result = await getThread(conn, threadId);
+    expect(result?.thread.title).toBe("Discussing project architecture");
   });
 
   test("get nonexistent thread returns null", async () => {


### PR DESCRIPTION
## Summary
- Auto-generates short descriptive titles for chat and daemon threads using the chunker model (Haiku) after the first user message
- Displays the current chat title in the TUI status bar next to "Botholomew"
- Adds title search to the Threads panel (`s` or `/` to search, `Escape` to clear)
- Backfills titles for existing threads when resumed with the default "New chat" title
- Fixes the default `chunker_model` to `claude-haiku-4-5-20251001` (previous ID returned 404)

## Test plan
- [x] `bun run lint` passes
- [x] `bun test` passes (390 tests, including new `updateThreadTitle` test)
- [ ] Start a new chat session, send a message — title should appear in status bar within ~5s
- [ ] Open Threads tab, press `s`, type a search term — list filters by title
- [ ] Resume an existing "New chat" thread — title should auto-generate on open

🤖 Generated with [Claude Code](https://claude.com/claude-code)