### PR TITLE
Add `context show` command

### DIFF
--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -67,6 +67,36 @@ export function registerContextCommand(program: Command) {
     );
 
   ctx
+    .command("show <path>")
+    .description("Show details and content of a context item")
+    .action((path: string) =>
+      withDb(program, async (conn) => {
+        const item = await getContextItemByPath(conn, path);
+        if (!item) {
+          logger.error(`Context item not found: ${path}`);
+          process.exit(1);
+        }
+
+        console.log(ansis.bold(item.title));
+        console.log(`  Path:        ${item.context_path}`);
+        console.log(`  MIME type:   ${item.mime_type}`);
+        if (item.source_path) console.log(`  Source:      ${item.source_path}`);
+        const indexed = item.indexed_at
+          ? `${ansis.green("yes")} (${fmtDate(item.indexed_at)})`
+          : ansis.dim("no");
+        console.log(`  Indexed:     ${indexed}`);
+        console.log(`  Created:     ${fmtDate(item.created_at)}`);
+        console.log(`  Updated:     ${fmtDate(item.updated_at)}`);
+
+        if (item.is_textual && item.content) {
+          console.log(`\n${"─".repeat(60)}\n${item.content}`);
+        } else if (!item.is_textual) {
+          console.log(ansis.dim("\n  (binary content not shown)"));
+        }
+      }),
+    );
+
+  ctx
     .command("add <paths...>")
     .description("Add files or directories to context")
     .option("--prefix <prefix>", "virtual path prefix", "/")

--- a/test/commands/context-show.test.ts
+++ b/test/commands/context-show.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getDbPath } from "../../src/constants.ts";
+import { getConnection } from "../../src/db/connection.ts";
+import { createContextItem } from "../../src/db/context.ts";
+import { migrate } from "../../src/db/schema.ts";
+import { initProject } from "../../src/init/index.ts";
+
+let tempDir: string;
+
+afterEach(async () => {
+  if (tempDir) {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+const CLI = join(import.meta.dir, "..", "..", "src", "cli.ts");
+
+async function run(
+  args: string[],
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  const proc = Bun.spawn(["bun", CLI, "--dir", tempDir, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, NO_COLOR: "1" },
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const code = await proc.exited;
+  return { code, stdout, stderr };
+}
+
+describe("context show CLI", () => {
+  test("shows details and content of a textual context item", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "botholomew-test-"));
+    await initProject(tempDir);
+
+    const conn = getConnection(getDbPath(tempDir));
+    migrate(conn);
+    await createContextItem(conn, {
+      title: "test.md",
+      content: "# Hello World\n\nSome content here.",
+      contextPath: "/docs/test.md",
+      mimeType: "text/markdown",
+      isTextual: true,
+    });
+    conn.close();
+
+    const result = await run(["context", "show", "/docs/test.md"]);
+    expect(result.code).toBe(0);
+
+    const output = result.stdout + result.stderr;
+    expect(output).toContain("test.md");
+    expect(output).toContain("/docs/test.md");
+    expect(output).toContain("text/markdown");
+    expect(output).toContain("# Hello World");
+    expect(output).toContain("Some content here.");
+  });
+
+  test("exits with error for non-existent path", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "botholomew-test-"));
+    await initProject(tempDir);
+
+    const result = await run(["context", "show", "/no/such/path.md"]);
+    expect(result.code).toBe(1);
+    expect(result.stdout + result.stderr).toContain(
+      "Context item not found: /no/such/path.md",
+    );
+  });
+
+  test("shows binary note for non-textual items", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "botholomew-test-"));
+    await initProject(tempDir);
+
+    const conn = getConnection(getDbPath(tempDir));
+    migrate(conn);
+    await createContextItem(conn, {
+      title: "image.png",
+      contextPath: "/assets/image.png",
+      mimeType: "image/png",
+      isTextual: false,
+    });
+    conn.close();
+
+    const result = await run(["context", "show", "/assets/image.png"]);
+    expect(result.code).toBe(0);
+
+    const output = result.stdout + result.stderr;
+    expect(output).toContain("image.png");
+    expect(output).toContain("image/png");
+    expect(output).toContain("binary content not shown");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `context show <path>` CLI subcommand to display metadata and content of a context item
- Shows title, path, MIME type, source path, indexed status, and timestamps
- Displays full content for textual items; notes binary items as not shown
- Includes 3 tests covering textual items, missing paths, and binary items

## Test plan
- [x] `bun run lint` passes
- [x] `bun test` passes (new tests in `test/commands/context-show.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)