### PR TITLE
Remove binary build from autorelease

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -85,38 +85,3 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-  build-binaries:
-    needs: [check-version, ci]
-    if: needs.check-version.outputs.should_release == 'true'
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - target: bun-darwin-arm64
-            artifact: botholomew-darwin-arm64
-          - target: bun-darwin-x64
-            artifact: botholomew-darwin-x64
-          - target: bun-linux-arm64
-            artifact: botholomew-linux-arm64
-          - target: bun-linux-x64
-            artifact: botholomew-linux-x64
-          - target: bun-windows-x64
-            artifact: botholomew-windows-x64.exe
-          - target: bun-windows-arm64
-            artifact: botholomew-windows-arm64.exe
-    steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-      - run: bun install --frozen-lockfile
-      - name: Build binary
-        run: |
-          bun build --compile --minify --sourcemap \
-            --external react-devtools-core \
-            --target=${{ matrix.target }} \
-            ./src/cli.ts --outfile dist/${{ matrix.artifact }}
-      - name: Upload to release
-        run: gh release upload "${{ needs.check-version.outputs.tag }}" dist/${{ matrix.artifact }} --clobber
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,6 @@ on:
   pull_request:
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
-      - run: bun install --frozen-lockfile
-      - run: bun run build
-
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -33,7 +25,7 @@ jobs:
   complete:
     runs-on: ubuntu-latest
     if: always()
-    needs: [build, lint, test]
+    needs: [lint, test]
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: exit 1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "An AI agent for knowledge work",
   "type": "module",
   "bin": {
@@ -19,7 +19,6 @@
     "dev": "bun run src/cli.ts",
     "dev:demo": "bun run src/cli.ts chat -p 'learn everything you can about me from the connected MCP services and then save what you'\\''ve learned about me to context'",
     "test": "bun test",
-    "build": "bun build --compile --minify --sourcemap --external react-devtools-core ./src/cli.ts --outfile dist/botholomew",
     "lint": "tsc --noEmit && biome check ."
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Removes the `build-binaries` job from the autorelease workflow
- Removes the `build` script from package.json
- Bumps version to 0.3.4

Native modules (`onnxruntime-node`, `sharp`) from `@huggingface/transformers` cannot be cross-compiled or embedded in `bun build --compile` standalone binaries. This caused `build-binaries` to fail on every release since PR #68. Distribution is now npm/bunx only.

## Test plan
- [x] `bun run lint` passes
- [x] `bun test` passes (405/406, 1 pre-existing timeout in semantic search)
- [ ] Verify autorelease workflow succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)