### PR TITLE
Add error-guided recovery and next-action hints to MCP tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ An AI agent for knowledge work. See `docs/plans/README.md` for the milestone roa
 - All database access goes through `src/db/` modules
 - All agent interactions are logged to the threads/interactions tables
 - No filesystem tools for the agent — FS access is abstracted through CRUD modules scoped to `.botholomew/`
+- When designing or modifying agent tools, follow PATs (Patterns for Agentic Tools): https://arcade.dev/patterns/llm.txt — key principles: error-guided recovery, next-action hints, token-efficient outputs, error classification
 
 ## Database Patterns
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "An AI agent for knowledge work",
   "type": "module",
   "bin": {

--- a/src/daemon/llm.ts
+++ b/src/daemon/llm.ts
@@ -181,8 +181,11 @@ async function executeToolCall(
 
   const parsed = tool.inputSchema.safeParse(toolUse.input);
   if (!parsed.success) {
+    const issues = parsed.error.issues
+      .map((i) => `${i.path.join(".")}: ${i.message}`)
+      .join("; ");
     return {
-      output: `Invalid input: ${JSON.stringify(parsed.error)}`,
+      output: `Invalid input for ${toolUse.name}: ${issues}. Check the tool's expected parameters.`,
       terminal: false,
       isError: true,
     };

--- a/src/tools/mcp/exec.ts
+++ b/src/tools/mcp/exec.ts
@@ -11,15 +11,72 @@ const inputSchema = z.object({
     .describe("Tool arguments as a JSON object"),
 });
 
+const errorKindSchema = z
+  .enum(["retryable", "permanent", "input_error", "auth_error"])
+  .optional();
+
 const outputSchema = z.object({
   result: z.string(),
   is_error: z.boolean(),
+  error_kind: errorKindSchema,
+  hint: z.string().optional(),
 });
+
+type ErrorKind = z.infer<typeof errorKindSchema>;
+
+function classifyError(err: unknown): { error_kind: ErrorKind; hint: string } {
+  const msg = String(err).toLowerCase();
+
+  if (
+    msg.includes("econnrefused") ||
+    msg.includes("etimedout") ||
+    msg.includes("enotfound") ||
+    msg.includes("rate limit") ||
+    msg.includes("429") ||
+    msg.includes("503")
+  ) {
+    return {
+      error_kind: "retryable",
+      hint: "Transient network error. Retry after a pause.",
+    };
+  }
+
+  if (
+    msg.includes("401") ||
+    msg.includes("403") ||
+    msg.includes("unauthorized") ||
+    msg.includes("forbidden") ||
+    msg.includes("authentication") ||
+    msg.includes("auth")
+  ) {
+    return {
+      error_kind: "auth_error",
+      hint: "Authentication failed. Check MCP server credentials. Not retryable.",
+    };
+  }
+
+  if (
+    msg.includes("invalid") ||
+    msg.includes("validation") ||
+    msg.includes("required") ||
+    msg.includes("schema")
+  ) {
+    return {
+      error_kind: "input_error",
+      hint: `Tool rejected input. Use mcp_info to check the expected schema for ${msg}, then retry with corrected arguments.`,
+    };
+  }
+
+  return {
+    error_kind: "permanent",
+    hint: "Unexpected error. Use mcp_search to find an alternative tool.",
+  };
+}
 
 export const mcpExecTool = {
   name: "mcp_exec",
   description:
-    "Execute a tool on an MCP server. Use mcp_list_tools or mcp_search to discover available tools first.",
+    "Execute a tool on an MCP server. Use mcp_list_tools or mcp_search to discover available tools first, and mcp_info to check the expected input schema.",
   group: "mcp",
   inputSchema,
   outputSchema,
@@ -27,8 +84,10 @@ export const mcpExecTool = {
     if (!ctx.mcpxClient) {
       return {
         result:
-          "No MCP servers configured. Add servers with `botholomew mcpx add`.",
+          "No MCP servers configured. This task requires external tool access. Add servers with `botholomew mcpx add`.",
         is_error: true,
+        error_kind: "permanent" as const,
+        hint: "Consider calling fail_task noting that MCP servers need to be configured.",
       };
     }
 
@@ -38,14 +97,22 @@ export const mcpExecTool = {
         input.tool,
         input.args,
       );
+      const isError = callResult.isError ?? false;
       return {
         result: formatCallToolResult(callResult),
-        is_error: callResult.isError ?? false,
+        is_error: isError,
+        error_kind: undefined,
+        hint: isError
+          ? "The tool returned an error. Check the error message and use mcp_info to verify you're passing the correct arguments."
+          : undefined,
       };
     } catch (err) {
+      const { error_kind, hint } = classifyError(err);
       return {
         result: `MCP tool error: ${err}`,
         is_error: true,
+        error_kind,
+        hint,
       };
     }
   },

--- a/src/tools/mcp/info.ts
+++ b/src/tools/mcp/info.ts
@@ -12,6 +12,7 @@ const outputSchema = z.object({
   description: z.string(),
   input_schema: z.string(),
   is_error: z.boolean(),
+  hint: z.string().optional(),
 });
 
 export const mcpInfoTool = {
@@ -29,6 +30,7 @@ export const mcpInfoTool = {
         description: "No MCP servers configured.",
         input_schema: "{}",
         is_error: true,
+        hint: "Add MCP servers with `botholomew mcpx add` before using external tools.",
       };
     }
 
@@ -40,6 +42,7 @@ export const mcpInfoTool = {
         description: `Tool "${input.tool}" not found on server "${input.server}".`,
         input_schema: "{}",
         is_error: true,
+        hint: "Tool not found. Use mcp_search or mcp_list_tools to find the correct server and tool name.",
       };
     }
 
@@ -49,6 +52,7 @@ export const mcpInfoTool = {
       description: tool.description ?? "",
       input_schema: JSON.stringify(tool.inputSchema ?? {}, null, 2),
       is_error: false,
+      hint: `Call mcp_exec with server='${input.server}', tool='${tool.name}', and the required args.`,
     };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/mcp/list-tools.ts
+++ b/src/tools/mcp/list-tools.ts
@@ -17,6 +17,7 @@ const ToolEntrySchema = z.object({
 const outputSchema = z.object({
   tools: z.array(ToolEntrySchema),
   is_error: z.boolean(),
+  hint: z.string().optional(),
 });
 
 export const mcpListToolsTool = {
@@ -28,17 +29,26 @@ export const mcpListToolsTool = {
   outputSchema,
   execute: async (input, ctx) => {
     if (!ctx.mcpxClient) {
-      return { tools: [], is_error: false };
+      return {
+        tools: [],
+        is_error: false,
+        hint: "No MCP servers configured. Add servers with `botholomew mcpx add`.",
+      };
     }
 
     const toolsWithServer = await ctx.mcpxClient.listTools(input.server);
+    const mapped = toolsWithServer.map((t) => ({
+      server: t.server,
+      name: t.tool.name,
+      description: t.tool.description ?? "",
+    }));
     return {
-      tools: toolsWithServer.map((t) => ({
-        server: t.server,
-        name: t.tool.name,
-        description: t.tool.description ?? "",
-      })),
+      tools: mapped,
       is_error: false,
+      hint:
+        mapped.length > 0
+          ? "Use mcp_search to find tools by capability, or mcp_info to get the full schema for a specific tool."
+          : "No tools available. MCP servers may not be configured or may be offline.",
     };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/mcp/search.ts
+++ b/src/tools/mcp/search.ts
@@ -24,6 +24,8 @@ const SearchResultSchema = z.object({
 const outputSchema = z.object({
   results: z.array(SearchResultSchema),
   is_error: z.boolean(),
+  error_message: z.string().optional(),
+  hint: z.string().optional(),
 });
 
 export const mcpSearchTool = {
@@ -35,7 +37,11 @@ export const mcpSearchTool = {
   outputSchema,
   execute: async (input, ctx) => {
     if (!ctx.mcpxClient) {
-      return { results: [], is_error: false };
+      return {
+        results: [],
+        is_error: false,
+        hint: "No MCP servers configured. Add servers with `botholomew mcpx add`.",
+      };
     }
 
     try {
@@ -43,18 +49,38 @@ export const mcpSearchTool = {
         keywordOnly: input.keyword_only,
         semanticOnly: input.semantic_only,
       });
+      const mapped = results.map((r) => ({
+        server: r.server,
+        tool: r.tool,
+        description: r.description ?? "",
+        score: r.score,
+        match_type: r.matchType ?? "keyword",
+      }));
       return {
-        results: results.map((r) => ({
-          server: r.server,
-          tool: r.tool,
-          description: r.description ?? "",
-          score: r.score,
-          match_type: r.matchType ?? "keyword",
-        })),
+        results: mapped,
         is_error: false,
+        hint:
+          mapped.length > 0
+            ? "Use mcp_info with server and tool name to see the full input schema before calling mcp_exec."
+            : "No matches. Try broader search terms, or use mcp_list_tools to browse all available tools.",
       };
-    } catch {
-      return { results: [], is_error: true };
+    } catch (err) {
+      const msg = String(err).toLowerCase();
+      const isIndexMissing =
+        msg.includes("index") ||
+        msg.includes("not found") ||
+        msg.includes("no such file");
+
+      return {
+        results: [],
+        is_error: true,
+        error_message: isIndexMissing
+          ? "Search index not built. Run 'botholomew mcpx index' to build it."
+          : `Search failed: ${err}`,
+        hint: isIndexMissing
+          ? "Use mcp_list_tools to browse available tools instead."
+          : "Search temporarily unavailable. Use mcp_list_tools as a fallback.",
+      };
     }
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/test/tools/mcp/exec.test.ts
+++ b/test/tools/mcp/exec.test.ts
@@ -24,6 +24,8 @@ describe("mcp_exec", () => {
     );
     expect(result.is_error).toBe(true);
     expect(result.result).toContain("No MCP servers configured");
+    expect(result.error_kind).toBe("permanent");
+    expect(result.hint).toBeDefined();
   });
 
   test("executes tool and returns formatted result", async () => {
@@ -38,9 +40,11 @@ describe("mcp_exec", () => {
     );
     expect(result.is_error).toBe(false);
     expect(result.result).toBe("Email sent successfully");
+    expect(result.error_kind).toBeUndefined();
+    expect(result.hint).toBeUndefined();
   });
 
-  test("propagates isError from tool result", async () => {
+  test("propagates isError from tool result with hint", async () => {
     const { ctx } = setupToolContext();
     ctx.mcpxClient = mockClient(
       {
@@ -55,13 +59,14 @@ describe("mcp_exec", () => {
     );
     expect(result.is_error).toBe(true);
     expect(result.result).toBe("Auth failed");
+    expect(result.hint).toContain("mcp_info");
   });
 
-  test("handles exec throwing", async () => {
+  test("classifies network errors as retryable", async () => {
     const { ctx } = setupToolContext();
     ctx.mcpxClient = {
       exec: mock(async () => {
-        throw new Error("Connection refused");
+        throw new Error("ECONNREFUSED: connection refused");
       }),
     } as unknown as McpxClient;
 
@@ -70,7 +75,59 @@ describe("mcp_exec", () => {
       ctx,
     );
     expect(result.is_error).toBe(true);
-    expect(result.result).toContain("Connection refused");
+    expect(result.error_kind).toBe("retryable");
+    expect(result.hint).toContain("Retry");
+  });
+
+  test("classifies auth errors", async () => {
+    const { ctx } = setupToolContext();
+    ctx.mcpxClient = {
+      exec: mock(async () => {
+        throw new Error("401 Unauthorized");
+      }),
+    } as unknown as McpxClient;
+
+    const result = await mcpExecTool.execute(
+      { server: "gmail", tool: "send_email" },
+      ctx,
+    );
+    expect(result.is_error).toBe(true);
+    expect(result.error_kind).toBe("auth_error");
+    expect(result.hint).toContain("Not retryable");
+  });
+
+  test("classifies input validation errors", async () => {
+    const { ctx } = setupToolContext();
+    ctx.mcpxClient = {
+      exec: mock(async () => {
+        throw new Error("Validation failed: required field missing");
+      }),
+    } as unknown as McpxClient;
+
+    const result = await mcpExecTool.execute(
+      { server: "gmail", tool: "send_email" },
+      ctx,
+    );
+    expect(result.is_error).toBe(true);
+    expect(result.error_kind).toBe("input_error");
+    expect(result.hint).toContain("mcp_info");
+  });
+
+  test("classifies unknown errors as permanent", async () => {
+    const { ctx } = setupToolContext();
+    ctx.mcpxClient = {
+      exec: mock(async () => {
+        throw new Error("Something completely unexpected");
+      }),
+    } as unknown as McpxClient;
+
+    const result = await mcpExecTool.execute(
+      { server: "gmail", tool: "send_email" },
+      ctx,
+    );
+    expect(result.is_error).toBe(true);
+    expect(result.error_kind).toBe("permanent");
+    expect(result.hint).toContain("alternative tool");
   });
 
   test("passes args through to exec", async () => {

--- a/test/tools/mcp/info.test.ts
+++ b/test/tools/mcp/info.test.ts
@@ -4,7 +4,7 @@ import { mcpInfoTool } from "../../../src/tools/mcp/info.ts";
 import { setupToolContext } from "../../helpers.ts";
 
 describe("mcp_info", () => {
-  test("returns not found when mcpxClient is null", async () => {
+  test("returns not found with hint when mcpxClient is null", async () => {
     const { ctx } = setupToolContext();
     const result = await mcpInfoTool.execute(
       { server: "gmail", tool: "send_email" },
@@ -12,9 +12,10 @@ describe("mcp_info", () => {
     );
     expect(result.found).toBe(false);
     expect(result.description).toContain("No MCP servers configured");
+    expect(result.hint).toContain("botholomew mcpx add");
   });
 
-  test("returns not found for unknown tool", async () => {
+  test("returns not found with discovery hint for unknown tool", async () => {
     const { ctx } = setupToolContext();
     ctx.mcpxClient = {
       info: mock(async () => undefined),
@@ -26,9 +27,10 @@ describe("mcp_info", () => {
     );
     expect(result.found).toBe(false);
     expect(result.description).toContain("not found");
+    expect(result.hint).toContain("mcp_search");
   });
 
-  test("returns tool schema when found", async () => {
+  test("returns tool schema with exec hint when found", async () => {
     const { ctx } = setupToolContext();
     ctx.mcpxClient = {
       info: mock(async () => ({
@@ -56,6 +58,8 @@ describe("mcp_info", () => {
     const schema = JSON.parse(result.input_schema);
     expect(schema.properties.to.type).toBe("string");
     expect(schema.required).toContain("to");
+    expect(result.hint).toContain("mcp_exec");
+    expect(result.hint).toContain("gmail");
   });
 
   test("handles tool with no inputSchema", async () => {
@@ -73,5 +77,6 @@ describe("mcp_info", () => {
     );
     expect(result.found).toBe(true);
     expect(result.input_schema).toBe("{}");
+    expect(result.hint).toContain("mcp_exec");
   });
 });

--- a/test/tools/mcp/list-tools.test.ts
+++ b/test/tools/mcp/list-tools.test.ts
@@ -20,13 +20,14 @@ function mockClient(
 }
 
 describe("mcp_list_tools", () => {
-  test("returns empty array when mcpxClient is null", async () => {
+  test("returns empty array with hint when mcpxClient is null", async () => {
     const { ctx } = setupToolContext();
     const result = await mcpListToolsTool.execute({}, ctx);
     expect(result.tools).toEqual([]);
+    expect(result.hint).toContain("No MCP servers configured");
   });
 
-  test("lists all tools from all servers", async () => {
+  test("lists all tools with next-action hint", async () => {
     const { ctx } = setupToolContext();
     ctx.mcpxClient = mockClient([
       { server: "gmail", name: "send_email", description: "Send email" },
@@ -40,6 +41,7 @@ describe("mcp_list_tools", () => {
       name: "send_email",
       description: "Send email",
     });
+    expect(result.hint).toContain("mcp_search");
   });
 
   test("filters by server name", async () => {
@@ -52,5 +54,14 @@ describe("mcp_list_tools", () => {
     const result = await mcpListToolsTool.execute({ server: "gmail" }, ctx);
     expect(result.tools).toHaveLength(1);
     expect(result.tools[0]?.server).toBe("gmail");
+  });
+
+  test("returns appropriate hint when no tools available", async () => {
+    const { ctx } = setupToolContext();
+    ctx.mcpxClient = mockClient([]);
+
+    const result = await mcpListToolsTool.execute({}, ctx);
+    expect(result.tools).toEqual([]);
+    expect(result.hint).toContain("No tools available");
   });
 });

--- a/test/tools/mcp/search.test.ts
+++ b/test/tools/mcp/search.test.ts
@@ -18,13 +18,14 @@ function mockClient(
 }
 
 describe("mcp_search", () => {
-  test("returns empty results when mcpxClient is null", async () => {
+  test("returns empty results with hint when mcpxClient is null", async () => {
     const { ctx } = setupToolContext();
     const result = await mcpSearchTool.execute({ query: "email" }, ctx);
     expect(result.results).toEqual([]);
+    expect(result.hint).toContain("No MCP servers configured");
   });
 
-  test("returns search results", async () => {
+  test("returns search results with next-action hint", async () => {
     const { ctx } = setupToolContext();
     ctx.mcpxClient = mockClient([
       {
@@ -45,17 +46,46 @@ describe("mcp_search", () => {
       score: 0.95,
       match_type: "both",
     });
+    expect(result.hint).toContain("mcp_info");
   });
 
-  test("returns empty results when search throws", async () => {
+  test("returns hint for empty results", async () => {
+    const { ctx } = setupToolContext();
+    ctx.mcpxClient = mockClient([]);
+
+    const result = await mcpSearchTool.execute({ query: "nonexistent" }, ctx);
+    expect(result.results).toEqual([]);
+    expect(result.is_error).toBe(false);
+    expect(result.hint).toContain("mcp_list_tools");
+  });
+
+  test("returns error_message when search index is missing", async () => {
     const { ctx } = setupToolContext();
     ctx.mcpxClient = {
       search: mock(async () => {
-        throw new Error("No search index");
+        throw new Error("Search index not found");
       }),
     } as unknown as McpxClient;
 
     const result = await mcpSearchTool.execute({ query: "email" }, ctx);
     expect(result.results).toEqual([]);
+    expect(result.is_error).toBe(true);
+    expect(result.error_message).toContain("Search index not built");
+    expect(result.hint).toContain("mcp_list_tools");
+  });
+
+  test("returns error_message for generic search failure", async () => {
+    const { ctx } = setupToolContext();
+    ctx.mcpxClient = {
+      search: mock(async () => {
+        throw new Error("Something broke");
+      }),
+    } as unknown as McpxClient;
+
+    const result = await mcpSearchTool.execute({ query: "email" }, ctx);
+    expect(result.results).toEqual([]);
+    expect(result.is_error).toBe(true);
+    expect(result.error_message).toContain("Search failed");
+    expect(result.hint).toContain("fallback");
   });
 });


### PR DESCRIPTION
## Summary

Applies [PATs (Patterns for Agentic Tools)](https://arcade.dev/patterns/llm.txt) principles to all four MCP tools. Adds error classification in `mcp_exec` (retryable/permanent/auth_error/input_error) with actionable recovery hints, next-action hints guiding the agent through the search→info→exec workflow, and graceful degradation in `mcp_search` that distinguishes missing index from empty results. Also improves Zod validation error formatting in the agent loop and adds a PATs reference to CLAUDE.md.

## Test plan

- [x] `bun run lint` passes
- [x] `bun test` — 406 pass, 0 fail
- [x] 21 MCP tool tests cover hints, error classification, and graceful degradation
- [ ] Manual: run a task using MCP tools to verify hints appear in interaction logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)