### PR TITLE
Fix border crash when deleting threads on non-Chat tabs

### DIFF
--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -1,4 +1,4 @@
-import { Box, Text, useApp, useInput } from "ink";
+import { Box, Static, Text, useApp, useInput } from "ink";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   type ChatSession,
@@ -13,7 +13,11 @@ import { ContextPanel } from "./components/ContextPanel.tsx";
 import { HelpPanel } from "./components/HelpPanel.tsx";
 import { InputBar } from "./components/InputBar.tsx";
 import { AnimatedLogo } from "./components/Logo.tsx";
-import { type ChatMessage, MessageList } from "./components/MessageList.tsx";
+import {
+  type ChatMessage,
+  MessageBubble,
+  MessageList,
+} from "./components/MessageList.tsx";
 import { QueuePanel } from "./components/QueuePanel.tsx";
 import { StatusBar } from "./components/StatusBar.tsx";
 import { TabBar, type TabId } from "./components/TabBar.tsx";
@@ -520,9 +524,17 @@ export function App({
 
   return (
     <Box flexDirection="column" height="100%">
+      {/* Completed messages — rendered once to terminal scrollback.
+          Must live outside the display="none" tab wrappers so the <Static>
+          node always has proper terminal width in its Yoga layout.
+          Otherwise Ink's border renderer crashes with a negative
+          contentWidth when tool-call boxes are rendered at width 0. */}
+      <Static items={messages}>
+        {(msg) => <MessageBubble key={msg.id} message={msg} />}
+      </Static>
+
       {/* Tab content area — all panels stay mounted to avoid expensive
-          remount cycles (especially <Static> in MessageList re-rendering
-          the entire history). display="none" hides inactive panels from
+          remount cycles. display="none" hides inactive panels from
           layout without destroying them. */}
       <Box
         display={activeTab === 1 ? "flex" : "none"}
@@ -530,7 +542,6 @@ export function App({
         flexGrow={1}
       >
         <MessageList
-          messages={messages}
           streamingText={streamingText}
           isLoading={isLoading}
           activeToolCalls={activeToolCalls}

--- a/src/tui/components/MessageList.tsx
+++ b/src/tui/components/MessageList.tsx
@@ -1,4 +1,4 @@
-import { Box, Static, Text, useStdout } from "ink";
+import { Box, Text, useStdout } from "ink";
 import Spinner from "ink-spinner";
 import { memo, useMemo } from "react";
 import { theme } from "../theme.ts";
@@ -13,7 +13,6 @@ export interface ChatMessage {
 }
 
 interface MessageListProps {
-  messages: ChatMessage[];
   streamingText: string;
   isLoading: boolean;
   activeToolCalls: ToolCallData[];
@@ -54,7 +53,7 @@ function renderMarkdown(text: string): string {
   return Bun.markdown.ansi(text).trimEnd();
 }
 
-const MessageBubble = memo(function MessageBubble({
+export const MessageBubble = memo(function MessageBubble({
   message,
 }: {
   message: ChatMessage;
@@ -129,18 +128,12 @@ const MessageBubble = memo(function MessageBubble({
 });
 
 export function MessageList({
-  messages,
   streamingText,
   isLoading,
   activeToolCalls,
 }: MessageListProps) {
   return (
     <>
-      {/* Completed messages — rendered once to terminal scrollback */}
-      <Static items={messages}>
-        {(msg) => <MessageBubble key={msg.id} message={msg} />}
-      </Static>
-
       {/* Dynamic area — streaming content, managed by Ink */}
       {(streamingText || activeToolCalls.length > 0) && (
         <Box flexDirection="column" marginTop={1}>


### PR DESCRIPTION
## Summary

Fixes a `RangeError` in Ink's `render-border.js` when deleting a thread while on the Threads tab. The `<Static>` component (completed chat messages with bordered tool-call boxes) was inside the Chat tab's `display="none"` wrapper. Ink always renders the static node tree separately on every render cycle, but `display: none` gives children Yoga-computed width=0, causing `box.top.repeat(negative)` to throw.

The fix moves `<Static>` to the top level of the root `<Box>` in `App.tsx` so it always gets proper terminal width, and removes the now-unnecessary `messages` prop from `MessageList`.

## Test plan
- [x] `bun run lint` passes
- [x] `bun test` passes (406/406)
- [ ] Manual: start TUI, send a chat that triggers tool calls, switch to Threads tab, delete a thread — should not crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)