### PR TITLE
Make thread title italic in TUI chat and status bar

### DIFF
--- a/src/tui/components/StatusBar.tsx
+++ b/src/tui/components/StatusBar.tsx
@@ -65,7 +65,7 @@ export function StatusBar({
       {chatTitle && (
         <>
           <Text dimColor> | </Text>
-          <Text color="cyan" bold>
+          <Text color="cyan" bold italic>
             {chatTitle.length > 30 ? `${chatTitle.slice(0, 29)}…` : chatTitle}
           </Text>
         </>

--- a/src/tui/components/ThreadPanel.tsx
+++ b/src/tui/components/ThreadPanel.tsx
@@ -80,7 +80,7 @@ function buildThreadDetailAnsi(
   const lines: string[] = [];
 
   lines.push(
-    `${ansi.bold}${ansi.info}${thread.title || "(untitled)"}${ansi.reset}`,
+    `${ansi.bold}${ansi.italic}${ansi.info}${thread.title || "(untitled)"}${ansi.reset}`,
   );
   lines.push("");
 

--- a/src/tui/theme.ts
+++ b/src/tui/theme.ts
@@ -61,6 +61,7 @@ export const theme = {
 export const ansi = {
   reset: "\x1b[0m",
   bold: "\x1b[1m",
+  italic: "\x1b[3m",
   dim: "\x1b[2m",
   success: "\x1b[32m",
   error: "\x1b[31m",


### PR DESCRIPTION
## Summary
- Adds italic styling to the thread title in both the TUI chat detail panel and the status bar
- Adds a reusable `italic` ANSI escape code to the theme module

## Test plan
- [ ] Open the TUI and verify thread titles appear italic in the chat panel
- [ ] Verify thread titles appear italic in the status bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)