### PR TITLE
Mark milestone 6 done, drop binary compilation

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -7,7 +7,7 @@
 | 3 | [Schedules & Task Hardening](milestone-3-schedules-and-task-hardening.md) | **Done** | Recurring schedules, cycle detection, timeouts, full task/schedule CLI |
 | 4 | [MCPX Integration](milestone-4-mcpx-integration.md) | **Done** | External tools via MCP servers (Gmail, Slack, web, etc.) |
 | 5 | [Chat TUI](milestone-5-chat-tui.md) | **Done** | Interactive Ink/React terminal UI for conversational interaction |
-| 6 | [Daemon Watchdog & Distribution](milestone-6-daemon-watchdog-and-distribution.md) | Planned | OS-level watchdog, binary compilation, agent self-modification |
+| 6 | [Daemon Watchdog & Distribution](milestone-6-daemon-watchdog-and-distribution.md) | **Done** | OS-level watchdog, agent self-modification |
 | 7 | [Skills (Slash-Commands)](milestone-7-skills.md) | Planned | User-defined slash-commands loaded from `.botholomew/skills/` markdown files |
 | 8 | [Remote Context](milestone-8-remote-context.md) | Planned | Ingest context from URLs via LLM-driven MCPX tool selection |
 

--- a/docs/plans/milestone-6-daemon-watchdog-and-distribution.md
+++ b/docs/plans/milestone-6-daemon-watchdog-and-distribution.md
@@ -58,12 +58,9 @@ The watchdog needs to handle multiple Botholomew projects on one machine:
 - Each project gets its own launchd/systemd unit, keyed by a hash of the project directory path
 - `botholomew daemon list` — new subcommand, lists all registered Botholomew projects on this machine (scan LaunchAgents/systemd user units for botholomew entries)
 
-### 5. Binary Compilation
+### 5. ~~Binary Compilation~~ (Dropped)
 
-Set up `bun build --compile`:
-- `bun run build` produces `dist/botholomew` — a single standalone binary
-- Test that the binary works on a clean machine (no Bun required)
-- Add build instructions to CLAUDE.md
+Binary compilation is not feasible — native dependencies like DuckDB and the embedding libraries cannot be bundled by `bun build --compile`.
 
 ### 6. Agent Self-Modification
 
@@ -85,8 +82,7 @@ Add daemon tools:
 | `src/daemon/healthcheck.ts` | **New** — standalone health check script |
 | `src/commands/daemon.ts` | Implement install/uninstall, add list subcommand |
 | `src/daemon/llm.ts` | Add update_beliefs, update_goals tools |
-| `package.json` | Verify build script works |
-| `CLAUDE.md` | Add build/distribution docs |
+| ~~`package.json`~~ | ~~Build script~~ (dropped — native deps can't compile) |
 
 ## Tests
 
@@ -100,6 +96,9 @@ Add daemon tools:
 2. Kill the daemon process — watchdog restarts it within 60 seconds
 3. `botholomew daemon status` — shows daemon running + watchdog installed
 4. `botholomew daemon uninstall` — removes watchdog
-5. `bun run build && ./dist/botholomew --version` — binary works standalone
-6. Daemon modifies beliefs.md during a tick — file updated correctly, frontmatter preserved
-7. `botholomew daemon list` — shows all registered projects on this machine
+5. Daemon modifies beliefs.md during a tick — file updated correctly, frontmatter preserved
+6. `botholomew daemon list` — shows all registered projects on this machine
+
+## Status: **Done**
+
+Binary compilation was dropped (native deps like DuckDB can't be bundled). All other items are implemented and tested.


### PR DESCRIPTION
## Summary
- Marks milestone 6 (Daemon Watchdog & Distribution) as **Done** in the roadmap
- Drops the binary compilation item — native deps (DuckDB, embedding libs) can't be bundled by `bun build --compile`
- All other M6 items (watchdog, healthcheck, daemon commands, multi-project management, self-modification tools) were already implemented and tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)