### PR TITLE
Remove HF Transformers, switch to OpenAI embeddings, add context commands

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,6 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.88.0",
         "@evantahler/mcpx": "0.18.3",
-        "@huggingface/transformers": "^4.0.1",
         "@sqliteai/sqlite-vector": "^0.9.95",
         "ansis": "^4.2.0",
         "commander": "^14.0.0",
@@ -63,9 +62,7 @@
 
     "@huggingface/jinja": ["@huggingface/jinja@0.5.6", "", {}, "sha512-MyMWyLnjqo+KRJYSH7oWNbsOn5onuIvfXYPcc0WOGxU0eHUV7oAYUoQTl2BMdu7ml+ea/bu11UM+EshbeHwtIA=="],
 
-    "@huggingface/tokenizers": ["@huggingface/tokenizers@0.1.3", "", {}, "sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA=="],
-
-    "@huggingface/transformers": ["@huggingface/transformers@4.0.1", "", { "dependencies": { "@huggingface/jinja": "^0.5.6", "@huggingface/tokenizers": "^0.1.3", "onnxruntime-node": "1.24.3", "onnxruntime-web": "1.25.0-dev.20260327-722743c0e2", "sharp": "^0.34.5" } }, "sha512-tAQYEy+cnW0ku/NxBSjFXCymi+DZa1/JkoGf4McxjzO36CZZIL/J4TF6X7i/tzs75yTjshUDgsvSz03s2xym2A=="],
+    "@huggingface/transformers": ["@huggingface/transformers@3.8.1", "", { "dependencies": { "@huggingface/jinja": "^0.5.3", "onnxruntime-node": "1.21.0", "onnxruntime-web": "1.22.0-dev.20250409-89f8206ba4", "sharp": "^0.34.1" } }, "sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA=="],
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
@@ -168,8 +165,6 @@
     "@types/uuid": ["@types/uuid@11.0.0", "", { "dependencies": { "uuid": "*" } }, "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
-
-    "adm-zip": ["adm-zip@0.5.17", "", {}, "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ=="],
 
     "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
@@ -405,11 +400,11 @@
 
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
-    "onnxruntime-common": ["onnxruntime-common@1.24.3", "", {}, "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA=="],
+    "onnxruntime-common": ["onnxruntime-common@1.21.0", "", {}, "sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ=="],
 
-    "onnxruntime-node": ["onnxruntime-node@1.24.3", "", { "dependencies": { "adm-zip": "^0.5.16", "global-agent": "^3.0.0", "onnxruntime-common": "1.24.3" }, "os": [ "linux", "win32", "darwin", ] }, "sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg=="],
+    "onnxruntime-node": ["onnxruntime-node@1.21.0", "", { "dependencies": { "global-agent": "^3.0.0", "onnxruntime-common": "1.21.0", "tar": "^7.0.1" }, "os": [ "linux", "win32", "darwin", ] }, "sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw=="],
 
-    "onnxruntime-web": ["onnxruntime-web@1.25.0-dev.20260327-722743c0e2", "", { "dependencies": { "flatbuffers": "^25.1.24", "guid-typescript": "^1.0.9", "long": "^5.2.3", "onnxruntime-common": "1.24.0-dev.20251116-b39e144322", "platform": "^1.3.6", "protobufjs": "^7.2.4" } }, "sha512-8PXdZy4Ekhg10CLg+cFFt39b4tFDGMRJB6lGjnQL6eA+2boUQYDymZ0gtxiS+H6oIWoCjQp/ziyirvFbaFKfiw=="],
+    "onnxruntime-web": ["onnxruntime-web@1.22.0-dev.20250409-89f8206ba4", "", { "dependencies": { "flatbuffers": "^25.1.24", "guid-typescript": "^1.0.9", "long": "^5.2.3", "onnxruntime-common": "1.22.0-dev.20250409-89f8206ba4", "platform": "^1.3.6", "protobufjs": "^7.2.4" } }, "sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ=="],
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
@@ -545,26 +540,16 @@
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
-    "@evantahler/mcpx/@huggingface/transformers": ["@huggingface/transformers@3.8.1", "", { "dependencies": { "@huggingface/jinja": "^0.5.3", "onnxruntime-node": "1.21.0", "onnxruntime-web": "1.22.0-dev.20250409-89f8206ba4", "sharp": "^0.34.1" } }, "sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA=="],
-
     "ink-text-input/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "matcher/escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
-    "onnxruntime-web/onnxruntime-common": ["onnxruntime-common@1.24.0-dev.20251116-b39e144322", "", {}, "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw=="],
+    "onnxruntime-web/onnxruntime-common": ["onnxruntime-common@1.22.0-dev.20250409-89f8206ba4", "", {}, "sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ=="],
 
     "roarr/sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
 
     "serialize-error/type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
 
     "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
-
-    "@evantahler/mcpx/@huggingface/transformers/onnxruntime-node": ["onnxruntime-node@1.21.0", "", { "dependencies": { "global-agent": "^3.0.0", "onnxruntime-common": "1.21.0", "tar": "^7.0.1" }, "os": [ "linux", "win32", "darwin", ] }, "sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw=="],
-
-    "@evantahler/mcpx/@huggingface/transformers/onnxruntime-web": ["onnxruntime-web@1.22.0-dev.20250409-89f8206ba4", "", { "dependencies": { "flatbuffers": "^25.1.24", "guid-typescript": "^1.0.9", "long": "^5.2.3", "onnxruntime-common": "1.22.0-dev.20250409-89f8206ba4", "platform": "^1.3.6", "protobufjs": "^7.2.4" } }, "sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ=="],
-
-    "@evantahler/mcpx/@huggingface/transformers/onnxruntime-node/onnxruntime-common": ["onnxruntime-common@1.21.0", "", {}, "sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ=="],
-
-    "@evantahler/mcpx/@huggingface/transformers/onnxruntime-web/onnxruntime-common": ["onnxruntime-common@1.22.0-dev.20250409-89f8206ba4", "", {}, "sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "An AI agent for knowledge work",
   "type": "module",
   "bin": {
@@ -24,8 +24,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.88.0",
     "@evantahler/mcpx": "0.18.3",
-    "@huggingface/transformers": "^4.0.1",
-    "@sqliteai/sqlite-vector": "^0.9.95",
+"@sqliteai/sqlite-vector": "^0.9.95",
     "ansis": "^4.2.0",
     "commander": "^14.0.0",
     "gray-matter": "^4.0.3",

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -5,8 +5,12 @@ import type { Command } from "commander";
 import { isText } from "istextorbinary";
 import { createSpinner } from "nanospinner";
 import { loadConfig } from "../config/loader.ts";
-import { embedSingle, warmupEmbedder } from "../context/embedder.ts";
-import { ingestContextItem } from "../context/ingest.ts";
+import { embedSingle } from "../context/embedder.ts";
+import {
+  type PreparedIngestion,
+  prepareIngestion,
+  storeIngestion,
+} from "../context/ingest.ts";
 import type { DbConnection } from "../db/connection.ts";
 import {
   type ContextItem,
@@ -17,7 +21,11 @@ import {
   listContextItemsByPrefix,
   updateContextItem,
 } from "../db/context.ts";
-import { hybridSearch, initVectorSearch } from "../db/embeddings.ts";
+import {
+  getEmbeddingsForItem,
+  hybridSearch,
+  initVectorSearch,
+} from "../db/embeddings.ts";
 import { logger } from "../utils/logger.ts";
 import { withDb } from "./with-db.ts";
 
@@ -34,14 +42,19 @@ export function registerContextCommand(program: Command) {
     .description("List context items")
     .option("--path <prefix>", "filter by path prefix")
     .option("-l, --limit <n>", "max number of items", Number.parseInt)
+    .option("-o, --offset <n>", "skip first N items", Number.parseInt)
     .action((opts) =>
       withDb(program, async (conn) => {
         const items = opts.path
           ? await listContextItemsByPrefix(conn, opts.path, {
               recursive: true,
               limit: opts.limit,
+              offset: opts.offset,
             })
-          : await listContextItems(conn, { limit: opts.limit });
+          : await listContextItems(conn, {
+              limit: opts.limit,
+              offset: opts.offset,
+            });
 
         if (items.length === 0) {
           logger.dim("No context items found.");
@@ -137,35 +150,71 @@ export function registerContextCommand(program: Command) {
           text: `Found ${filesToAdd.length} file(s) to add.`,
         });
 
-        // Phase 2: Warmup embedder
-        const embedSpinner = createSpinner(
-          "Loading embedding model...",
-        ).start();
+        // Phase 2: Load config and upsert DB records (sequential, fast)
         const config = await loadConfig(dir);
-        await warmupEmbedder();
-        embedSpinner.success({ text: "Embedding model loaded." });
+        const upsertSpinner = createSpinner(
+          "Adding files to database...",
+        ).start();
+        const itemIds: { id: string; contextPath: string }[] = [];
+        for (const { filePath, contextPath } of filesToAdd) {
+          const result = await addFile(conn, filePath, contextPath);
+          if (result) itemIds.push({ id: result, contextPath });
+        }
+        upsertSpinner.success({
+          text: `Added ${itemIds.length} file(s) to database.`,
+        });
 
-        // Phase 3: Process files one-by-one
-        let added = 0;
-        let chunks = 0;
-
-        for (const [i, { filePath, contextPath }] of filesToAdd.entries()) {
-          const fileSpinner = createSpinner(
-            `Processing ${basename(filePath)} (${i + 1}/${filesToAdd.length})...`,
-          ).start();
-          const count = await addFile(conn, config, filePath, contextPath);
-          if (count >= 0) {
-            added++;
-            chunks += count;
-            fileSpinner.success({
-              text: `${contextPath} (${count} chunks)`,
-            });
-          } else {
-            fileSpinner.warn({ text: `${contextPath}: skipped` });
+        // Phase 3: Chunk + embed in parallel (network I/O)
+        if (itemIds.length === 0 || !config.openai_api_key) {
+          if (!config.openai_api_key) {
+            logger.dim("Skipping embeddings (no OpenAI API key configured).");
           }
+          logger.success(`Added ${itemIds.length} file(s), 0 chunks indexed.`);
+          process.exit(0);
         }
 
-        logger.success(`Added ${added} file(s), ${chunks} chunk(s) indexed.`);
+        const CONCURRENCY = 10;
+        let completed = 0;
+        const embedSpinner = createSpinner(
+          `Embedding 0/${itemIds.length} files...`,
+        ).start();
+
+        const prepared: PreparedIngestion[] = [];
+        for (let i = 0; i < itemIds.length; i += CONCURRENCY) {
+          const batch = itemIds.slice(i, i + CONCURRENCY);
+          const results = await Promise.all(
+            batch.map(async ({ id }) => {
+              const result = await prepareIngestion(conn, id, config);
+              completed++;
+              embedSpinner.update({
+                text: `Embedding ${completed}/${itemIds.length} files...`,
+              });
+              return result;
+            }),
+          );
+          for (const r of results) {
+            if (r) prepared.push(r);
+          }
+        }
+        embedSpinner.success({
+          text: `Embedded ${prepared.length} file(s).`,
+        });
+
+        // Phase 4: Store embeddings (sequential, fast DB writes)
+        let chunks = 0;
+        let filesAdded = 0;
+        let filesUpdated = 0;
+        for (const p of prepared) {
+          const result = storeIngestion(conn, p);
+          chunks += result.chunks;
+          if (result.isUpdate) filesUpdated++;
+          else filesAdded++;
+        }
+
+        const parts: string[] = [];
+        if (filesAdded > 0) parts.push(`${filesAdded} added`);
+        if (filesUpdated > 0) parts.push(`${filesUpdated} updated`);
+        logger.success(`${parts.join(", ")} — ${chunks} chunk(s) indexed.`);
         process.exit(0);
       }),
     );
@@ -175,10 +224,10 @@ export function registerContextCommand(program: Command) {
     .description("Search context items")
     .option("-k, --top-k <n>", "max results", Number.parseInt, 10)
     .action((query, opts) =>
-      withDb(program, async (conn) => {
-        await warmupEmbedder();
+      withDb(program, async (conn, dir) => {
+        const config = await loadConfig(dir);
         initVectorSearch(conn);
-        const queryVec = await embedSingle(query);
+        const queryVec = await embedSingle(query, config);
         const results = hybridSearch(conn, query, queryVec, opts.topK);
 
         if (results.length === 0) {
@@ -215,14 +264,186 @@ export function registerContextCommand(program: Command) {
         logger.success(`Deleted context item: ${path}`);
       }),
     );
+  ctx
+    .command("chunks <path>")
+    .description("Show chunks and embeddings for a context item")
+    .action((path: string) =>
+      withDb(program, async (conn) => {
+        const item = await getContextItemByPath(conn, path);
+        if (!item) {
+          logger.error(`Context item not found: ${path}`);
+          process.exit(1);
+        }
+
+        if (!item.indexed_at) {
+          logger.dim("Item has not been indexed yet.");
+          return;
+        }
+
+        const embeddings = getEmbeddingsForItem(conn, item.id);
+
+        console.log(ansis.bold(item.title));
+        console.log(`  Path:      ${item.context_path}`);
+        console.log(`  Indexed:   ${fmtDate(item.indexed_at)}`);
+        console.log(`  Chunks:    ${embeddings.length}`);
+        console.log("");
+
+        for (const emb of embeddings) {
+          const preview = emb.chunk_content
+            ? emb.chunk_content.slice(0, 200).replace(/\n/g, " ") +
+              (emb.chunk_content.length > 200 ? "..." : "")
+            : ansis.dim("(no content)");
+          const chars = emb.chunk_content?.length ?? 0;
+
+          console.log(
+            `${ansis.bold(`Chunk ${emb.chunk_index}`)}  ${ansis.dim(`${chars} chars, ${emb.embedding.length} dims`)}`,
+          );
+          console.log(`  ${preview}`);
+          console.log("");
+        }
+
+        const totalChars = embeddings.reduce(
+          (sum, e) => sum + (e.chunk_content?.length ?? 0),
+          0,
+        );
+        console.log(
+          ansis.dim(`${embeddings.length} chunk(s), ${totalChars} total chars`),
+        );
+      }),
+    );
+
+  ctx
+    .command("refresh [path]")
+    .description("Re-import files from disk and re-embed if content changed")
+    .option("--all", "refresh all items with a source path")
+    .action((path: string | undefined, opts: { all?: boolean }) =>
+      withDb(program, async (conn, dir) => {
+        const items = await resolveItems(conn, path, !!opts.all);
+        if (items.length === 0) {
+          logger.error("No matching context items found.");
+          process.exit(1);
+        }
+
+        const sourced = items.filter((i) => i.source_path);
+        if (sourced.length === 0) {
+          logger.dim("No items with a source path to refresh.");
+          return;
+        }
+        if (sourced.length < items.length) {
+          logger.dim(
+            `Skipping ${items.length - sourced.length} item(s) without a source path.`,
+          );
+        }
+
+        const config = await loadConfig(dir);
+
+        // Phase 1: Read files from disk, compare, and update DB
+        const spinner = createSpinner(
+          `Refreshing 0/${sourced.length} items...`,
+        ).start();
+        let updated = 0;
+        let unchanged = 0;
+        let missing = 0;
+        const toReembed: string[] = [];
+
+        for (const [idx, item] of sourced.entries()) {
+          spinner.update({
+            text: `Refreshing ${idx + 1}/${sourced.length} items...`,
+          });
+          try {
+            const sourcePath = item.source_path as string;
+            const bunFile = Bun.file(sourcePath);
+            if (!(await bunFile.exists())) {
+              missing++;
+              logger.warn(`  Missing: ${item.source_path}`);
+              continue;
+            }
+            const content = await bunFile.text();
+            if (content === item.content) {
+              unchanged++;
+              continue;
+            }
+            await updateContextItem(conn, item.id, { content });
+            updated++;
+            toReembed.push(item.id);
+          } catch (err) {
+            logger.warn(`  Error reading ${item.source_path}: ${err}`);
+          }
+        }
+        spinner.success({
+          text: `Checked ${sourced.length} file(s): ${updated} updated, ${unchanged} unchanged, ${missing} missing.`,
+        });
+
+        // Phase 2: Re-embed changed items
+        if (toReembed.length === 0 || !config.openai_api_key) {
+          if (toReembed.length > 0 && !config.openai_api_key) {
+            logger.dim("Skipping embeddings (no OpenAI API key configured).");
+          }
+          return;
+        }
+
+        const CONCURRENCY = 10;
+        let completed = 0;
+        const embedSpinner = createSpinner(
+          `Embedding 0/${toReembed.length} files...`,
+        ).start();
+
+        const prepared: PreparedIngestion[] = [];
+        for (let i = 0; i < toReembed.length; i += CONCURRENCY) {
+          const batch = toReembed.slice(i, i + CONCURRENCY);
+          const results = await Promise.all(
+            batch.map(async (id) => {
+              const result = await prepareIngestion(conn, id, config);
+              completed++;
+              embedSpinner.update({
+                text: `Embedding ${completed}/${toReembed.length} files...`,
+              });
+              return result;
+            }),
+          );
+          for (const r of results) {
+            if (r) prepared.push(r);
+          }
+        }
+        embedSpinner.success({
+          text: `Embedded ${prepared.length} file(s).`,
+        });
+
+        let chunks = 0;
+        for (const p of prepared) {
+          const result = storeIngestion(conn, p);
+          chunks += result.chunks;
+        }
+
+        logger.success(
+          `Refreshed ${updated} file(s), ${chunks} chunk(s) re-indexed.`,
+        );
+      }),
+    );
 }
 
+async function resolveItems(
+  conn: DbConnection,
+  path: string | undefined,
+  all: boolean,
+): Promise<ContextItem[]> {
+  if (!path && !all) {
+    logger.error("Provide a path or use --all.");
+    process.exit(1);
+  }
+  if (all) return listContextItems(conn);
+  const p = path as string;
+  const exact = await getContextItemByPath(conn, p);
+  if (exact) return [exact];
+  return listContextItemsByPrefix(conn, p, { recursive: true });
+}
+
+/** Upsert a file into the context DB. Returns the item ID if textual, null otherwise. */
 async function addFile(
   conn: DbConnection,
-  config: Awaited<ReturnType<typeof loadConfig>>,
   filePath: string,
   contextPath: string,
-): Promise<number> {
+): Promise<string | null> {
   try {
     const bunFile = Bun.file(filePath);
     const mimeType = bunFile.type.split(";")[0] || "application/octet-stream";
@@ -253,14 +474,10 @@ async function addFile(
       });
     }
 
-    if (textual && content) {
-      return await ingestContextItem(conn, item.id, config);
-    }
-
-    return 0;
+    return textual && content ? item.id : null;
   } catch (err) {
     logger.warn(`  ! ${contextPath}: ${err}`);
-    return -1;
+    return null;
   }
 }
 

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -1,16 +1,25 @@
 import type { Command } from "commander";
-import { warmupEmbedder } from "../context/embedder.ts";
+import { loadConfig } from "../config/loader.ts";
+import { embedSingle } from "../context/embedder.ts";
 import { logger } from "../utils/logger.ts";
+import { withDb } from "./with-db.ts";
 
 export function registerPrepareCommand(program: Command) {
   program
     .command("prepare")
-    .description(
-      "Download and cache required models. Run this in CI or on first setup.",
-    )
-    .action(async () => {
-      logger.info("Preparing Botholomew...");
-      await warmupEmbedder();
-      logger.success("All models downloaded and ready.");
-    });
+    .description("Verify API keys and connectivity. Run this on first setup.")
+    .action(() =>
+      withDb(program, async (_conn, dir) => {
+        logger.info("Preparing Botholomew...");
+        const config = await loadConfig(dir);
+        if (!config.openai_api_key) {
+          logger.error(
+            "OpenAI API key not set. Set openai_api_key in config or OPENAI_API_KEY env var.",
+          );
+          process.exit(1);
+        }
+        await embedSingle("test", config);
+        logger.success("OpenAI embeddings API is reachable and configured.");
+      }),
+    );
 }

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -14,9 +14,12 @@ export async function loadConfig(
 
   const config = { ...DEFAULT_CONFIG, ...userConfig };
 
-  // env var override takes precedence
+  // env var overrides take precedence
   if (process.env.ANTHROPIC_API_KEY) {
     config.anthropic_api_key = process.env.ANTHROPIC_API_KEY;
+  }
+  if (process.env.OPENAI_API_KEY) {
+    config.openai_api_key = process.env.OPENAI_API_KEY;
   }
 
   return config;

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -1,7 +1,10 @@
 export interface BotholomewConfig {
   anthropic_api_key?: string;
+  openai_api_key?: string;
   model?: string;
   chunker_model?: string;
+  embedding_model?: string;
+  embedding_dimension?: number;
   tick_interval_seconds?: number;
   max_tick_duration_seconds?: number;
   system_prompt_override?: string;
@@ -10,8 +13,11 @@ export interface BotholomewConfig {
 
 export const DEFAULT_CONFIG: Required<BotholomewConfig> = {
   anthropic_api_key: "",
+  openai_api_key: "",
   model: "claude-opus-4-20250514",
   chunker_model: "claude-haiku-4-5-20251001",
+  embedding_model: "text-embedding-3-small",
+  embedding_dimension: 1536,
   tick_interval_seconds: 300,
   max_tick_duration_seconds: 120,
   system_prompt_override: "",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,9 +18,8 @@ export const LOG_FILENAME = "daemon.log";
 export const CONFIG_FILENAME = "config.json";
 export const MCPX_DIR = "mcpx";
 export const MCPX_SERVERS_FILENAME = "servers.json";
-export const EMBEDDING_DIMENSION = 384;
-export const EMBEDDING_MODEL_ID = "Xenova/bge-small-en-v1.5";
-export const EMBEDDING_DTYPE = "fp32";
+export const EMBEDDING_DIMENSION = 1536;
+export const EMBEDDING_MODEL = "text-embedding-3-small";
 
 export const LAUNCHD_LABEL_PREFIX = "com.botholomew.";
 export const SYSTEMD_UNIT_PREFIX = "botholomew-";

--- a/src/context/embedder.ts
+++ b/src/context/embedder.ts
@@ -1,75 +1,69 @@
-import {
-  EMBEDDING_DIMENSION,
-  EMBEDDING_DTYPE,
-  EMBEDDING_MODEL_ID,
-} from "../constants.ts";
+import type { BotholomewConfig } from "../config/schemas.ts";
 
-type EmbedFn = (texts: string[]) => Promise<number[][]>;
+type EmbedFn = (
+  texts: string[],
+  config: Required<BotholomewConfig>,
+) => Promise<number[][]>;
 
-let pipelineInstance: ReturnType<typeof createPipelinePromise> | null = null;
-
-function createPipelinePromise() {
-  return (async () => {
-    const { pipeline } = await import("@huggingface/transformers");
-    const pipe = await pipeline("feature-extraction", EMBEDDING_MODEL_ID, {
-      dtype: EMBEDDING_DTYPE,
-    });
-    return pipe;
-  })();
-}
-
-async function getEmbeddingPipeline() {
-  if (!pipelineInstance) {
-    pipelineInstance = createPipelinePromise();
-  }
-  return pipelineInstance;
+interface OpenAIEmbeddingResponse {
+  data: { embedding: number[]; index: number }[];
+  usage: { total_tokens: number };
 }
 
 /**
- * Ensure the embedding model is downloaded and loaded.
- * Call at application boot (daemon start, CLI commands that need embeddings).
- * Downloads the model on first run (~33MB).
+ * Embed multiple texts using the OpenAI embeddings API.
+ * Returns an array of float vectors with the configured dimension.
  */
-export async function warmupEmbedder(): Promise<void> {
-  await getEmbeddingPipeline();
-}
-
-/**
- * Embed multiple texts using the local BGE model.
- * Returns an array of 384-dimensional float vectors.
- */
-export async function embed(texts: string[]): Promise<number[][]> {
+export async function embed(
+  texts: string[],
+  config: Required<BotholomewConfig>,
+): Promise<number[][]> {
   if (texts.length === 0) return [];
 
-  const pipe = await getEmbeddingPipeline();
-  const output = await pipe(texts, { pooling: "cls", normalize: true });
-
-  const results: number[][] = [];
-  for (let i = 0; i < texts.length; i++) {
-    const row = (output as { data: Float32Array }).data.slice(
-      i * EMBEDDING_DIMENSION,
-      (i + 1) * EMBEDDING_DIMENSION,
+  if (!config.openai_api_key) {
+    throw new Error(
+      "OpenAI API key is required for embeddings. Set openai_api_key in config or OPENAI_API_KEY env var.",
     );
-    results.push(Array.from(row));
   }
-  return results;
+
+  const response = await fetch("https://api.openai.com/v1/embeddings", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${config.openai_api_key}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      input: texts,
+      model: config.embedding_model,
+      dimensions: config.embedding_dimension,
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `OpenAI embeddings API error (${response.status}): ${body}`,
+    );
+  }
+
+  const result = (await response.json()) as OpenAIEmbeddingResponse;
+
+  // Sort by index to ensure order matches input
+  const sorted = result.data.sort((a, b) => a.index - b.index);
+  return sorted.map((d) => d.embedding);
 }
 
 /**
  * Embed a single text string.
  */
-export async function embedSingle(text: string): Promise<number[]> {
-  const results = await embed([text]);
+export async function embedSingle(
+  text: string,
+  config: Required<BotholomewConfig>,
+): Promise<number[]> {
+  const results = await embed([text], config);
   const vec = results[0];
   if (!vec) throw new Error("embed returned empty results");
   return vec;
-}
-
-/**
- * Reset the singleton pipeline (for testing).
- */
-export function resetEmbedder(): void {
-  pipelineInstance = null;
 }
 
 export type { EmbedFn };

--- a/src/context/ingest.ts
+++ b/src/context/ingest.ts
@@ -8,8 +8,118 @@ import {
 } from "../db/embeddings.ts";
 import { logger } from "../utils/logger.ts";
 import { chunk } from "./chunker.ts";
-import type { EmbedFn } from "./embedder.ts";
 import { embed as defaultEmbed } from "./embedder.ts";
+
+type IngestEmbedFn = (texts: string[]) => Promise<number[][]>;
+
+export interface PreparedIngestion {
+  itemId: string;
+  title: string;
+  description: string;
+  sourcePath: string | null;
+  chunks: { index: number; content: string }[];
+  vectors: number[][];
+}
+
+/**
+ * Prepare an item for ingestion: chunk content and compute embeddings.
+ * This is the expensive (parallelizable) part — no DB writes happen here.
+ */
+export async function prepareIngestion(
+  conn: DbConnection,
+  itemId: string,
+  config: Required<BotholomewConfig>,
+  embedFn?: IngestEmbedFn,
+): Promise<PreparedIngestion | null> {
+  const item = await getContextItem(conn, itemId);
+  if (!item) {
+    logger.warn(`ingest: context item ${itemId} not found`);
+    return null;
+  }
+
+  if (!item.is_textual || !item.content) {
+    logger.debug(`ingest: skipping non-textual item ${itemId}`);
+    return null;
+  }
+
+  const chunks = await chunk(item.content, item.mime_type, config);
+  if (chunks.length === 0) return null;
+
+  const doEmbed =
+    embedFn ??
+    (config.openai_api_key
+      ? (texts: string[]) => defaultEmbed(texts, config)
+      : null);
+  if (!doEmbed) {
+    logger.debug("ingest: skipping embeddings (no OpenAI API key configured)");
+    return null;
+  }
+
+  const vectors = await doEmbed(chunks.map((c) => c.content));
+
+  return {
+    itemId,
+    title: item.title,
+    description: item.description,
+    sourcePath: item.source_path,
+    chunks,
+    vectors,
+  };
+}
+
+export interface IngestionResult {
+  chunks: number;
+  isUpdate: boolean;
+}
+
+/**
+ * Store a prepared ingestion into the database.
+ * This is fast (synchronous DB writes) and must be called sequentially.
+ */
+export function storeIngestion(
+  conn: DbConnection,
+  prepared: PreparedIngestion,
+): IngestionResult {
+  initVectorSearch(conn);
+
+  let isUpdate = false;
+  conn.exec("BEGIN");
+  try {
+    const deleted = deleteEmbeddingsForItem(conn, prepared.itemId);
+    isUpdate = deleted > 0;
+
+    for (const [i, c] of prepared.chunks.entries()) {
+      const v = prepared.vectors[i];
+      if (!v) continue;
+      createEmbedding(conn, {
+        contextItemId: prepared.itemId,
+        chunkIndex: c.index,
+        chunkContent: c.content,
+        title: prepared.title,
+        description: prepared.description,
+        sourcePath: prepared.sourcePath,
+        embedding: v,
+      });
+    }
+
+    conn
+      .query(
+        "UPDATE context_items SET indexed_at = datetime('now') WHERE id = ?1",
+      )
+      .run(prepared.itemId);
+
+    conn.exec("COMMIT");
+  } catch (err) {
+    conn.exec("ROLLBACK");
+    throw err;
+  }
+
+  const action = isUpdate ? "updated" : "added";
+  logger.info(
+    `ingest: ${action} ${prepared.chunks.length} chunks for "${prepared.title}" (${prepared.itemId})`,
+  );
+  return { chunks: prepared.chunks.length, isUpdate };
+}
 
 /**
  * Full ingestion pipeline for a context item:
@@ -22,66 +132,11 @@ export async function ingestContextItem(
   conn: DbConnection,
   itemId: string,
   config: Required<BotholomewConfig>,
-  embedFn: EmbedFn = defaultEmbed,
+  embedFn?: IngestEmbedFn,
 ): Promise<number> {
-  const item = await getContextItem(conn, itemId);
-  if (!item) {
-    logger.warn(`ingest: context item ${itemId} not found`);
-    return 0;
-  }
-
-  if (!item.is_textual || !item.content) {
-    logger.debug(`ingest: skipping non-textual item ${itemId}`);
-    return 0;
-  }
-
-  // Initialize vector search (idempotent)
-  initVectorSearch(conn);
-
-  // Chunk and embed outside the transaction (may involve LLM/model calls)
-  const chunks = await chunk(item.content, item.mime_type, config);
-  if (chunks.length === 0) return 0;
-
-  const vectors = await embedFn(chunks.map((c) => c.content));
-
-  // Wrap DB mutations in a transaction
-  conn.exec("BEGIN");
-  try {
-    // Clear stale embeddings
-    deleteEmbeddingsForItem(conn, itemId);
-
-    // Store each chunk + embedding
-    for (const [i, c] of chunks.entries()) {
-      const v = vectors[i];
-      if (!v) continue;
-      createEmbedding(conn, {
-        contextItemId: itemId,
-        chunkIndex: c.index,
-        chunkContent: c.content,
-        title: item.title,
-        description: item.description,
-        sourcePath: item.source_path,
-        embedding: v,
-      });
-    }
-
-    // Mark as indexed
-    conn
-      .query(
-        "UPDATE context_items SET indexed_at = datetime('now') WHERE id = ?1",
-      )
-      .run(itemId);
-
-    conn.exec("COMMIT");
-  } catch (err) {
-    conn.exec("ROLLBACK");
-    throw err;
-  }
-
-  logger.debug(
-    `ingest: indexed ${chunks.length} chunks for "${item.title}" (${itemId})`,
-  );
-  return chunks.length;
+  const prepared = await prepareIngestion(conn, itemId, config, embedFn);
+  if (!prepared) return 0;
+  return storeIngestion(conn, prepared).chunks;
 }
 
 /**
@@ -91,7 +146,7 @@ export async function ingestByPath(
   conn: DbConnection,
   contextPath: string,
   config: Required<BotholomewConfig>,
-  embedFn: EmbedFn = defaultEmbed,
+  embedFn?: IngestEmbedFn,
 ): Promise<number> {
   const item = await getContextItemByPath(conn, contextPath);
   if (!item) {

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1,6 +1,5 @@
 import { loadConfig } from "../config/loader.ts";
 import { getDbPath } from "../constants.ts";
-import { warmupEmbedder } from "../context/embedder.ts";
 import { getConnection } from "../db/connection.ts";
 import { migrate } from "../db/schema.ts";
 import { createMcpxClient } from "../mcpx/client.ts";
@@ -13,9 +12,6 @@ export async function startDaemon(projectDir: string): Promise<void> {
   const dbPath = getDbPath(projectDir);
   const conn = getConnection(dbPath);
   migrate(conn);
-
-  // Ensure embedding model is downloaded and loaded before accepting work
-  await warmupEmbedder();
 
   // Initialize MCPX client for external tool access
   const mcpxClient = await createMcpxClient(projectDir);

--- a/src/daemon/prompt.ts
+++ b/src/daemon/prompt.ts
@@ -97,10 +97,10 @@ export async function buildSystemPrompt(
   parts.push(...(await loadPersistentContext(projectDir, taskKeywords)));
 
   // Relevant context from embeddings search
-  if (task && conn) {
+  if (task && conn && _config?.openai_api_key) {
     try {
       const query = `${task.name} ${task.description}`;
-      const queryVec = await embedSingle(query);
+      const queryVec = await embedSingle(query, _config);
       initVectorSearch(conn);
       const results = hybridSearch(conn, query, queryVec, 5);
 

--- a/src/db/context.ts
+++ b/src/db/context.ts
@@ -114,6 +114,7 @@ export async function listContextItems(
     contextPath?: string;
     mimeType?: string;
     limit?: number;
+    offset?: number;
   },
 ): Promise<ContextItem[]> {
   const { where, params } = buildWhereClause([
@@ -121,10 +122,11 @@ export async function listContextItems(
     ["mime_type", filters?.mimeType],
   ]);
   const limit = filters?.limit ? `LIMIT ${filters.limit}` : "";
+  const offset = filters?.offset ? `OFFSET ${filters.offset}` : "";
 
   const rows = db
     .query(
-      `SELECT * FROM context_items ${where} ORDER BY context_path ASC ${limit}`,
+      `SELECT * FROM context_items ${where} ORDER BY context_path ASC ${limit} ${offset}`,
     )
     .all(...params) as ContextItemRow[];
   return rows.map(rowToContextItem);
@@ -133,11 +135,12 @@ export async function listContextItems(
 export async function listContextItemsByPrefix(
   db: DbConnection,
   prefix: string,
-  opts?: { recursive?: boolean; limit?: number },
+  opts?: { recursive?: boolean; limit?: number; offset?: number },
 ): Promise<ContextItem[]> {
   const normalizedPrefix = prefix.endsWith("/") ? prefix : `${prefix}/`;
 
   const limit = opts?.limit ? `LIMIT ${opts.limit}` : "";
+  const offset = opts?.offset ? `OFFSET ${opts.offset}` : "";
 
   let rows: ContextItemRow[];
   if (opts?.recursive) {
@@ -145,7 +148,7 @@ export async function listContextItemsByPrefix(
       .query(
         `SELECT * FROM context_items
        WHERE context_path LIKE ?1
-       ORDER BY context_path ASC ${limit}`,
+       ORDER BY context_path ASC ${limit} ${offset}`,
       )
       .all(`${normalizedPrefix}%`) as ContextItemRow[];
   } else {
@@ -155,7 +158,7 @@ export async function listContextItemsByPrefix(
         `SELECT * FROM context_items
        WHERE context_path LIKE ?1
          AND context_path NOT LIKE ?2
-       ORDER BY context_path ASC ${limit}`,
+       ORDER BY context_path ASC ${limit} ${offset}`,
       )
       .all(
         `${normalizedPrefix}%`,

--- a/src/db/embeddings.ts
+++ b/src/db/embeddings.ts
@@ -107,6 +107,18 @@ export function createEmbedding(
   };
 }
 
+export function getEmbeddingsForItem(
+  conn: DbConnection,
+  contextItemId: string,
+): Embedding[] {
+  const rows = conn
+    .query(
+      "SELECT * FROM embeddings WHERE context_item_id = ?1 ORDER BY chunk_index ASC",
+    )
+    .all(contextItemId) as EmbeddingRow[];
+  return rows.map(rowToEmbedding);
+}
+
 export function deleteEmbeddingsForItem(
   conn: DbConnection,
   contextItemId: string,

--- a/src/db/sql/5-reset_embeddings_for_openai.sql
+++ b/src/db/sql/5-reset_embeddings_for_openai.sql
@@ -1,0 +1,1 @@
+DELETE FROM embeddings

--- a/src/tools/file/edit.ts
+++ b/src/tools/file/edit.ts
@@ -38,7 +38,7 @@ export const fileEditTool = {
       input.patches,
     );
 
-    await ingestByPath(ctx.conn, input.path, ctx.config, ctx.embedFn);
+    await ingestByPath(ctx.conn, input.path, ctx.config);
     return { applied, content: item.content ?? "", is_error: false };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/file/write.ts
+++ b/src/tools/file/write.ts
@@ -72,7 +72,7 @@ export const fileWriteTool = {
           description: input.description,
         });
       }
-      await ingestByPath(ctx.conn, input.path, ctx.config, ctx.embedFn);
+      await ingestByPath(ctx.conn, input.path, ctx.config);
       return { id: existing.id, path: input.path, is_error: false };
     }
 
@@ -88,7 +88,7 @@ export const fileWriteTool = {
       isTextual,
     });
 
-    await ingestByPath(ctx.conn, input.path, ctx.config, ctx.embedFn);
+    await ingestByPath(ctx.conn, input.path, ctx.config);
     return { id: item.id, path: item.context_path, is_error: false };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/search/semantic.ts
+++ b/src/tools/search/semantic.ts
@@ -38,7 +38,7 @@ export const searchSemanticTool = {
   execute: async (input, ctx) => {
     initVectorSearch(ctx.conn);
 
-    const queryVec = await embedSingle(input.query);
+    const queryVec = await embedSingle(input.query, ctx.config);
     const results = hybridSearch(ctx.conn, input.query, queryVec, input.top_k);
 
     const threshold = input.threshold;

--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -2,7 +2,6 @@ import type { Tool as AnthropicTool } from "@anthropic-ai/sdk/resources/messages
 import type { McpxClient } from "@evantahler/mcpx";
 import { z } from "zod";
 import type { BotholomewConfig } from "../config/schemas.ts";
-import type { EmbedFn } from "../context/embedder.ts";
 import type { DbConnection } from "../db/connection.ts";
 
 export interface ToolContext {
@@ -10,7 +9,6 @@ export interface ToolContext {
   projectDir: string;
   config: Required<BotholomewConfig>;
   mcpxClient: McpxClient | null;
-  embedFn?: EmbedFn;
 }
 
 type ToolOutputBase = { is_error: z.ZodBoolean };

--- a/test/constants.test.ts
+++ b/test/constants.test.ts
@@ -6,8 +6,7 @@ import {
   DB_FILENAME,
   DEFAULTS,
   EMBEDDING_DIMENSION,
-  EMBEDDING_DTYPE,
-  EMBEDDING_MODEL_ID,
+  EMBEDDING_MODEL,
   ENV,
   getBotholomewDir,
   getConfigPath,
@@ -34,9 +33,8 @@ describe("constants", () => {
   });
 
   test("embedding constants are defined", () => {
-    expect(EMBEDDING_DIMENSION).toBe(384);
-    expect(EMBEDDING_MODEL_ID).toBe("Xenova/bge-small-en-v1.5");
-    expect(EMBEDDING_DTYPE).toBe("fp32");
+    expect(EMBEDDING_DIMENSION).toBe(1536);
+    expect(EMBEDDING_MODEL).toBe("text-embedding-3-small");
   });
 
   test("environment variable keys are defined", () => {

--- a/test/context/embedder.test.ts
+++ b/test/context/embedder.test.ts
@@ -1,62 +1,126 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { DEFAULT_CONFIG } from "../../src/config/schemas.ts";
 import { embed, embedSingle } from "../../src/context/embedder.ts";
 
-// These tests use the real model — they're slow on first run (~2s model load)
-// but fast on subsequent runs due to singleton caching.
+const config = {
+  ...DEFAULT_CONFIG,
+  openai_api_key: "test-key",
+  embedding_model: "text-embedding-3-small",
+  embedding_dimension: 1536,
+};
+
+function mockFetchResponse(embeddings: number[][]) {
+  return mock(() =>
+    Promise.resolve(
+      new Response(
+        JSON.stringify({
+          data: embeddings.map((e, i) => ({ embedding: e, index: i })),
+          usage: { total_tokens: 10 },
+        }),
+        { status: 200 },
+      ),
+    ),
+  );
+}
+
+const originalFetchGlobal = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = originalFetchGlobal;
+});
 
 describe("embed", () => {
-  test("returns vectors of correct dimension", async () => {
-    const texts = ["hello world", "how are you"];
-    const vectors = await embed(texts);
-
-    expect(vectors).toHaveLength(2);
-    const [v0, v1] = vectors;
-    expect(v0).toHaveLength(384);
-    expect(v1).toHaveLength(384);
-  });
-
   test("returns empty array for empty input", async () => {
-    const vectors = await embed([]);
+    const vectors = await embed([], config);
     expect(vectors).toHaveLength(0);
   });
 
-  test("vectors are approximately normalized", async () => {
-    const results = await embed(["test normalization"]);
-    const [vec] = results;
-    expect(vec).toBeDefined();
-    const norm = Math.sqrt((vec ?? []).reduce((sum, v) => sum + v * v, 0));
-    expect(norm).toBeCloseTo(1.0, 1);
+  test("throws when API key is missing", async () => {
+    const noKeyConfig = { ...config, openai_api_key: "" };
+    expect(embed(["hello"], noKeyConfig)).rejects.toThrow("OpenAI API key");
+  });
+
+  test("calls OpenAI API and returns vectors", async () => {
+    const fakeVec = new Array(1536).fill(0.1);
+    const originalFetch = globalThis.fetch;
+    const mockFn = mockFetchResponse([fakeVec]);
+    globalThis.fetch = mockFn as unknown as typeof fetch;
+
+    try {
+      const result = await embed(["hello world"], config);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toHaveLength(1536);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+
+      const callArgs = mockFn.mock.calls[0] as unknown as [string, RequestInit];
+      expect(callArgs[0]).toBe("https://api.openai.com/v1/embeddings");
+
+      const body = JSON.parse(callArgs[1].body as string);
+      expect(body.model).toBe("text-embedding-3-small");
+      expect(body.dimensions).toBe(1536);
+      expect(body.input).toEqual(["hello world"]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("sorts results by index", async () => {
+    const vec0 = new Array(1536).fill(0.1);
+    const vec1 = new Array(1536).fill(0.2);
+    const originalFetch = globalThis.fetch;
+    // Return out of order
+    globalThis.fetch = mock(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            data: [
+              { embedding: vec1, index: 1 },
+              { embedding: vec0, index: 0 },
+            ],
+            usage: { total_tokens: 10 },
+          }),
+          { status: 200 },
+        ),
+      ),
+    ) as unknown as typeof fetch;
+
+    try {
+      const result = await embed(["a", "b"], config);
+      expect(result[0]?.[0]).toBe(0.1);
+      expect(result[1]?.[0]).toBe(0.2);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("throws on API error", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(() =>
+      Promise.resolve(new Response("rate limited", { status: 429 })),
+    ) as unknown as typeof fetch;
+
+    try {
+      expect(embed(["hello"], config)).rejects.toThrow(
+        "OpenAI embeddings API error (429)",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });
 
 describe("embedSingle", () => {
-  test("returns a single vector of correct dimension", async () => {
-    const vec = await embedSingle("single text");
-    expect(vec).toHaveLength(384);
-  });
+  test("returns a single vector", async () => {
+    const fakeVec = new Array(1536).fill(0.5);
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mockFetchResponse([fakeVec]) as unknown as typeof fetch;
 
-  test("similar texts produce similar vectors", async () => {
-    const v1: number[] = await embedSingle("the cat sat on the mat");
-    const v2: number[] = await embedSingle("a cat was sitting on a mat");
-    const v3: number[] = await embedSingle("quantum physics equations");
-
-    // Cosine similarity between similar texts should be higher
-    const sim12 = cosineSimilarity(v1, v2);
-    const sim13 = cosineSimilarity(v1, v3);
-
-    expect(sim12).toBeGreaterThan(sim13);
+    try {
+      const vec = await embedSingle("test", config);
+      expect(vec).toHaveLength(1536);
+      expect(vec[0]).toBe(0.5);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });
-
-function cosineSimilarity(a: number[], b: number[]): number {
-  let dot = 0;
-  let normA = 0;
-  let normB = 0;
-  for (const [i, aVal] of a.entries()) {
-    const bVal = b[i] ?? 0;
-    dot += aVal * bVal;
-    normA += aVal * aVal;
-    normB += bVal * bVal;
-  }
-  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
-}

--- a/test/daemon/llm.test.ts
+++ b/test/daemon/llm.test.ts
@@ -35,8 +35,11 @@ let conn: DbConnection;
 
 const testConfig = {
   anthropic_api_key: "test-key",
+  openai_api_key: "",
   model: "claude-opus-4-20250514",
   chunker_model: "claude-haiku-4-20250514",
+  embedding_model: "text-embedding-3-small",
+  embedding_dimension: 1536,
   tick_interval_seconds: 300,
   max_tick_duration_seconds: 120,
   max_turns: 10,

--- a/test/daemon/schedules.test.ts
+++ b/test/daemon/schedules.test.ts
@@ -29,8 +29,11 @@ let conn: DbConnection;
 
 const testConfig = {
   anthropic_api_key: "test-key",
+  openai_api_key: "",
   model: "claude-opus-4-20250514",
   chunker_model: "claude-haiku-4-20250514",
+  embedding_model: "text-embedding-3-small",
+  embedding_dimension: 1536,
   tick_interval_seconds: 300,
   max_tick_duration_seconds: 120,
   max_turns: 0,

--- a/test/daemon/tick.test.ts
+++ b/test/daemon/tick.test.ts
@@ -45,8 +45,11 @@ describe("daemon tick", () => {
 
     await tick("/tmp/test-project", conn, {
       anthropic_api_key: "test-key",
+      openai_api_key: "",
       model: "claude-opus-4-20250514",
       chunker_model: "claude-haiku-4-20250514",
+      embedding_model: "text-embedding-3-small",
+      embedding_dimension: 1536,
       tick_interval_seconds: 300,
       max_tick_duration_seconds: 120,
       max_turns: 0,
@@ -66,8 +69,11 @@ describe("daemon tick", () => {
 
     await tick("/tmp/test-project", conn, {
       anthropic_api_key: "test-key",
+      openai_api_key: "",
       model: "claude-opus-4-20250514",
       chunker_model: "claude-haiku-4-20250514",
+      embedding_model: "text-embedding-3-small",
+      embedding_dimension: 1536,
       tick_interval_seconds: 300,
       max_tick_duration_seconds: 120,
       max_turns: 0,
@@ -96,8 +102,11 @@ describe("daemon tick", () => {
   test("does nothing when no tasks available", async () => {
     await tick("/tmp/test-project", conn, {
       anthropic_api_key: "test-key",
+      openai_api_key: "",
       model: "claude-opus-4-20250514",
       chunker_model: "claude-haiku-4-20250514",
+      embedding_model: "text-embedding-3-small",
+      embedding_dimension: 1536,
       tick_interval_seconds: 300,
       max_tick_duration_seconds: 120,
       max_turns: 0,
@@ -130,8 +139,11 @@ describe("daemon tick", () => {
 
     await tickFresh("/tmp/test-project", conn, {
       anthropic_api_key: "test-key",
+      openai_api_key: "",
       model: "claude-opus-4-20250514",
       chunker_model: "claude-haiku-4-20250514",
+      embedding_model: "text-embedding-3-small",
+      embedding_dimension: 1536,
       tick_interval_seconds: 300,
       max_tick_duration_seconds: 120,
       max_turns: 0,
@@ -184,8 +196,11 @@ describe("daemon tick", () => {
 
     await tick("/tmp/test-project", conn, {
       anthropic_api_key: "test-key",
+      openai_api_key: "",
       model: "claude-opus-4-20250514",
       chunker_model: "claude-haiku-4-20250514",
+      embedding_model: "text-embedding-3-small",
+      embedding_dimension: 1536,
       tick_interval_seconds: 300,
       max_tick_duration_seconds: 120,
       max_turns: 0,

--- a/test/db/schema.test.ts
+++ b/test/db/schema.test.ts
@@ -33,7 +33,7 @@ describe("schema migrations", () => {
     const row = db.query("SELECT COUNT(*) AS count FROM _migrations").get() as {
       count: number;
     };
-    expect(row.count).toBe(4);
+    expect(row.count).toBe(5);
 
     db.close();
   });

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,13 +1,12 @@
 import { DEFAULT_CONFIG } from "../src/config/schemas.ts";
 import { EMBEDDING_DIMENSION } from "../src/constants.ts";
-import type { EmbedFn } from "../src/context/embedder.ts";
 import { type DbConnection, getConnection } from "../src/db/connection.ts";
 import { createContextItem } from "../src/db/context.ts";
 import { migrate } from "../src/db/schema.ts";
 import type { ToolContext } from "../src/tools/tool.ts";
 
-/** Mock embedder that returns zero vectors without loading a real model. */
-export const mockEmbed: EmbedFn = async (texts: string[]) =>
+/** Mock embedder that returns zero vectors without calling a real API. */
+export const mockEmbed = async (texts: string[]) =>
   texts.map(() => new Array(EMBEDDING_DIMENSION).fill(0));
 
 /** Create a fresh in-memory database with migrations applied. */
@@ -25,7 +24,6 @@ export function setupToolContext(): { conn: DbConnection; ctx: ToolContext } {
     projectDir: "/tmp/test",
     config: { ...DEFAULT_CONFIG },
     mcpxClient: null,
-    embedFn: mockEmbed,
   };
   return { conn, ctx };
 }

--- a/test/tools/search.test.ts
+++ b/test/tools/search.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { EMBEDDING_DIMENSION } from "../../src/constants.ts";
 import { ingestContextItem } from "../../src/context/ingest.ts";
 import type { DbConnection } from "../../src/db/connection.ts";
@@ -10,8 +10,13 @@ import { seedFile, setupToolContext } from "../helpers.ts";
 let conn: DbConnection;
 let ctx: ToolContext;
 
+const originalFetch = globalThis.fetch;
 beforeEach(() => {
   ({ conn, ctx } = setupToolContext());
+  ctx.config.openai_api_key = "test-key";
+});
+afterEach(() => {
+  globalThis.fetch = originalFetch;
 });
 
 // ── search_grep ─────────────────────────────────────────────
@@ -131,9 +136,22 @@ describe("search_semantic", () => {
     );
     await ingestContextItem(conn, item.id, ctx.config, mockEmbed);
 
-    // search_semantic uses the real embedder, so we test the grep-based path here
-    // by verifying the tool doesn't throw anymore
-    // Full integration test with real model is in embedder.test.ts
+    // Mock fetch for the embedSingle call inside searchSemanticTool
+    const queryVec = await mockEmbed(["quarterly revenue"]).then(
+      (r) => r[0] ?? [],
+    );
+    globalThis.fetch = mock(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            data: [{ embedding: queryVec, index: 0 }],
+            usage: { total_tokens: 5 },
+          }),
+          { status: 200 },
+        ),
+      ),
+    ) as unknown as typeof fetch;
+
     const result = await searchSemanticTool.execute(
       { query: "quarterly revenue", top_k: 5 },
       ctx,


### PR DESCRIPTION
## Summary
- Replace local `@huggingface/transformers` embeddings with OpenAI API embeddings (`text-embedding-3-small`), removing the heavy HF dependency and its native ONNX runtime
- Add `context chunks <path>` command to inspect chunk/embedding details for a context item
- Add `context refresh [path] [--all]` command to re-import files from disk and re-embed changed content
- Add `--offset` pagination support to `context list`
- Add migration to reset existing embeddings for the new OpenAI embedding dimensions

## Test plan
- [x] `bun run lint` passes
- [x] `bun test` passes (458 tests)
- [ ] Manual: `context add`, `context chunks`, `context refresh` workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)