### PR TITLE
Milestone 6: daemon reliability, thread follow, and agent safety

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "An AI agent for knowledge work",
   "type": "module",
   "bin": {

--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -16,25 +16,41 @@ export function registerChatCommand(program: Command) {
     )
     .option("--thread-id <id>", "Resume an existing chat thread")
     .option("-p, --prompt <text>", "Start chat with an initial prompt")
-    .action(async (opts: { threadId?: string; prompt?: string }) => {
-      const { render } = await import("ink");
-      const React = await import("react");
-      const { App } = await import("../tui/App.tsx");
-      const dir = program.opts().dir;
-      const instance = render(
-        React.createElement(App, {
-          projectDir: dir,
-          threadId: opts.threadId,
-          initialPrompt: opts.prompt,
-        }),
-        {
-          exitOnCtrlC: false,
-          kittyKeyboard: {
-            mode: "enabled",
-            flags: ["disambiguateEscapeCodes"],
+    .option("--no-daemon", "don't auto-start the daemon")
+    .action(
+      async (opts: {
+        threadId?: string;
+        prompt?: string;
+        daemon?: boolean;
+      }) => {
+        const { render } = await import("ink");
+        const React = await import("react");
+        const { App } = await import("../tui/App.tsx");
+        const dir = program.opts().dir;
+
+        // Auto-spawn daemon if not running (attached mode)
+        if (opts.daemon !== false) {
+          const { ensureDaemonRunning } = await import(
+            "../daemon/ensure-running.ts"
+          );
+          await ensureDaemonRunning(dir);
+        }
+
+        const instance = render(
+          React.createElement(App, {
+            projectDir: dir,
+            threadId: opts.threadId,
+            initialPrompt: opts.prompt,
+          }),
+          {
+            exitOnCtrlC: false,
+            kittyKeyboard: {
+              mode: "enabled",
+              flags: ["disambiguateEscapeCodes"],
+            },
           },
-        },
-      );
-      await instance.waitUntilExit();
-    });
+        );
+        await instance.waitUntilExit();
+      },
+    );
 }

--- a/src/commands/daemon.ts
+++ b/src/commands/daemon.ts
@@ -7,21 +7,21 @@ export function registerDaemonCommand(program: Command) {
     .description("Manage the Botholomew daemon");
 
   daemon
-    .command("start")
-    .description("Start the daemon for this project")
-    .option("--foreground", "run in the foreground (don't detach)")
-    .action(async (opts) => {
+    .command("run")
+    .description("Run the daemon in the foreground (blocks until stopped)")
+    .action(async () => {
       const dir = program.opts().dir;
+      const { startDaemon } = await import("../daemon/index.ts");
+      await startDaemon(dir);
+    });
 
-      if (opts.foreground) {
-        // Import dynamically to avoid loading daemon code for other commands
-        const { startDaemon } = await import("../daemon/index.ts");
-        await startDaemon(dir);
-      } else {
-        // Spawn detached child process
-        const { spawnDaemon } = await import("../daemon/spawn.ts");
-        await spawnDaemon(dir);
-      }
+  daemon
+    .command("start")
+    .description("Start the daemon as a background process")
+    .action(async () => {
+      const dir = program.opts().dir;
+      const { spawnDaemon } = await import("../daemon/spawn.ts");
+      await spawnDaemon(dir);
     });
 
   daemon
@@ -50,12 +50,90 @@ export function registerDaemonCommand(program: Command) {
       } else {
         logger.dim("Daemon is not running.");
       }
+
+      const { getWatchdogStatus } = await import("../daemon/watchdog.ts");
+      try {
+        const watchdog = await getWatchdogStatus(dir);
+        if (watchdog.installed) {
+          logger.info(`Watchdog: installed (${watchdog.platform})`);
+          if (watchdog.configPath) {
+            logger.dim(`  Config: ${watchdog.configPath}`);
+          }
+        } else {
+          logger.dim("Watchdog: not installed");
+        }
+      } catch {
+        logger.dim("Watchdog: not installed");
+      }
     });
 
   daemon
     .command("install")
     .description("Install OS-level watchdog (launchd/systemd)")
     .action(async () => {
-      logger.warn("Not yet implemented. Coming soon.");
+      const dir = program.opts().dir;
+      const { installWatchdog } = await import("../daemon/watchdog.ts");
+      try {
+        const result = await installWatchdog(dir);
+        logger.success(`Watchdog installed (${result.platform})`);
+        for (const p of result.paths) {
+          logger.dim(`  ${p}`);
+        }
+      } catch (err) {
+        logger.error(
+          `Failed to install watchdog: ${err instanceof Error ? err.message : err}`,
+        );
+      }
+    });
+
+  daemon
+    .command("uninstall")
+    .description("Remove OS-level watchdog")
+    .action(async () => {
+      const dir = program.opts().dir;
+      const { uninstallWatchdog } = await import("../daemon/watchdog.ts");
+      try {
+        const result = await uninstallWatchdog(dir);
+        if (result.removed) {
+          logger.success(`Watchdog removed (${result.platform})`);
+        } else {
+          logger.warn("No watchdog found to remove.");
+        }
+      } catch (err) {
+        logger.error(
+          `Failed to remove watchdog: ${err instanceof Error ? err.message : err}`,
+        );
+      }
+    });
+
+  daemon
+    .command("list")
+    .description("List all registered Botholomew projects on this machine")
+    .action(async () => {
+      const { listAllWatchdogProjects } = await import("../daemon/watchdog.ts");
+      try {
+        const projects = await listAllWatchdogProjects();
+        if (projects.length === 0) {
+          logger.dim("No registered projects found.");
+          return;
+        }
+        for (const p of projects) {
+          logger.info(p.projectDir);
+          logger.dim(`  Config: ${p.configPath}`);
+        }
+      } catch (err) {
+        logger.error(
+          `Failed to list projects: ${err instanceof Error ? err.message : err}`,
+        );
+      }
+    });
+
+  daemon
+    .command("healthcheck")
+    .description("Run health check (used by watchdog)")
+    .action(async () => {
+      const dir = program.opts().dir;
+      const { runHealthCheck } = await import("../daemon/healthcheck.ts");
+      await runHealthCheck(dir);
     });
 }

--- a/src/commands/thread.ts
+++ b/src/commands/thread.ts
@@ -2,7 +2,14 @@ import ansis from "ansis";
 import type { Command } from "commander";
 import type { DbConnection } from "../db/connection.ts";
 import type { Interaction, Thread } from "../db/threads.ts";
-import { deleteThread, getThread, listThreads } from "../db/threads.ts";
+import {
+  deleteThread,
+  getActiveThread,
+  getInteractionsAfter,
+  getThread,
+  isThreadEnded,
+  listThreads,
+} from "../db/threads.ts";
 import { logger } from "../utils/logger.ts";
 import { withDb } from "./with-db.ts";
 
@@ -76,6 +83,87 @@ export function registerThreadCommand(program: Command) {
           process.exit(1);
         }
         logger.success(`Deleted thread: ${resolvedId}`);
+      }),
+    );
+
+  thread
+    .command("follow [id]")
+    .description("Follow a thread live (like tail -f)")
+    .option("-i, --interval <ms>", "poll interval in ms", parseInt)
+    .action((id, opts) =>
+      withDb(program, async (conn) => {
+        let resolvedId: string;
+        if (id) {
+          const found = await resolveThreadId(conn, id);
+          if (!found) {
+            logger.error(`Thread not found: ${id}`);
+            process.exit(1);
+          }
+          resolvedId = found;
+        } else {
+          const active = await getActiveThread(conn);
+          if (!active) {
+            logger.error("No active thread found.");
+            process.exit(1);
+          }
+          resolvedId = active.id;
+        }
+
+        const result = await getThread(conn, resolvedId);
+        if (!result) {
+          logger.error(`Thread not found: ${resolvedId}`);
+          process.exit(1);
+        }
+
+        printThreadDetail(result.thread, result.interactions);
+
+        if (result.thread.ended_at) {
+          logger.dim("Thread already ended.");
+          return;
+        }
+
+        let lastSequence =
+          result.interactions.length > 0
+            ? (result.interactions[result.interactions.length - 1]?.sequence ??
+              0)
+            : 0;
+
+        const pollMs = opts.interval ?? 500;
+        logger.info(
+          `Following thread ${ansis.dim(resolvedId.slice(0, 8))}... (Ctrl+C to stop)`,
+        );
+
+        const interval = setInterval(async () => {
+          try {
+            const newInteractions = await getInteractionsAfter(
+              conn,
+              resolvedId,
+              lastSequence,
+            );
+            for (const i of newInteractions) {
+              printInteraction(i);
+              lastSequence = i.sequence;
+            }
+
+            const ended = await isThreadEnded(conn, resolvedId);
+            if (ended) {
+              logger.dim("Thread ended.");
+              clearInterval(interval);
+              process.exit(0);
+            }
+          } catch {
+            // Transient DB errors (e.g. SQLITE_BUSY) — retry next tick
+          }
+        }, pollMs);
+
+        process.on("SIGINT", () => {
+          clearInterval(interval);
+          console.log();
+          process.exit(0);
+        });
+
+        // Keep the process alive
+        await new Promise(() => {});
       }),
     );
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,6 +22,11 @@ export const EMBEDDING_DIMENSION = 384;
 export const EMBEDDING_MODEL_ID = "Xenova/bge-small-en-v1.5";
 export const EMBEDDING_DTYPE = "fp32";
 
+export const LAUNCHD_LABEL_PREFIX = "com.botholomew.";
+export const SYSTEMD_UNIT_PREFIX = "botholomew-";
+export const LOG_MAX_BYTES = 10 * 1024 * 1024; // 10 MB
+export const WATCHDOG_LOG_FILENAME = "watchdog.log";
+
 export function getBotholomewDir(projectDir: string): string {
   return join(projectDir, BOTHOLOMEW_DIR);
 }
@@ -44,4 +49,21 @@ export function getConfigPath(projectDir: string): string {
 
 export function getMcpxDir(projectDir: string): string {
   return join(projectDir, BOTHOLOMEW_DIR, MCPX_DIR);
+}
+
+export function getWatchdogLogPath(projectDir: string): string {
+  return join(projectDir, BOTHOLOMEW_DIR, WATCHDOG_LOG_FILENAME);
+}
+
+/**
+ * Convert an absolute directory path into a service-name-safe string.
+ * e.g. "/Users/evan/myproject" → "users-evan-myproject"
+ */
+export function sanitizePathForServiceName(projectDir: string): string {
+  return projectDir
+    .toLowerCase()
+    .replace(/[/\\:]+/g, "-")
+    .replace(/^-+/, "")
+    .replace(/-+$/, "")
+    .replace(/-+/g, "-");
 }

--- a/src/daemon/ensure-running.ts
+++ b/src/daemon/ensure-running.ts
@@ -1,0 +1,16 @@
+import { getDaemonStatus } from "../utils/pid.ts";
+import { spawnDaemon } from "./spawn.ts";
+
+/**
+ * If no daemon is running for this project, spawn one in the background.
+ * Returns true if a new daemon was spawned, false if one was already running.
+ */
+export async function ensureDaemonRunning(
+  projectDir: string,
+): Promise<boolean> {
+  const status = await getDaemonStatus(projectDir);
+  if (status) return false;
+
+  await spawnDaemon(projectDir);
+  return true;
+}

--- a/src/daemon/healthcheck.ts
+++ b/src/daemon/healthcheck.ts
@@ -1,0 +1,47 @@
+import { rename } from "node:fs/promises";
+import { getLogPath, LOG_MAX_BYTES } from "../constants.ts";
+import { isProcessAlive, readPidFile, removePidFile } from "../utils/pid.ts";
+import { spawnDaemon } from "./spawn.ts";
+
+export async function runHealthCheck(projectDir: string): Promise<void> {
+  const pid = await readPidFile(projectDir);
+
+  if (pid !== null) {
+    if (isProcessAlive(pid)) {
+      // Daemon is healthy — nothing to do
+      return;
+    }
+    // Stale PID file — clean it up
+    await removePidFile(projectDir);
+  }
+
+  // Daemon is not running — start it
+  await spawnDaemon(projectDir);
+
+  // Rotate daemon.log if it's too large
+  await rotateLogIfNeeded(projectDir);
+}
+
+export async function rotateLogIfNeeded(projectDir: string): Promise<void> {
+  const logPath = getLogPath(projectDir);
+  const logFile = Bun.file(logPath);
+
+  if (!(await logFile.exists())) return;
+
+  if (logFile.size > LOG_MAX_BYTES) {
+    try {
+      await rename(logPath, `${logPath}.1`);
+    } catch {
+      // Best-effort rotation — don't fail the healthcheck
+    }
+  }
+}
+
+if (import.meta.main) {
+  const projectDir = process.argv[2];
+  if (!projectDir) {
+    console.error("Usage: bun run healthcheck.ts <projectDir>");
+    process.exit(1);
+  }
+  await runHealthCheck(projectDir);
+}

--- a/src/daemon/watchdog.ts
+++ b/src/daemon/watchdog.ts
@@ -1,0 +1,306 @@
+import { unlink } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+  getWatchdogLogPath,
+  LAUNCHD_LABEL_PREFIX,
+  SYSTEMD_UNIT_PREFIX,
+  sanitizePathForServiceName,
+} from "../constants.ts";
+import {
+  listRegisteredProjects,
+  registerProject,
+  unregisterProject,
+} from "../utils/project-registry.ts";
+
+export type Platform = "macos" | "linux";
+
+export function detectPlatform(): Platform {
+  if (process.platform === "darwin") return "macos";
+  if (process.platform === "linux") return "linux";
+  throw new Error(`Unsupported platform: ${process.platform}`);
+}
+
+function getServiceName(projectDir: string): string {
+  return sanitizePathForServiceName(resolve(projectDir));
+}
+
+function getHealthcheckCommand(projectDir: string): string[] {
+  const healthcheckScript = new URL("./healthcheck.ts", import.meta.url)
+    .pathname;
+  return ["bun", "run", healthcheckScript, resolve(projectDir)];
+}
+
+function getLaunchdLabel(projectDir: string): string {
+  return `${LAUNCHD_LABEL_PREFIX}${getServiceName(projectDir)}`;
+}
+
+function getLaunchdPlistPath(projectDir: string): string {
+  return join(
+    homedir(),
+    "Library",
+    "LaunchAgents",
+    `${getLaunchdLabel(projectDir)}.plist`,
+  );
+}
+
+function getSystemdBaseName(projectDir: string): string {
+  return `${SYSTEMD_UNIT_PREFIX}${getServiceName(projectDir)}`;
+}
+
+function getSystemdDir(): string {
+  return join(homedir(), ".config", "systemd", "user");
+}
+
+export function generateLaunchdPlist(
+  projectDir: string,
+  healthcheckCmd: string[],
+): string {
+  const absDir = resolve(projectDir);
+  const label = getLaunchdLabel(absDir);
+  const watchdogLog = getWatchdogLogPath(absDir);
+
+  const programArgs = healthcheckCmd
+    .map((arg) => `    <string>${escapeXml(arg)}</string>`)
+    .join("\n");
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${escapeXml(label)}</string>
+  <key>ProgramArguments</key>
+  <array>
+${programArgs}
+  </array>
+  <key>StartInterval</key>
+  <integer>60</integer>
+  <key>KeepAlive</key>
+  <false/>
+  <key>StandardOutPath</key>
+  <string>${escapeXml(watchdogLog)}</string>
+  <key>StandardErrorPath</key>
+  <string>${escapeXml(watchdogLog)}</string>
+</dict>
+</plist>
+`;
+}
+
+export function generateSystemdService(
+  projectDir: string,
+  healthcheckCmd: string[],
+): string {
+  const absDir = resolve(projectDir);
+  return `[Unit]
+Description=Botholomew healthcheck for ${absDir}
+
+[Service]
+Type=oneshot
+ExecStart=${healthcheckCmd.join(" ")}
+
+[Install]
+WantedBy=default.target
+`;
+}
+
+export function generateSystemdTimer(serviceName: string): string {
+  return `[Unit]
+Description=Botholomew watchdog timer for ${serviceName}
+
+[Timer]
+OnBootSec=60
+OnUnitActiveSec=60
+
+[Install]
+WantedBy=timers.target
+`;
+}
+
+export function generateWatchdogConfig(projectDir: string): {
+  platform: Platform;
+  files: Array<{ path: string; content: string }>;
+} {
+  const absDir = resolve(projectDir);
+  const platform = detectPlatform();
+  const cmd = getHealthcheckCommand(absDir);
+
+  if (platform === "macos") {
+    return {
+      platform,
+      files: [
+        {
+          path: getLaunchdPlistPath(absDir),
+          content: generateLaunchdPlist(absDir, cmd),
+        },
+      ],
+    };
+  }
+
+  const baseName = getSystemdBaseName(absDir);
+  const systemdDir = getSystemdDir();
+  return {
+    platform,
+    files: [
+      {
+        path: join(systemdDir, `${baseName}.service`),
+        content: generateSystemdService(absDir, cmd),
+      },
+      {
+        path: join(systemdDir, `${baseName}.timer`),
+        content: generateSystemdTimer(baseName),
+      },
+    ],
+  };
+}
+
+export async function installWatchdog(projectDir: string): Promise<{
+  installed: boolean;
+  platform: Platform;
+  paths: string[];
+}> {
+  const absDir = resolve(projectDir);
+  const config = generateWatchdogConfig(absDir);
+  const paths: string[] = [];
+
+  for (const file of config.files) {
+    await Bun.write(file.path, file.content);
+    paths.push(file.path);
+  }
+
+  if (config.platform === "macos") {
+    const plistPath = config.files[0]?.path;
+    if (!plistPath) throw new Error("No plist file generated");
+    const proc = Bun.spawnSync(["launchctl", "load", plistPath]);
+    if (proc.exitCode !== 0) {
+      const stderr = proc.stderr.toString().trim();
+      throw new Error(`launchctl load failed: ${stderr}`);
+    }
+  } else {
+    const baseName = getSystemdBaseName(absDir);
+    const reload = Bun.spawnSync(["systemctl", "--user", "daemon-reload"]);
+    if (reload.exitCode !== 0) {
+      throw new Error(
+        `systemctl daemon-reload failed: ${reload.stderr.toString().trim()}`,
+      );
+    }
+    const enable = Bun.spawnSync([
+      "systemctl",
+      "--user",
+      "enable",
+      "--now",
+      `${baseName}.timer`,
+    ]);
+    if (enable.exitCode !== 0) {
+      throw new Error(
+        `systemctl enable failed: ${enable.stderr.toString().trim()}`,
+      );
+    }
+  }
+
+  await registerProject(absDir);
+
+  return { installed: true, platform: config.platform, paths };
+}
+
+export async function uninstallWatchdog(projectDir: string): Promise<{
+  removed: boolean;
+  platform: Platform;
+}> {
+  const absDir = resolve(projectDir);
+  const platform = detectPlatform();
+
+  if (platform === "macos") {
+    const plistPath = getLaunchdPlistPath(absDir);
+    const file = Bun.file(plistPath);
+    if (!(await file.exists())) {
+      return { removed: false, platform };
+    }
+    Bun.spawnSync(["launchctl", "unload", plistPath]);
+    try {
+      await unlink(plistPath);
+    } catch {
+      // ignore
+    }
+  } else {
+    const baseName = getSystemdBaseName(absDir);
+    Bun.spawnSync([
+      "systemctl",
+      "--user",
+      "disable",
+      "--now",
+      `${baseName}.timer`,
+    ]);
+    const systemdDir = getSystemdDir();
+    for (const ext of [".service", ".timer"]) {
+      try {
+        await unlink(join(systemdDir, `${baseName}${ext}`));
+      } catch {
+        // ignore
+      }
+    }
+    Bun.spawnSync(["systemctl", "--user", "daemon-reload"]);
+  }
+
+  await unregisterProject(absDir);
+
+  return { removed: true, platform };
+}
+
+export async function getWatchdogStatus(projectDir: string): Promise<{
+  installed: boolean;
+  platform: Platform;
+  configPath?: string;
+}> {
+  const absDir = resolve(projectDir);
+  const platform = detectPlatform();
+
+  if (platform === "macos") {
+    const plistPath = getLaunchdPlistPath(absDir);
+    const exists = await Bun.file(plistPath).exists();
+    return {
+      installed: exists,
+      platform,
+      configPath: exists ? plistPath : undefined,
+    };
+  }
+
+  const baseName = getSystemdBaseName(absDir);
+  const timerPath = join(getSystemdDir(), `${baseName}.timer`);
+  const exists = await Bun.file(timerPath).exists();
+  return {
+    installed: exists,
+    platform,
+    configPath: exists ? timerPath : undefined,
+  };
+}
+
+export async function listAllWatchdogProjects(): Promise<
+  Array<{ projectDir: string; configPath: string }>
+> {
+  const projects = await listRegisteredProjects();
+  const platform = detectPlatform();
+  const results: Array<{ projectDir: string; configPath: string }> = [];
+
+  for (const project of projects) {
+    let configPath: string;
+    if (platform === "macos") {
+      configPath = getLaunchdPlistPath(project.projectDir);
+    } else {
+      const baseName = getSystemdBaseName(project.projectDir);
+      configPath = join(getSystemdDir(), `${baseName}.timer`);
+    }
+    results.push({ projectDir: project.projectDir, configPath });
+  }
+
+  return results;
+}
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}

--- a/src/db/threads.ts
+++ b/src/db/threads.ts
@@ -192,6 +192,41 @@ export async function deleteThread(
   return result.changes > 0;
 }
 
+export async function getInteractionsAfter(
+  db: DbConnection,
+  threadId: string,
+  afterSequence: number,
+): Promise<Interaction[]> {
+  const rows = db
+    .query(
+      `SELECT * FROM interactions WHERE thread_id = ?1 AND sequence > ?2 ORDER BY sequence ASC`,
+    )
+    .all(threadId, afterSequence) as InteractionRow[];
+  return rows.map(rowToInteraction);
+}
+
+export async function getActiveThread(
+  db: DbConnection,
+): Promise<Thread | null> {
+  const row = db
+    .query(
+      `SELECT * FROM threads WHERE ended_at IS NULL ORDER BY started_at DESC LIMIT 1`,
+    )
+    .get() as ThreadRow | null;
+  return row ? rowToThread(row) : null;
+}
+
+export async function isThreadEnded(
+  db: DbConnection,
+  threadId: string,
+): Promise<boolean> {
+  const row = db
+    .query(`SELECT ended_at FROM threads WHERE id = ?1`)
+    .get(threadId) as { ended_at: string | null } | null;
+  if (!row) return true;
+  return row.ended_at !== null;
+}
+
 export async function listThreads(
   db: DbConnection,
   filters?: {

--- a/src/tools/context/update-beliefs.ts
+++ b/src/tools/context/update-beliefs.ts
@@ -42,6 +42,14 @@ export const updateBeliefsTool = {
       const raw = await file.text();
       const parsed = parseContextFile(raw);
       meta = parsed.meta;
+
+      if (!meta["agent-modification"]) {
+        return {
+          message: "Agent modification not allowed for this file",
+          path: filePath,
+          is_error: true,
+        };
+      }
     }
 
     const serialized = serializeContextFile(meta, input.content);

--- a/src/tools/context/update-goals.ts
+++ b/src/tools/context/update-goals.ts
@@ -42,6 +42,14 @@ export const updateGoalsTool = {
       const raw = await file.text();
       const parsed = parseContextFile(raw);
       meta = parsed.meta;
+
+      if (!meta["agent-modification"]) {
+        return {
+          message: "Agent modification not allowed for this file",
+          path: filePath,
+          is_error: true,
+        };
+      }
     }
 
     const serialized = serializeContextFile(meta, input.content);

--- a/src/tui/components/ThreadPanel.tsx
+++ b/src/tui/components/ThreadPanel.tsx
@@ -1,10 +1,12 @@
 import { Box, Text, useInput, useStdout } from "ink";
-import { memo, useCallback, useEffect, useMemo, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { DbConnection } from "../../db/connection.ts";
 import {
   deleteThread,
+  getInteractionsAfter,
   getThread,
   type Interaction,
+  isThreadEnded,
   listThreads,
   type Thread,
 } from "../../db/threads.ts";
@@ -197,6 +199,8 @@ export const ThreadPanel = memo(function ThreadPanel({
     thread: Thread;
     interactions: Interaction[];
   } | null>(null);
+  const [following, setFollowing] = useState(false);
+  const lastSeenSequenceRef = useRef(0);
 
   // Fetch thread list
   // biome-ignore lint/correctness/useExhaustiveDependencies: refreshTick triggers manual refresh
@@ -230,10 +234,11 @@ export const ThreadPanel = memo(function ThreadPanel({
     return threads.filter((t) => t.title.toLowerCase().includes(q));
   }, [threads, searchQuery]);
 
-  // Fetch detail for selected thread
+  // Fetch detail for selected thread (skip while following — follow effect handles updates)
   const selectedThread = filteredThreads[selectedIndex];
   // biome-ignore lint/correctness/useExhaustiveDependencies: selectedThread?.id is the intentional trigger
   useEffect(() => {
+    if (following) return;
     let mounted = true;
     if (!selectedThread) {
       setSelectedDetail(null);
@@ -249,7 +254,59 @@ export const ThreadPanel = memo(function ThreadPanel({
     return () => {
       mounted = false;
     };
-  }, [conn, selectedThread?.id]);
+  }, [conn, selectedThread?.id, following]);
+
+  // Follow mode: poll for new interactions every 1s
+  // biome-ignore lint/correctness/useExhaustiveDependencies: following and selectedThread?.id are the intentional triggers
+  useEffect(() => {
+    if (!following || !selectedThread) return;
+    let mounted = true;
+
+    const poll = async () => {
+      try {
+        const newInteractions = await getInteractionsAfter(
+          conn,
+          selectedThread.id,
+          lastSeenSequenceRef.current,
+        );
+        if (!mounted || newInteractions.length === 0) return;
+
+        const maxNewSeq =
+          newInteractions[newInteractions.length - 1]?.sequence ?? 0;
+        lastSeenSequenceRef.current = maxNewSeq;
+
+        setSelectedDetail((prev) => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            interactions: [...prev.interactions, ...newInteractions],
+          };
+        });
+
+        // Auto-scroll will be handled by the detailLines/maxDetailScroll recalc
+        setDetailScroll(Number.MAX_SAFE_INTEGER);
+
+        const ended = await isThreadEnded(conn, selectedThread.id);
+        if (mounted && ended) {
+          setFollowing(false);
+          // Refresh the thread to get the ended_at timestamp
+          const result = await getThread(conn, selectedThread.id);
+          if (mounted && result) {
+            setSelectedDetail(result);
+          }
+        }
+      } catch {
+        // Transient DB errors — retry next tick
+      }
+    };
+
+    poll();
+    const interval = setInterval(poll, 1000);
+    return () => {
+      mounted = false;
+      clearInterval(interval);
+    };
+  }, [conn, following, selectedThread?.id]);
 
   const isActiveSelected = selectedThread?.id === activeThreadId;
 
@@ -277,10 +334,11 @@ export const ThreadPanel = memo(function ThreadPanel({
     ),
   );
 
-  // Reset detail scroll when selection changes
+  // Reset detail scroll and follow mode when selection changes
   // biome-ignore lint/correctness/useExhaustiveDependencies: selectedIndex is the intentional trigger
   useEffect(() => {
     setDetailScroll(0);
+    setFollowing(false);
   }, [selectedIndex]);
 
   const forceRefresh = useCallback(() => {
@@ -388,6 +446,17 @@ export const ThreadPanel = memo(function ThreadPanel({
       if (input === "s" || input === "/") {
         setSearching(true);
         setSearchQuery("");
+        return;
+      }
+      if (input === "w" && selectedThread) {
+        if (following) {
+          setFollowing(false);
+        } else if (!selectedThread.ended_at) {
+          const maxSeq = selectedDetail?.interactions.at(-1)?.sequence ?? 0;
+          lastSeenSequenceRef.current = maxSeq;
+          setFollowing(true);
+          setDetailScroll(maxDetailScroll);
+        }
         return;
       }
     },
@@ -521,9 +590,16 @@ export const ThreadPanel = memo(function ThreadPanel({
         })}
         {detailLines.length > visibleRows && (
           <Box>
+            {following && (
+              <Text color={theme.success} bold>
+                {" "}
+                FOLLOWING{" "}
+              </Text>
+            )}
             <Text dimColor>
-              s search · f filter · ↑↓ select · j/k scroll · d delete · r
-              refresh · [{detailScroll + 1}–
+              s search · f filter · ↑↓ select · j/k scroll · d delete ·
+              {selectedThread && !selectedThread.ended_at ? " w follow ·" : ""}{" "}
+              r refresh · [{detailScroll + 1}–
               {Math.min(detailScroll + visibleRows, detailLines.length)} of{" "}
               {detailLines.length}]
             </Text>
@@ -531,9 +607,19 @@ export const ThreadPanel = memo(function ThreadPanel({
         )}
         {detailLines.length <= visibleRows && <Box flexGrow={1} />}
         {detailLines.length <= visibleRows && (
-          <Text dimColor>
-            s search · f filter · ↑↓ select · d delete · r refresh
-          </Text>
+          <Box>
+            {following && (
+              <Text color={theme.success} bold>
+                {" "}
+                FOLLOWING{" "}
+              </Text>
+            )}
+            <Text dimColor>
+              s search · f filter · ↑↓ select · d delete ·
+              {selectedThread && !selectedThread.ended_at ? " w follow ·" : ""}{" "}
+              r refresh
+            </Text>
+          </Box>
         )}
       </Box>
     </Box>

--- a/src/utils/project-registry.ts
+++ b/src/utils/project-registry.ts
@@ -1,0 +1,48 @@
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { HOME_CONFIG_DIR, sanitizePathForServiceName } from "../constants.ts";
+
+const REGISTRY_PATH = join(HOME_CONFIG_DIR, "projects.json");
+
+interface ProjectEntry {
+  projectDir: string;
+  installedAt: string;
+}
+
+type ProjectRegistry = Record<string, ProjectEntry>;
+
+export async function readRegistry(): Promise<ProjectRegistry> {
+  const file = Bun.file(REGISTRY_PATH);
+  if (!(await file.exists())) return {};
+  try {
+    return (await file.json()) as ProjectRegistry;
+  } catch {
+    return {};
+  }
+}
+
+async function writeRegistry(registry: ProjectRegistry): Promise<void> {
+  await mkdir(HOME_CONFIG_DIR, { recursive: true });
+  await Bun.write(REGISTRY_PATH, `${JSON.stringify(registry, null, 2)}\n`);
+}
+
+export async function registerProject(projectDir: string): Promise<void> {
+  const registry = await readRegistry();
+  const key = sanitizePathForServiceName(projectDir);
+  registry[key] = { projectDir, installedAt: new Date().toISOString() };
+  await writeRegistry(registry);
+}
+
+export async function unregisterProject(projectDir: string): Promise<void> {
+  const registry = await readRegistry();
+  const key = sanitizePathForServiceName(projectDir);
+  delete registry[key];
+  await writeRegistry(registry);
+}
+
+export async function listRegisteredProjects(): Promise<
+  Array<{ projectDir: string; installedAt: string }>
+> {
+  const registry = await readRegistry();
+  return Object.values(registry);
+}

--- a/test/daemon/healthcheck.test.ts
+++ b/test/daemon/healthcheck.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { BOTHOLOMEW_DIR, LOG_MAX_BYTES } from "../../src/constants.ts";
+
+let mockPidValue: number | null = null;
+let mockAlive = false;
+let removePidCalled = false;
+let spawnCalled = false;
+
+mock.module("../../src/utils/pid.ts", () => ({
+  readPidFile: async () => mockPidValue,
+  isProcessAlive: () => mockAlive,
+  removePidFile: async () => {
+    removePidCalled = true;
+  },
+}));
+
+mock.module("../../src/daemon/spawn.ts", () => ({
+  spawnDaemon: async () => {
+    spawnCalled = true;
+  },
+}));
+
+const { runHealthCheck, rotateLogIfNeeded } = await import(
+  "../../src/daemon/healthcheck.ts"
+);
+
+let tempDir: string;
+
+beforeEach(async () => {
+  mockPidValue = null;
+  mockAlive = false;
+  removePidCalled = false;
+  spawnCalled = false;
+  tempDir = await mkdtemp(join(tmpdir(), "bth-hc-"));
+  await Bun.write(join(tempDir, BOTHOLOMEW_DIR, "config.json"), "{}");
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true });
+});
+
+describe("runHealthCheck", () => {
+  test("does nothing when daemon is alive", async () => {
+    mockPidValue = 12345;
+    mockAlive = true;
+
+    await runHealthCheck(tempDir);
+
+    expect(removePidCalled).toBe(false);
+    expect(spawnCalled).toBe(false);
+  });
+
+  test("cleans up stale PID and spawns daemon when process is dead", async () => {
+    mockPidValue = 99999;
+    mockAlive = false;
+
+    await runHealthCheck(tempDir);
+
+    expect(removePidCalled).toBe(true);
+    expect(spawnCalled).toBe(true);
+  });
+
+  test("spawns daemon when no PID file exists", async () => {
+    mockPidValue = null;
+
+    await runHealthCheck(tempDir);
+
+    expect(removePidCalled).toBe(false);
+    expect(spawnCalled).toBe(true);
+  });
+});
+
+describe("rotateLogIfNeeded", () => {
+  test("does nothing when log file does not exist", async () => {
+    await rotateLogIfNeeded(tempDir);
+    // No error thrown
+  });
+
+  test("does nothing when log is under threshold", async () => {
+    const logPath = join(tempDir, BOTHOLOMEW_DIR, "daemon.log");
+    await Bun.write(logPath, "small log content");
+
+    await rotateLogIfNeeded(tempDir);
+
+    // Original file still exists
+    expect(await Bun.file(logPath).exists()).toBe(true);
+    // No rotated file
+    expect(await Bun.file(`${logPath}.1`).exists()).toBe(false);
+  });
+
+  test("rotates log when over threshold", async () => {
+    const logPath = join(tempDir, BOTHOLOMEW_DIR, "daemon.log");
+    // Write a file larger than LOG_MAX_BYTES
+    const largeContent = "x".repeat(LOG_MAX_BYTES + 1024);
+    await Bun.write(logPath, largeContent);
+
+    await rotateLogIfNeeded(tempDir);
+
+    // Original should be gone (renamed)
+    expect(await Bun.file(logPath).exists()).toBe(false);
+    // Rotated file should exist
+    expect(await Bun.file(`${logPath}.1`).exists()).toBe(true);
+  });
+});

--- a/test/daemon/self-modify.test.ts
+++ b/test/daemon/self-modify.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DEFAULT_CONFIG } from "../../src/config/schemas.ts";
+import { BOTHOLOMEW_DIR } from "../../src/constants.ts";
+import { updateBeliefsTool } from "../../src/tools/context/update-beliefs.ts";
+import { updateGoalsTool } from "../../src/tools/context/update-goals.ts";
+import type { ToolContext } from "../../src/tools/tool.ts";
+import {
+  parseContextFile,
+  serializeContextFile,
+} from "../../src/utils/frontmatter.ts";
+import { setupTestDb } from "../helpers.ts";
+
+let tempDir: string;
+let ctx: ToolContext;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "bth-self-modify-"));
+  ctx = {
+    conn: setupTestDb(),
+    projectDir: tempDir,
+    config: { ...DEFAULT_CONFIG },
+    mcpxClient: null,
+  };
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true });
+});
+
+describe("update_beliefs", () => {
+  test("creates beliefs.md with default frontmatter when file does not exist", async () => {
+    const result = await updateBeliefsTool.execute(
+      { content: "I believe in testing." },
+      ctx,
+    );
+
+    expect(result.is_error).toBe(false);
+    expect(result.message).toContain("Updated beliefs.md");
+
+    const filePath = join(tempDir, BOTHOLOMEW_DIR, "beliefs.md");
+    const raw = await Bun.file(filePath).text();
+    const parsed = parseContextFile(raw);
+    expect(parsed.meta.loading).toBe("always");
+    expect(parsed.meta["agent-modification"]).toBe(true);
+    expect(parsed.content).toBe("I believe in testing.");
+  });
+
+  test("preserves existing frontmatter when updating", async () => {
+    const filePath = join(tempDir, BOTHOLOMEW_DIR, "beliefs.md");
+    const original = serializeContextFile(
+      { loading: "always", "agent-modification": true },
+      "Old beliefs",
+    );
+    await Bun.write(filePath, original);
+
+    const result = await updateBeliefsTool.execute(
+      { content: "New beliefs" },
+      ctx,
+    );
+
+    expect(result.is_error).toBe(false);
+    const raw = await Bun.file(filePath).text();
+    const parsed = parseContextFile(raw);
+    expect(parsed.meta.loading).toBe("always");
+    expect(parsed.meta["agent-modification"]).toBe(true);
+    expect(parsed.content).toBe("New beliefs");
+  });
+
+  test("rejects modification when agent-modification is false", async () => {
+    const filePath = join(tempDir, BOTHOLOMEW_DIR, "beliefs.md");
+    const locked = serializeContextFile(
+      { loading: "always", "agent-modification": false },
+      "Protected beliefs",
+    );
+    await Bun.write(filePath, locked);
+
+    const result = await updateBeliefsTool.execute(
+      { content: "Hacked beliefs" },
+      ctx,
+    );
+
+    expect(result.is_error).toBe(true);
+    expect(result.message).toContain("not allowed");
+
+    // Content should be unchanged
+    const raw = await Bun.file(filePath).text();
+    const parsed = parseContextFile(raw);
+    expect(parsed.content).toBe("Protected beliefs");
+  });
+});
+
+describe("update_goals", () => {
+  test("creates goals.md with default frontmatter when file does not exist", async () => {
+    const result = await updateGoalsTool.execute(
+      { content: "Learn everything." },
+      ctx,
+    );
+
+    expect(result.is_error).toBe(false);
+    expect(result.message).toContain("Updated goals.md");
+
+    const filePath = join(tempDir, BOTHOLOMEW_DIR, "goals.md");
+    const raw = await Bun.file(filePath).text();
+    const parsed = parseContextFile(raw);
+    expect(parsed.meta.loading).toBe("always");
+    expect(parsed.meta["agent-modification"]).toBe(true);
+    expect(parsed.content).toBe("Learn everything.");
+  });
+
+  test("preserves existing frontmatter when updating", async () => {
+    const filePath = join(tempDir, BOTHOLOMEW_DIR, "goals.md");
+    const original = serializeContextFile(
+      { loading: "always", "agent-modification": true },
+      "Old goals",
+    );
+    await Bun.write(filePath, original);
+
+    const result = await updateGoalsTool.execute({ content: "New goals" }, ctx);
+
+    expect(result.is_error).toBe(false);
+    const raw = await Bun.file(filePath).text();
+    const parsed = parseContextFile(raw);
+    expect(parsed.content).toBe("New goals");
+  });
+
+  test("rejects modification when agent-modification is false", async () => {
+    const filePath = join(tempDir, BOTHOLOMEW_DIR, "goals.md");
+    const locked = serializeContextFile(
+      { loading: "always", "agent-modification": false },
+      "Protected goals",
+    );
+    await Bun.write(filePath, locked);
+
+    const result = await updateGoalsTool.execute(
+      { content: "Hacked goals" },
+      ctx,
+    );
+
+    expect(result.is_error).toBe(true);
+    expect(result.message).toContain("not allowed");
+
+    const raw = await Bun.file(filePath).text();
+    const parsed = parseContextFile(raw);
+    expect(parsed.content).toBe("Protected goals");
+  });
+});

--- a/test/daemon/watchdog.test.ts
+++ b/test/daemon/watchdog.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, test } from "bun:test";
+import { sanitizePathForServiceName } from "../../src/constants.ts";
+import {
+  detectPlatform,
+  generateLaunchdPlist,
+  generateSystemdService,
+  generateSystemdTimer,
+  generateWatchdogConfig,
+} from "../../src/daemon/watchdog.ts";
+
+describe("sanitizePathForServiceName", () => {
+  test("converts absolute path to lowercase dash-separated string", () => {
+    expect(sanitizePathForServiceName("/Users/evan/myproject")).toBe(
+      "users-evan-myproject",
+    );
+  });
+
+  test("handles trailing slashes", () => {
+    expect(sanitizePathForServiceName("/Users/evan/myproject/")).toBe(
+      "users-evan-myproject",
+    );
+  });
+
+  test("collapses multiple slashes", () => {
+    expect(sanitizePathForServiceName("/Users//evan///myproject")).toBe(
+      "users-evan-myproject",
+    );
+  });
+
+  test("handles backslashes (Windows-style)", () => {
+    expect(sanitizePathForServiceName("C:\\Users\\evan\\myproject")).toBe(
+      "c-users-evan-myproject",
+    );
+  });
+
+  test("different paths produce different names", () => {
+    const a = sanitizePathForServiceName("/home/alice/project-a");
+    const b = sanitizePathForServiceName("/home/bob/project-b");
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("detectPlatform", () => {
+  test("returns macos or linux on supported platforms", () => {
+    const platform = detectPlatform();
+    expect(["macos", "linux"]).toContain(platform);
+  });
+});
+
+describe("generateLaunchdPlist", () => {
+  const projectDir = "/Users/evan/myproject";
+  const cmd = ["bun", "run", "/path/to/healthcheck.ts", projectDir];
+
+  test("generates valid XML plist", () => {
+    const plist = generateLaunchdPlist(projectDir, cmd);
+    expect(plist).toContain('<?xml version="1.0"');
+    expect(plist).toContain("<!DOCTYPE plist");
+    expect(plist).toContain('<plist version="1.0">');
+  });
+
+  test("includes correct label", () => {
+    const plist = generateLaunchdPlist(projectDir, cmd);
+    expect(plist).toContain("com.botholomew.users-evan-myproject");
+  });
+
+  test("includes StartInterval of 60", () => {
+    const plist = generateLaunchdPlist(projectDir, cmd);
+    expect(plist).toContain("<key>StartInterval</key>");
+    expect(plist).toContain("<integer>60</integer>");
+  });
+
+  test("has KeepAlive false", () => {
+    const plist = generateLaunchdPlist(projectDir, cmd);
+    expect(plist).toContain("<key>KeepAlive</key>");
+    expect(plist).toContain("<false/>");
+  });
+
+  test("includes program arguments", () => {
+    const plist = generateLaunchdPlist(projectDir, cmd);
+    expect(plist).toContain("<string>bun</string>");
+    expect(plist).toContain("<string>run</string>");
+    expect(plist).toContain("<string>/path/to/healthcheck.ts</string>");
+  });
+
+  test("includes watchdog log paths", () => {
+    const plist = generateLaunchdPlist(projectDir, cmd);
+    expect(plist).toContain("<key>StandardOutPath</key>");
+    expect(plist).toContain("<key>StandardErrorPath</key>");
+    expect(plist).toContain("watchdog.log");
+  });
+
+  test("escapes XML special characters in paths", () => {
+    const dirWithSpecial = "/Users/evan/my&project";
+    const plist = generateLaunchdPlist(dirWithSpecial, [
+      "bun",
+      "run",
+      "hc.ts",
+      dirWithSpecial,
+    ]);
+    expect(plist).toContain("my&amp;project");
+    expect(plist).not.toContain("my&project");
+  });
+});
+
+describe("generateSystemdService", () => {
+  const projectDir = "/home/evan/myproject";
+  const cmd = ["bun", "run", "/path/to/healthcheck.ts", projectDir];
+
+  test("generates valid service unit", () => {
+    const service = generateSystemdService(projectDir, cmd);
+    expect(service).toContain("[Unit]");
+    expect(service).toContain("[Service]");
+    expect(service).toContain("[Install]");
+  });
+
+  test("is Type=oneshot", () => {
+    const service = generateSystemdService(projectDir, cmd);
+    expect(service).toContain("Type=oneshot");
+  });
+
+  test("includes ExecStart with full command", () => {
+    const service = generateSystemdService(projectDir, cmd);
+    expect(service).toContain(
+      "ExecStart=bun run /path/to/healthcheck.ts /home/evan/myproject",
+    );
+  });
+
+  test("includes project dir in description", () => {
+    const service = generateSystemdService(projectDir, cmd);
+    expect(service).toContain(projectDir);
+  });
+});
+
+describe("generateSystemdTimer", () => {
+  test("generates valid timer unit", () => {
+    const timer = generateSystemdTimer("botholomew-home-evan-myproject");
+    expect(timer).toContain("[Unit]");
+    expect(timer).toContain("[Timer]");
+    expect(timer).toContain("[Install]");
+  });
+
+  test("fires on boot and every 60 seconds", () => {
+    const timer = generateSystemdTimer("botholomew-home-evan-myproject");
+    expect(timer).toContain("OnBootSec=60");
+    expect(timer).toContain("OnUnitActiveSec=60");
+  });
+
+  test("includes service name in description", () => {
+    const timer = generateSystemdTimer("botholomew-home-evan-myproject");
+    expect(timer).toContain("botholomew-home-evan-myproject");
+  });
+});
+
+describe("generateWatchdogConfig", () => {
+  const projectDir = "/Users/evan/myproject";
+
+  test("returns platform and files array", () => {
+    const config = generateWatchdogConfig(projectDir);
+    expect(config.platform).toBeDefined();
+    expect(Array.isArray(config.files)).toBe(true);
+    expect(config.files.length).toBeGreaterThan(0);
+  });
+
+  test("each file has path and content", () => {
+    const config = generateWatchdogConfig(projectDir);
+    for (const file of config.files) {
+      expect(file.path).toBeTruthy();
+      expect(file.content).toBeTruthy();
+    }
+  });
+
+  test("macOS config has single plist file", () => {
+    const config = generateWatchdogConfig(projectDir);
+    if (config.platform === "macos") {
+      expect(config.files).toHaveLength(1);
+      const plistFile = config.files[0];
+      expect(plistFile?.path).toContain(".plist");
+      expect(plistFile?.path).toContain("LaunchAgents");
+    }
+  });
+
+  test("linux config has service and timer files", () => {
+    const config = generateWatchdogConfig(projectDir);
+    if (config.platform === "linux") {
+      expect(config.files).toHaveLength(2);
+      expect(config.files.some((f) => f.path.endsWith(".service"))).toBe(true);
+      expect(config.files.some((f) => f.path.endsWith(".timer"))).toBe(true);
+    }
+  });
+});

--- a/test/db/threads.test.ts
+++ b/test/db/threads.test.ts
@@ -4,7 +4,10 @@ import {
   createThread,
   deleteThread,
   endThread,
+  getActiveThread,
+  getInteractionsAfter,
   getThread,
+  isThreadEnded,
   listThreads,
   logInteraction,
   updateThreadTitle,
@@ -213,5 +216,79 @@ describe("listThreads", () => {
 
     const threads = await listThreads(conn, { limit: 2 });
     expect(threads).toHaveLength(2);
+  });
+});
+
+describe("follow queries", () => {
+  test("getInteractionsAfter returns only interactions after given sequence", async () => {
+    const threadId = await createThread(conn, "daemon_tick");
+    for (let i = 0; i < 5; i++) {
+      await logInteraction(conn, threadId, {
+        role: "assistant",
+        kind: "message",
+        content: `Message ${i + 1}`,
+      });
+    }
+
+    const after3 = await getInteractionsAfter(conn, threadId, 3);
+    expect(after3).toHaveLength(2);
+    expect(after3[0]?.sequence).toBe(4);
+    expect(after3[1]?.sequence).toBe(5);
+  });
+
+  test("getInteractionsAfter returns empty when caught up", async () => {
+    const threadId = await createThread(conn, "daemon_tick");
+    await logInteraction(conn, threadId, {
+      role: "assistant",
+      kind: "message",
+      content: "Only message",
+    });
+
+    const result = await getInteractionsAfter(conn, threadId, 1);
+    expect(result).toHaveLength(0);
+  });
+
+  test("getActiveThread returns most recent active thread", async () => {
+    const id1 = await createThread(
+      conn,
+      "daemon_tick",
+      undefined,
+      "First tick",
+    );
+    await endThread(conn, id1);
+    const id2 = await createThread(
+      conn,
+      "daemon_tick",
+      undefined,
+      "Second tick",
+    );
+
+    const active = await getActiveThread(conn);
+    expect(active).not.toBeNull();
+    expect(active?.id).toBe(id2);
+    expect(active?.title).toBe("Second tick");
+  });
+
+  test("getActiveThread returns null when all threads ended", async () => {
+    const id = await createThread(conn, "daemon_tick");
+    await endThread(conn, id);
+
+    const active = await getActiveThread(conn);
+    expect(active).toBeNull();
+  });
+
+  test("isThreadEnded returns false for active thread", async () => {
+    const id = await createThread(conn, "daemon_tick");
+    expect(await isThreadEnded(conn, id)).toBe(false);
+  });
+
+  test("isThreadEnded returns true for ended thread", async () => {
+    const id = await createThread(conn, "daemon_tick");
+    await endThread(conn, id);
+    expect(await isThreadEnded(conn, id)).toBe(true);
+  });
+
+  test("isThreadEnded returns true for nonexistent thread", async () => {
+    expect(await isThreadEnded(conn, "nonexistent")).toBe(true);
   });
 });

--- a/test/utils/project-registry.test.ts
+++ b/test/utils/project-registry.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  listRegisteredProjects,
+  readRegistry,
+  registerProject,
+  unregisterProject,
+} from "../../src/utils/project-registry.ts";
+
+describe("project-registry", () => {
+  const testDir = `/tmp/botholomew-test-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+  afterEach(async () => {
+    // Clean up our test entry
+    await unregisterProject(testDir);
+  });
+
+  test("readRegistry returns empty object when no file exists", async () => {
+    const registry = await readRegistry();
+    expect(typeof registry).toBe("object");
+  });
+
+  test("registerProject adds entry and listRegisteredProjects returns it", async () => {
+    await registerProject(testDir);
+    const projects = await listRegisteredProjects();
+    const found = projects.find((p) => p.projectDir === testDir);
+    expect(found).toBeDefined();
+    expect(found?.installedAt).toBeTruthy();
+  });
+
+  test("unregisterProject removes entry", async () => {
+    await registerProject(testDir);
+    await unregisterProject(testDir);
+    const projects = await listRegisteredProjects();
+    const found = projects.find((p) => p.projectDir === testDir);
+    expect(found).toBeUndefined();
+  });
+
+  test("unregisterProject is a no-op for non-existent entry", async () => {
+    // Should not throw
+    await unregisterProject("/nonexistent/path/that/does/not/exist");
+  });
+
+  test("registerProject overwrites existing entry", async () => {
+    await registerProject(testDir);
+    const before = await listRegisteredProjects();
+    const first = before.find((p) => p.projectDir === testDir);
+
+    // Small delay to get a different timestamp
+    await Bun.sleep(10);
+    await registerProject(testDir);
+    const after = await listRegisteredProjects();
+    const second = after.find((p) => p.projectDir === testDir);
+
+    expect(second).toBeDefined();
+    expect(second?.installedAt).not.toBe(first?.installedAt);
+  });
+});


### PR DESCRIPTION
## Summary

- **OS-level watchdog**: launchd (macOS) and systemd (Linux) service management for daemon auto-restart, with `daemon install/uninstall/list/healthcheck` CLI commands
- **Auto-spawn daemon**: `botholomew chat` now auto-starts the daemon if not running (`--no-daemon` to opt out)
- **Thread follow**: real-time observation of daemon threads via `thread follow [id]` CLI command (tail -f style) and `w` keybinding in the TUI ThreadPanel with 1s polling and auto-scroll
- **Agent-modification guards**: context update tools (`update-beliefs`, `update-goals`) now check `agent-modification` frontmatter before allowing writes
- **Project registry**: shared registry at `~/.botholomew/projects.json` for cross-project daemon discovery

## Test plan

- [x] `bun test` passes (454 tests)
- [x] `bun run lint` passes
- [ ] Manual: run `botholomew daemon install` and verify launchd service created
- [ ] Manual: start daemon with a pending task, run `botholomew thread follow` and verify live streaming
- [ ] Manual: open TUI Threads tab, select active thread, press `w` to verify follow mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)