### PR TITLE
Add thread list/view/delete CLI commands

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,7 @@ import { registerMcpxCommand } from "./commands/mcpx.ts";
 import { registerPrepareCommand } from "./commands/prepare.ts";
 import { registerScheduleCommand } from "./commands/schedule.ts";
 import { registerTaskCommand } from "./commands/task.ts";
+import { registerThreadCommand } from "./commands/thread.ts";
 import { registerToolCommands } from "./commands/tools.ts";
 import { registerUpgradeCommand } from "./commands/upgrade.ts";
 import { maybeCheckForUpdate } from "./update/background.ts";
@@ -33,6 +34,7 @@ program
 registerInitCommand(program);
 registerDaemonCommand(program);
 registerTaskCommand(program);
+registerThreadCommand(program);
 registerScheduleCommand(program);
 registerChatCommand(program);
 registerContextCommand(program);

--- a/src/commands/thread.ts
+++ b/src/commands/thread.ts
@@ -1,0 +1,180 @@
+import ansis from "ansis";
+import type { Command } from "commander";
+import type { DbConnection } from "../db/connection.ts";
+import type { Interaction, Thread } from "../db/threads.ts";
+import { deleteThread, getThread, listThreads } from "../db/threads.ts";
+import { logger } from "../utils/logger.ts";
+import { withDb } from "./with-db.ts";
+
+export function registerThreadCommand(program: Command) {
+  const thread = program.command("thread").description("Manage chat threads");
+
+  thread
+    .command("list")
+    .description("List threads")
+    .option("-t, --type <type>", "filter by type (daemon_tick, chat_session)")
+    .option("-l, --limit <n>", "max number of threads", parseInt)
+    .action((opts) =>
+      withDb(program, async (conn) => {
+        const threads = await listThreads(conn, {
+          type: opts.type,
+          limit: opts.limit,
+        });
+
+        if (threads.length === 0) {
+          logger.dim("No threads found.");
+          return;
+        }
+
+        for (const t of threads) {
+          printThread(t);
+        }
+      }),
+    );
+
+  thread
+    .command("view <id>")
+    .description("View thread details and interactions")
+    .option(
+      "--only <roles>",
+      "show only these roles (comma-separated: user,assistant,tool,system)",
+    )
+    .action((id, opts) =>
+      withDb(program, async (conn) => {
+        const resolvedId = await resolveThreadId(conn, id);
+        if (!resolvedId) {
+          logger.error(`Thread not found: ${id}`);
+          process.exit(1);
+        }
+        const result = await getThread(conn, resolvedId);
+        if (!result) {
+          logger.error(`Thread not found: ${id}`);
+          process.exit(1);
+        }
+        const interactions = opts.only
+          ? result.interactions.filter((i) =>
+              (opts.only as string).split(",").includes(i.role),
+            )
+          : result.interactions;
+        printThreadDetail(result.thread, interactions);
+      }),
+    );
+
+  thread
+    .command("delete <id>")
+    .description("Delete a thread and its interactions")
+    .action((id) =>
+      withDb(program, async (conn) => {
+        const resolvedId = await resolveThreadId(conn, id);
+        if (!resolvedId) {
+          logger.error(`Thread not found: ${id}`);
+          process.exit(1);
+        }
+        const deleted = await deleteThread(conn, resolvedId);
+        if (!deleted) {
+          logger.error(`Thread not found: ${id}`);
+          process.exit(1);
+        }
+        logger.success(`Deleted thread: ${resolvedId}`);
+      }),
+    );
+}
+
+async function resolveThreadId(
+  conn: DbConnection,
+  idPrefix: string,
+): Promise<string | null> {
+  if (idPrefix.length >= 36) return idPrefix;
+  const all = await listThreads(conn);
+  const matches = all.filter((t) => t.id.startsWith(idPrefix));
+  if (matches.length === 1) {
+    const match = matches[0] as Thread;
+    return match.id;
+  }
+  if (matches.length === 0) return null;
+  logger.error(
+    `Ambiguous thread prefix "${idPrefix}" matches ${matches.length} threads`,
+  );
+  process.exit(1);
+}
+
+function typeColor(type: Thread["type"]): string {
+  switch (type) {
+    case "daemon_tick":
+      return ansis.magenta(type);
+    case "chat_session":
+      return ansis.cyan(type);
+  }
+}
+
+function statusLabel(thread: Thread): string {
+  return thread.ended_at ? ansis.dim("ended") : ansis.green("active");
+}
+
+function roleColor(role: Interaction["role"]): string {
+  switch (role) {
+    case "user":
+      return ansis.cyan(role);
+    case "assistant":
+      return ansis.green(role);
+    case "system":
+      return ansis.yellow(role);
+    case "tool":
+      return ansis.magenta(role);
+  }
+}
+
+function printThread(t: Thread) {
+  const id = ansis.dim(t.id.slice(0, 8));
+  const title = t.title || ansis.dim("(untitled)");
+  console.log(`  ${id}  ${typeColor(t.type)}  ${statusLabel(t)}  ${title}`);
+}
+
+function printThreadDetail(t: Thread, interactions: Interaction[]) {
+  console.log(ansis.bold(t.title || "(untitled)"));
+  console.log(`  ID:       ${t.id}`);
+  console.log(`  Type:     ${typeColor(t.type)}`);
+  console.log(`  Status:   ${statusLabel(t)}`);
+  if (t.task_id) console.log(`  Task:     ${t.task_id}`);
+  console.log(`  Started:  ${t.started_at.toISOString()}`);
+  console.log(
+    `  Ended:    ${t.ended_at ? t.ended_at.toISOString() : ansis.dim("—")}`,
+  );
+
+  if (interactions.length === 0) {
+    console.log(`\n  ${ansis.dim("No interactions.")}`);
+    return;
+  }
+
+  console.log(`\n  Interactions (${interactions.length}):`);
+  for (const i of interactions) {
+    printInteraction(i);
+  }
+}
+
+function formatTime(date: Date): string {
+  return date
+    .toISOString()
+    .replace("T", " ")
+    .replace(/\.\d{3}Z$/, "");
+}
+
+function printInteraction(i: Interaction) {
+  const seq = ansis.dim(`#${i.sequence}`);
+  const ts = ansis.dim(formatTime(i.created_at));
+  const kind = ansis.dim(`[${i.kind}]`);
+  let preview: string;
+  if (i.kind === "tool_use" && i.tool_name) {
+    preview = ansis.yellow(i.tool_name);
+  } else {
+    const text = i.content.replace(/\n/g, " ");
+    preview = text.length > 120 ? `${text.slice(0, 120)}...` : text;
+  }
+  const extras: string[] = [];
+  if (i.token_count) extras.push(`${i.token_count} tok`);
+  if (i.duration_ms) extras.push(`${i.duration_ms}ms`);
+  const suffix = extras.length > 0 ? `  ${ansis.dim(extras.join(", "))}` : "";
+  console.log(
+    `  ${seq}  ${ts}  ${roleColor(i.role)}  ${kind}  ${preview}${suffix}`,
+  );
+}

--- a/test/commands/thread.test.ts
+++ b/test/commands/thread.test.ts
@@ -1,0 +1,281 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getDbPath } from "../../src/constants.ts";
+import { getConnection } from "../../src/db/connection.ts";
+import { migrate } from "../../src/db/schema.ts";
+import {
+  createThread,
+  getThread,
+  logInteraction,
+} from "../../src/db/threads.ts";
+import { initProject } from "../../src/init/index.ts";
+
+let tempDir: string;
+
+afterEach(async () => {
+  if (tempDir) {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+const CLI = join(import.meta.dir, "..", "..", "src", "cli.ts");
+
+async function run(
+  args: string[],
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  const proc = Bun.spawn(["bun", CLI, "--dir", tempDir, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, NO_COLOR: "1" },
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const code = await proc.exited;
+  return { code, stdout, stderr };
+}
+
+describe("thread list", () => {
+  test("shows empty message when no threads", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "botholomew-test-"));
+    await initProject(tempDir);
+
+    const result = await run(["thread", "list"]);
+    expect(result.code).toBe(0);
+    expect(result.stdout + result.stderr).toContain("No threads found");
+  });
+
+  test("lists seeded threads", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "botholomew-test-"));
+    await initProject(tempDir);
+
+    const conn = getConnection(getDbPath(tempDir));
+    migrate(conn);
+    const id1 = await createThread(conn, "chat_session", undefined, "Chat A");
+    const id2 = await createThread(conn, "daemon_tick", undefined, "Tick B");
+    conn.close();
+
+    const result = await run(["thread", "list"]);
+    expect(result.code).toBe(0);
+    const output = result.stdout + result.stderr;
+    expect(output).toContain(id1.slice(0, 8));
+    expect(output).toContain(id2.slice(0, 8));
+    expect(output).toContain("Chat A");
+    expect(output).toContain("Tick B");
+  });
+
+  test("filters by type", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "botholomew-test-"));
+    await initProject(tempDir);
+
+    const conn = getConnection(getDbPath(tempDir));
+    migrate(conn);
+    await createThread(conn, "chat_session", undefined, "Chat");
+    await createThread(conn, "daemon_tick", undefined, "Tick");
+    conn.close();
+
+    const result = await run(["thread", "list", "-t", "chat_session"]);
+    expect(result.code).toBe(0);
+    const output = result.stdout + result.stderr;
+    expect(output).toContain("Chat");
+    expect(output).not.toContain("Tick");
+  });
+});
+
+describe("thread view", () => {
+  test("shows thread details and interactions", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "botholomew-test-"));
+    await initProject(tempDir);
+
+    const conn = getConnection(getDbPath(tempDir));
+    migrate(conn);
+    const threadId = await createThread(
+      conn,
+      "chat_session",
+      undefined,
+      "Test Chat",
+    );
+    await logInteraction(conn, threadId, {
+      role: "user",
+      kind: "message",
+      content: "Hello there",
+    });
+    await logInteraction(conn, threadId, {
+      role: "assistant",
+      kind: "message",
+      content: "Hi! How can I help?",
+    });
+    conn.close();
+
+    const result = await run(["thread", "view", threadId]);
+    expect(result.code).toBe(0);
+    const output = result.stdout + result.stderr;
+    expect(output).toContain("Test Chat");
+    expect(output).toContain(threadId);
+    expect(output).toContain("chat_session");
+    expect(output).toContain("Interactions (2)");
+    expect(output).toContain("Hello there");
+    expect(output).toContain("Hi! How can I help?");
+  });
+
+  test("filters interactions by --only role", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "botholomew-test-"));
+    await initProject(tempDir);
+
+    const conn = getConnection(getDbPath(tempDir));
+    migrate(conn);
+    const threadId = await createThread(
+      conn,
+      "chat_session",
+      undefined,
+      "Filter Test",
+    );
+    await logInteraction(conn, threadId, {
+      role: "user",
+      kind: "message",
+      content: "user message here",
+    });
+    await logInteraction(conn, threadId, {
+      role: "assistant",
+      kind: "message",
+      content: "assistant reply here",
+    });
+    await logInteraction(conn, threadId, {
+      role: "tool",
+      kind: "tool_result",
+      content: "tool output here",
+    });
+    conn.close();
+
+    const result = await run([
+      "thread",
+      "view",
+      threadId,
+      "--only",
+      "assistant",
+    ]);
+    expect(result.code).toBe(0);
+    const output = result.stdout + result.stderr;
+    expect(output).toContain("assistant reply here");
+    expect(output).not.toContain("user message here");
+    expect(output).not.toContain("tool output here");
+    expect(output).toContain("Interactions (1)");
+  });
+
+  test("filters by multiple roles with --only", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "botholomew-test-"));
+    await initProject(tempDir);
+
+    const conn = getConnection(getDbPath(tempDir));
+    migrate(conn);
+    const threadId = await createThread(
+      conn,
+      "chat_session",
+      undefined,
+      "Multi Filter",
+    );
+    await logInteraction(conn, threadId, {
+      role: "user",
+      kind: "message",
+      content: "user msg",
+    });
+    await logInteraction(conn, threadId, {
+      role: "assistant",
+      kind: "message",
+      content: "assistant msg",
+    });
+    await logInteraction(conn, threadId, {
+      role: "tool",
+      kind: "tool_result",
+      content: "tool msg",
+    });
+    conn.close();
+
+    const result = await run([
+      "thread",
+      "view",
+      threadId,
+      "--only",
+      "user,tool",
+    ]);
+    expect(result.code).toBe(0);
+    const output = result.stdout + result.stderr;
+    expect(output).toContain("user msg");
+    expect(output).toContain("tool msg");
+    expect(output).not.toContain("assistant msg");
+    expect(output).toContain("Interactions (2)");
+  });
+
+  test("supports short ID prefix", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "botholomew-test-"));
+    await initProject(tempDir);
+
+    const conn = getConnection(getDbPath(tempDir));
+    migrate(conn);
+    const threadId = await createThread(
+      conn,
+      "chat_session",
+      undefined,
+      "Prefix Test",
+    );
+    conn.close();
+
+    const result = await run(["thread", "view", threadId.slice(0, 8)]);
+    expect(result.code).toBe(0);
+    expect(result.stdout + result.stderr).toContain("Prefix Test");
+  });
+
+  test("errors on unknown thread", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "botholomew-test-"));
+    await initProject(tempDir);
+
+    const result = await run(["thread", "view", "nonexistent"]);
+    expect(result.code).toBe(1);
+    expect(result.stdout + result.stderr).toContain("Thread not found");
+  });
+});
+
+describe("thread delete", () => {
+  test("deletes existing thread", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "botholomew-test-"));
+    await initProject(tempDir);
+
+    const conn = getConnection(getDbPath(tempDir));
+    migrate(conn);
+    const threadId = await createThread(
+      conn,
+      "chat_session",
+      undefined,
+      "To Delete",
+    );
+    await logInteraction(conn, threadId, {
+      role: "user",
+      kind: "message",
+      content: "bye",
+    });
+    conn.close();
+
+    const result = await run(["thread", "delete", threadId]);
+    expect(result.code).toBe(0);
+    expect(result.stdout + result.stderr).toContain("Deleted thread");
+
+    // Verify it's actually gone
+    const conn2 = getConnection(getDbPath(tempDir));
+    migrate(conn2);
+    const gone = await getThread(conn2, threadId);
+    conn2.close();
+    expect(gone).toBeNull();
+  });
+
+  test("errors on unknown thread", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "botholomew-test-"));
+    await initProject(tempDir);
+
+    const result = await run(["thread", "delete", "nonexistent"]);
+    expect(result.code).toBe(1);
+    expect(result.stdout + result.stderr).toContain("Thread not found");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `botholomew thread list` to list threads with optional `--type` and `--limit` filters
- Adds `botholomew thread view <id>` to show thread details and interaction timeline, with `--only` role filtering and short ID prefix support
- Adds `botholomew thread delete <id>` to remove threads and their interactions
- Registers the new `thread` command in the CLI entrypoint
- Includes 10 tests covering all subcommands, filters, prefix matching, and error cases

## Test plan
- [x] `bun run lint` passes
- [x] `bun test test/commands/thread.test.ts` — 10/10 pass
- [x] `bun test` — full suite 397 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)