### PR TITLE
Fix autorelease binary build by excluding react-devtools-core

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -113,6 +113,7 @@ jobs:
       - name: Build binary
         run: |
           bun build --compile --minify --sourcemap \
+            --external react-devtools-core \
             --target=${{ matrix.target }} \
             ./src/cli.ts --outfile dist/${{ matrix.artifact }}
       - name: Upload to release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "An AI agent for knowledge work",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Add `--external react-devtools-core` to the `build-binaries` workflow step, matching the existing `package.json` build script
- The autorelease failed because `react-devtools-core` (an optional Ink dependency) isn't installed in CI and wasn't excluded from the bundle
- Bump version to 0.3.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)