### PR TITLE
Fix TUI 100% CPU hang on fast input and tab switching

### DIFF
--- a/src/chat/agent.ts
+++ b/src/chat/agent.ts
@@ -137,10 +137,22 @@ export async function runChatTurn(input: {
 
     // Collect the full response
     let assistantText = "";
+    const earlyReportedToolIds = new Set<string>();
 
     stream.on("text", (text) => {
       assistantText += text;
       callbacks.onToken(text);
+    });
+
+    stream.on("contentBlock", (block) => {
+      if (block.type === "tool_use") {
+        earlyReportedToolIds.add(block.id);
+        callbacks.onToolStart(
+          block.id,
+          block.name,
+          JSON.stringify(block.input),
+        );
+      }
     });
 
     const response = await stream.finalMessage();
@@ -176,7 +188,9 @@ export async function runChatTurn(input: {
     // Log all tool_use entries and notify UI
     for (const toolUse of toolUseBlocks) {
       const toolInput = JSON.stringify(toolUse.input);
-      callbacks.onToolStart(toolUse.id, toolUse.name, toolInput);
+      if (!earlyReportedToolIds.has(toolUse.id)) {
+        callbacks.onToolStart(toolUse.id, toolUse.name, toolInput);
+      }
 
       await logInteraction(conn, threadId, {
         role: "assistant",

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -194,63 +194,78 @@ export function App({
     return () => clearTimeout(timer);
   }, []);
 
-  // Tab switching via useInput at the App level
-  // On the Chat tab (1), only Tab key switches — number keys go to InputBar.
-  // On other tabs, both Tab and number keys switch tabs, Escape returns to Chat.
-  useInput((input, key) => {
-    // Ctrl+C exits
-    if (input === "c" && key.ctrl) {
-      exit();
-      return;
-    }
+  // Stable ref for App-level input handler — same pattern as InputBar to
+  // prevent Ink's useInput from re-registering stdin listeners on every render.
+  const activeTabRef = useRef(activeTab);
+  const queuedMessagesRef = useRef(queuedMessages);
+  const selectedQueueIndexRef = useRef(selectedQueueIndex);
+  activeTabRef.current = activeTab;
+  queuedMessagesRef.current = queuedMessages;
+  selectedQueueIndexRef.current = selectedQueueIndex;
 
-    // Tab key cycles tabs — always active (InputBar ignores tab)
-    if (key.tab && !key.shift) {
-      setActiveTab((t) => ((t % 6) + 1) as TabId);
-      return;
-    }
+  const stableAppHandler = useCallback(
+    // biome-ignore lint/suspicious/noExplicitAny: Ink's Key type is not exported
+    (input: string, key: any) => {
+      // Ctrl+C exits
+      if (input === "c" && key.ctrl) {
+        exit();
+        return;
+      }
 
-    // Queue manipulation keybindings (only when queue has items on Chat tab)
-    if (activeTab === 1 && queuedMessages.length > 0 && key.ctrl) {
-      if (input === "j") {
-        setSelectedQueueIndex((i) =>
-          Math.min(i + 1, queuedMessages.length - 1),
-        );
+      // Tab key cycles tabs — always active (InputBar ignores tab)
+      if (key.tab && !key.shift) {
+        setActiveTab((t) => ((t % 6) + 1) as TabId);
         return;
       }
-      if (input === "k") {
-        setSelectedQueueIndex((i) => Math.max(i - 1, 0));
-        return;
-      }
-      if (input === "x") {
-        queueRef.current.splice(selectedQueueIndex, 1);
-        syncQueue();
-        return;
-      }
-      if (input === "e") {
-        const [msg] = queueRef.current.splice(selectedQueueIndex, 1);
-        syncQueue();
-        if (msg) {
-          setInputValue(msg);
+
+      // Queue manipulation keybindings (only when queue has items on Chat tab)
+      const tab = activeTabRef.current;
+      const queue = queuedMessagesRef.current;
+      if (tab === 1 && queue.length > 0 && key.ctrl) {
+        if (input === "j") {
+          setSelectedQueueIndex((i) => Math.min(i + 1, queue.length - 1));
+          return;
         }
-        return;
+        if (input === "k") {
+          setSelectedQueueIndex((i) => Math.max(i - 1, 0));
+          return;
+        }
+        if (input === "x") {
+          queueRef.current.splice(selectedQueueIndexRef.current, 1);
+          syncQueue();
+          return;
+        }
+        if (input === "e") {
+          const [msg] = queueRef.current.splice(
+            selectedQueueIndexRef.current,
+            1,
+          );
+          syncQueue();
+          if (msg) {
+            setInputValue(msg);
+          }
+          return;
+        }
       }
-    }
 
-    if (activeTab !== 1) {
-      // Number keys jump to tab on non-chat tabs
-      const num = Number.parseInt(input, 10);
-      if (num >= 1 && num <= 6) {
-        setActiveTab(num as TabId);
-        return;
+      if (tab !== 1) {
+        // Number keys jump to tab on non-chat tabs
+        const num = Number.parseInt(input, 10);
+        if (num >= 1 && num <= 6) {
+          setActiveTab(num as TabId);
+          return;
+        }
+        // Escape returns to chat
+        if (key.escape) {
+          setActiveTab(1);
+          return;
+        }
       }
-      // Escape returns to chat
-      if (key.escape) {
-        setActiveTab(1);
-        return;
-      }
-    }
-  });
+    },
+    [exit, syncQueue],
+  );
+
+  useInput(stableAppHandler);
 
   const processQueue = useCallback(async () => {
     if (processingRef.current || !sessionRef.current) return;
@@ -436,6 +451,19 @@ export function App({
     [exit, processQueue, syncQueue],
   );
 
+  const sessionConn = sessionRef.current?.conn;
+  const inputBarHeader = useMemo(
+    () =>
+      sessionConn ? (
+        <StatusBar
+          projectDir={projectDir}
+          conn={sessionConn}
+          onDaemonStatusChange={setDaemonRunning}
+        />
+      ) : null,
+    [projectDir, sessionConn],
+  );
+
   const allToolCalls = useMemo(
     () => messages.flatMap((m) => m.toolCalls ?? []),
     [messages],
@@ -468,36 +496,65 @@ export function App({
 
   return (
     <Box flexDirection="column" height="100%">
-      {/* Tab content area */}
-      {activeTab === 1 && (
+      {/* Tab content area — all panels stay mounted to avoid expensive
+          remount cycles (especially <Static> in MessageList re-rendering
+          the entire history). display="none" hides inactive panels from
+          layout without destroying them. */}
+      <Box
+        display={activeTab === 1 ? "flex" : "none"}
+        flexDirection="column"
+        flexGrow={1}
+      >
         <MessageList
           messages={messages}
           streamingText={streamingText}
           isLoading={isLoading}
           activeToolCalls={activeToolCalls}
         />
-      )}
-      {activeTab === 2 && (
+      </Box>
+      <Box
+        display={activeTab === 2 ? "flex" : "none"}
+        flexDirection="column"
+        flexGrow={1}
+      >
         <ToolPanel toolCalls={allToolCalls} isActive={activeTab === 2} />
-      )}
-      {activeTab === 3 && (
+      </Box>
+      <Box
+        display={activeTab === 3 ? "flex" : "none"}
+        flexDirection="column"
+        flexGrow={1}
+      >
         <ContextPanel conn={conn} isActive={activeTab === 3} />
-      )}
-      {activeTab === 4 && <TaskPanel conn={conn} isActive={activeTab === 4} />}
-      {activeTab === 5 && (
+      </Box>
+      <Box
+        display={activeTab === 4 ? "flex" : "none"}
+        flexDirection="column"
+        flexGrow={1}
+      >
+        <TaskPanel conn={conn} isActive={activeTab === 4} />
+      </Box>
+      <Box
+        display={activeTab === 5 ? "flex" : "none"}
+        flexDirection="column"
+        flexGrow={1}
+      >
         <ThreadPanel
           conn={conn}
           activeThreadId={threadId}
           isActive={activeTab === 5}
         />
-      )}
-      {activeTab === 6 && (
+      </Box>
+      <Box
+        display={activeTab === 6 ? "flex" : "none"}
+        flexDirection="column"
+        flexGrow={1}
+      >
         <HelpPanel
           projectDir={projectDir}
           threadId={threadId}
           daemonRunning={daemonRunning}
         />
-      )}
+      </Box>
 
       {/* Queued messages (only on Chat tab) */}
       {activeTab === 1 && queuedMessages.length > 0 && (
@@ -514,13 +571,7 @@ export function App({
         onSubmit={handleSubmit}
         disabled={activeTab !== 1}
         history={inputHistory}
-        header={
-          <StatusBar
-            projectDir={projectDir}
-            conn={conn}
-            onDaemonStatusChange={setDaemonRunning}
-          />
-        }
+        header={inputBarHeader}
       />
       <TabBar activeTab={activeTab} />
     </Box>

--- a/src/tui/components/ContextPanel.tsx
+++ b/src/tui/components/ContextPanel.tsx
@@ -1,5 +1,5 @@
 import { Box, Text, useInput, useStdout } from "ink";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import type { DbConnection } from "../../db/connection.ts";
 import {
   type ContextItem,
@@ -31,7 +31,10 @@ type Entry = DirEntry | FileEntry;
 // Reserve lines for header, search bar, padding, tab bar, status/input bar
 const CHROME_LINES = 8;
 
-export function ContextPanel({ conn, isActive }: ContextPanelProps) {
+export const ContextPanel = memo(function ContextPanel({
+  conn,
+  isActive,
+}: ContextPanelProps) {
   const { stdout } = useStdout();
   const termRows = stdout?.rows ?? 24;
 
@@ -409,4 +412,4 @@ export function ContextPanel({ conn, isActive }: ContextPanelProps) {
       )}
     </Box>
   );
-}
+});

--- a/src/tui/components/HelpPanel.tsx
+++ b/src/tui/components/HelpPanel.tsx
@@ -1,4 +1,5 @@
 import { Box, Text } from "ink";
+import { memo } from "react";
 
 interface HelpPanelProps {
   projectDir: string;
@@ -6,7 +7,7 @@ interface HelpPanelProps {
   daemonRunning: boolean;
 }
 
-export function HelpPanel({
+export const HelpPanel = memo(function HelpPanel({
   projectDir,
   threadId,
   daemonRunning,
@@ -162,4 +163,4 @@ export function HelpPanel({
       </Box>
     </Box>
   );
-}
+});

--- a/src/tui/components/InputBar.tsx
+++ b/src/tui/components/InputBar.tsx
@@ -1,6 +1,12 @@
 import { Box, Text, useInput } from "ink";
-import type { ReactNode } from "react";
-import { useEffect, useRef, useState } from "react";
+import {
+  memo,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 
 interface InputBarProps {
   value: string;
@@ -11,7 +17,7 @@ interface InputBarProps {
   header?: ReactNode;
 }
 
-export function InputBar({
+export const InputBar = memo(function InputBar({
   value,
   onChange,
   onSubmit,
@@ -25,7 +31,24 @@ export function InputBar({
   const savedInput = useRef("");
   const lastActivity = useRef(Date.now());
 
-  // Blink cursor when input is active
+  // Refs for values read inside the input handler — eagerly updated so rapid
+  // keystrokes that arrive before React re-renders always see fresh state.
+  const valueRef = useRef(value);
+  const cursorPosRef = useRef(cursorPos);
+  const historyIndexRef = useRef(historyIndex);
+  const onChangeRef = useRef(onChange);
+  const onSubmitRef = useRef(onSubmit);
+  const historyRef = useRef(history);
+
+  valueRef.current = value;
+  cursorPosRef.current = cursorPos;
+  historyIndexRef.current = historyIndex;
+  onChangeRef.current = onChange;
+  onSubmitRef.current = onSubmit;
+  historyRef.current = history;
+
+  // Blink cursor when input is active — skip ticks while typing so the
+  // cursor stays solid and we avoid unnecessary renders during rapid input.
   useEffect(() => {
     if (disabled) {
       setCursorVisible(true);
@@ -33,85 +56,119 @@ export function InputBar({
     }
     const id = setInterval(() => {
       const elapsed = Date.now() - lastActivity.current;
+      if (elapsed < 530) return; // still typing — keep cursor solid
       const phase = Math.floor(elapsed / 530) % 2 === 0;
-      setCursorVisible(phase);
+      setCursorVisible((prev) => (prev === phase ? prev : phase));
     }, 530);
     return () => clearInterval(id);
   }, [disabled]);
 
-  useInput(
-    (input, key) => {
+  // Stable input handler — the callback reference never changes, which
+  // prevents Ink's useInput from removing/re-adding the stdin listener on
+  // every render. Without this, rapid typing causes listener churn that
+  // overwhelms the event loop and pegs the CPU at 100%.
+  const stableHandler = useCallback(
+    // biome-ignore lint/suspicious/noExplicitAny: Ink's Key type is not exported
+    (input: string, key: any) => {
       if (disabled) return;
       lastActivity.current = Date.now();
-      setCursorVisible(true);
+
+      const val = valueRef.current;
+      const pos = cursorPosRef.current;
+      const hIdx = historyIndexRef.current;
+      const hist = historyRef.current;
 
       // Enter: submit (shift+enter or opt+enter inserts newline)
       if (key.return) {
         if (key.shift || key.meta) {
-          const before = value.slice(0, cursorPos);
-          const after = value.slice(cursorPos);
-          onChange(`${before}\n${after}`);
-          setCursorPos(cursorPos + 1);
+          const before = val.slice(0, pos);
+          const after = val.slice(pos);
+          const newVal = `${before}\n${after}`;
+          const newPos = pos + 1;
+          valueRef.current = newVal;
+          cursorPosRef.current = newPos;
+          onChangeRef.current(newVal);
+          setCursorPos(newPos);
         } else {
+          historyIndexRef.current = -1;
           setHistoryIndex(-1);
           savedInput.current = "";
+          cursorPosRef.current = 0;
           setCursorPos(0);
-          onSubmit(value);
+          onSubmitRef.current(val);
         }
         return;
       }
 
       // Backspace
       if (key.backspace || key.delete) {
-        if (cursorPos > 0) {
-          const before = value.slice(0, cursorPos - 1);
-          const after = value.slice(cursorPos);
-          onChange(before + after);
-          setCursorPos(cursorPos - 1);
+        if (pos > 0) {
+          const before = val.slice(0, pos - 1);
+          const after = val.slice(pos);
+          const newVal = before + after;
+          const newPos = pos - 1;
+          valueRef.current = newVal;
+          cursorPosRef.current = newPos;
+          onChangeRef.current(newVal);
+          setCursorPos(newPos);
         }
         return;
       }
 
       // Left/right arrow for cursor movement
       if (key.leftArrow) {
-        setCursorPos((c) => Math.max(0, c - 1));
+        const newPos = Math.max(0, pos - 1);
+        cursorPosRef.current = newPos;
+        setCursorPos(newPos);
         return;
       }
       if (key.rightArrow) {
-        setCursorPos((c) => Math.min(value.length, c + 1));
+        const newPos = Math.min(val.length, pos + 1);
+        cursorPosRef.current = newPos;
+        setCursorPos(newPos);
         return;
       }
 
       // History navigation
-      if (key.upArrow && history.length > 0) {
-        const nextIndex = historyIndex + 1;
-        if (nextIndex < history.length) {
-          if (historyIndex === -1) {
-            savedInput.current = value;
+      if (key.upArrow && hist.length > 0) {
+        const nextIndex = hIdx + 1;
+        if (nextIndex < hist.length) {
+          if (hIdx === -1) {
+            savedInput.current = val;
           }
+          historyIndexRef.current = nextIndex;
           setHistoryIndex(nextIndex);
-          const entry = history[history.length - 1 - nextIndex];
+          const entry = hist[hist.length - 1 - nextIndex];
           if (entry !== undefined) {
-            onChange(entry);
+            valueRef.current = entry;
+            cursorPosRef.current = entry.length;
+            onChangeRef.current(entry);
             setCursorPos(entry.length);
           }
         }
         return;
       }
 
-      if (key.downArrow && history.length > 0) {
-        if (historyIndex > 0) {
-          const nextIndex = historyIndex - 1;
+      if (key.downArrow && hist.length > 0) {
+        if (hIdx > 0) {
+          const nextIndex = hIdx - 1;
+          historyIndexRef.current = nextIndex;
           setHistoryIndex(nextIndex);
-          const entry = history[history.length - 1 - nextIndex];
+          const entry = hist[hist.length - 1 - nextIndex];
           if (entry !== undefined) {
-            onChange(entry);
+            valueRef.current = entry;
+            cursorPosRef.current = entry.length;
+            onChangeRef.current(entry);
             setCursorPos(entry.length);
           }
-        } else if (historyIndex === 0) {
+        } else if (hIdx === 0) {
+          historyIndexRef.current = -1;
           setHistoryIndex(-1);
-          onChange(savedInput.current);
-          setCursorPos(savedInput.current.length);
+          const saved = savedInput.current;
+          valueRef.current = saved;
+          cursorPosRef.current = saved.length;
+          onChangeRef.current(saved);
+          setCursorPos(saved.length);
         }
         return;
       }
@@ -123,17 +180,24 @@ export function InputBar({
 
       // Regular character input
       if (input) {
-        if (historyIndex !== -1) {
+        if (hIdx !== -1) {
+          historyIndexRef.current = -1;
           setHistoryIndex(-1);
         }
-        const before = value.slice(0, cursorPos);
-        const after = value.slice(cursorPos);
-        onChange(before + input + after);
-        setCursorPos(cursorPos + input.length);
+        const before = val.slice(0, pos);
+        const after = val.slice(pos);
+        const newVal = before + input + after;
+        const newPos = pos + input.length;
+        valueRef.current = newVal;
+        cursorPosRef.current = newPos;
+        onChangeRef.current(newVal);
+        setCursorPos(newPos);
       }
     },
-    { isActive: !disabled },
+    [disabled],
   );
+
+  useInput(stableHandler, { isActive: !disabled });
 
   const isMultiline = value.includes("\n");
   const placeholder = !value && !disabled;
@@ -169,4 +233,4 @@ export function InputBar({
       )}
     </Box>
   );
-}
+});

--- a/src/tui/components/TaskPanel.tsx
+++ b/src/tui/components/TaskPanel.tsx
@@ -1,5 +1,5 @@
 import { Box, Text, useInput, useStdout } from "ink";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import type { DbConnection } from "../../db/connection.ts";
 import {
   deleteTask,
@@ -138,7 +138,10 @@ function cycleFilter<T>(current: T | null, values: readonly T[]): T | null {
   return values[idx + 1] ?? null;
 }
 
-export function TaskPanel({ conn, isActive }: TaskPanelProps) {
+export const TaskPanel = memo(function TaskPanel({
+  conn,
+  isActive,
+}: TaskPanelProps) {
   const { stdout } = useStdout();
   const termRows = stdout?.rows ?? 24;
   const [tasks, setTasks] = useState<Task[]>([]);
@@ -403,4 +406,4 @@ export function TaskPanel({ conn, isActive }: TaskPanelProps) {
       </Box>
     </Box>
   );
-}
+});

--- a/src/tui/components/ThreadPanel.tsx
+++ b/src/tui/components/ThreadPanel.tsx
@@ -1,5 +1,5 @@
 import { Box, Text, useInput, useStdout } from "ink";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import type { DbConnection } from "../../db/connection.ts";
 import {
   deleteThread,
@@ -178,7 +178,7 @@ function cycleFilter<T>(current: T | null, values: readonly T[]): T | null {
   return values[idx + 1] ?? null;
 }
 
-export function ThreadPanel({
+export const ThreadPanel = memo(function ThreadPanel({
   conn,
   activeThreadId,
   isActive,
@@ -488,4 +488,4 @@ export function ThreadPanel({
       </Box>
     </Box>
   );
-}
+});

--- a/src/tui/components/ToolPanel.tsx
+++ b/src/tui/components/ToolPanel.tsx
@@ -1,5 +1,5 @@
 import { Box, Text, useInput, useStdout } from "ink";
-import { useEffect, useMemo, useState } from "react";
+import { memo, useEffect, useMemo, useState } from "react";
 import { ansi, theme } from "../theme.ts";
 import { resolveToolDisplay, type ToolCallData } from "./ToolCall.tsx";
 
@@ -115,7 +115,10 @@ function buildDetailAnsi(tool: ToolCallData): string {
 
 const PAGE_SCROLL_LINES = 10;
 
-export function ToolPanel({ toolCalls, isActive }: ToolPanelProps) {
+export const ToolPanel = memo(function ToolPanel({
+  toolCalls,
+  isActive,
+}: ToolPanelProps) {
   const { stdout } = useStdout();
   const termRows = stdout?.rows ?? 24;
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -336,4 +339,4 @@ export function ToolPanel({ toolCalls, isActive }: ToolPanelProps) {
       </Box>
     </Box>
   );
-}
+});


### PR DESCRIPTION
## Summary

- **Stabilize `useInput` callbacks** in InputBar and App using refs so Ink stops re-registering stdin listeners on every render — the primary cause of CPU saturation during rapid typing
- **Switch panel rendering from conditional mount/unmount to `display="none"` toggling** so fast tab switching no longer triggers expensive remount cycles (especially `<Static>` re-rendering the full message history)
- **Wrap all panel components in `React.memo()`** to prevent streaming state updates from cascading unnecessary re-renders to inactive panels
- **Report tool_use blocks early** via the `contentBlock` stream event so the UI shows tool calls as they start rather than waiting for the full response
- **Fix stale closures** in InputBar's input handler by eagerly updating refs, preventing dropped characters during fast typing

## Test plan

- [ ] Launch TUI, type rapidly for several seconds — CPU should stay low, no characters dropped
- [ ] While the agent is streaming a response, rapidly press Tab to cycle through all panels — should remain responsive
- [ ] Verify tool calls appear in the UI as soon as they start streaming (not after the full response)
- [ ] Confirm all panel functionality still works (navigation, filters, search, delete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)