### PR TITLE
Fix SQL injection, task claim race condition; add missing tests

### DIFF
--- a/src/db/context.ts
+++ b/src/db/context.ts
@@ -1,5 +1,5 @@
 import type { DbConnection } from "./connection.ts";
-import { buildSetClauses, buildWhereClause } from "./query.ts";
+import { buildSetClauses, buildWhereClause, sanitizeInt } from "./query.ts";
 import { uuidv7 } from "./uuid.ts";
 
 export interface ContextItem {
@@ -120,8 +120,8 @@ export async function listContextItems(
     ["context_path", filters?.contextPath],
     ["mime_type", filters?.mimeType],
   ]);
-  const limit = filters?.limit ? `LIMIT ${filters.limit}` : "";
-  const offset = filters?.offset ? `OFFSET ${filters.offset}` : "";
+  const limit = filters?.limit ? `LIMIT ${sanitizeInt(filters.limit)}` : "";
+  const offset = filters?.offset ? `OFFSET ${sanitizeInt(filters.offset)}` : "";
 
   const rows = await db.queryAll<ContextItemRow>(
     `SELECT * FROM context_items ${where} ORDER BY context_path ASC ${limit} ${offset}`,
@@ -137,8 +137,8 @@ export async function listContextItemsByPrefix(
 ): Promise<ContextItem[]> {
   const normalizedPrefix = prefix.endsWith("/") ? prefix : `${prefix}/`;
 
-  const limit = opts?.limit ? `LIMIT ${opts.limit}` : "";
-  const offset = opts?.offset ? `OFFSET ${opts.offset}` : "";
+  const limit = opts?.limit ? `LIMIT ${sanitizeInt(opts.limit)}` : "";
+  const offset = opts?.offset ? `OFFSET ${sanitizeInt(opts.offset)}` : "";
 
   let rows: ContextItemRow[];
   if (opts?.recursive) {

--- a/src/db/embeddings.ts
+++ b/src/db/embeddings.ts
@@ -2,6 +2,10 @@ import { EMBEDDING_DIMENSION } from "../constants.ts";
 import type { DbConnection } from "./connection.ts";
 import { uuidv7 } from "./uuid.ts";
 
+if (!Number.isInteger(EMBEDDING_DIMENSION) || EMBEDDING_DIMENSION <= 0) {
+  throw new Error(`Invalid EMBEDDING_DIMENSION: ${EMBEDDING_DIMENSION}`);
+}
+
 export interface Embedding {
   id: string;
   context_item_id: string;

--- a/src/db/query.ts
+++ b/src/db/query.ts
@@ -1,6 +1,17 @@
 type SqlParam = string | number | null;
 
 /**
+ * Validate that a value is a positive integer, suitable for use in
+ * LIMIT / OFFSET clauses that must be interpolated into SQL strings.
+ */
+export function sanitizeInt(val: number): number {
+  if (!Number.isInteger(val) || val <= 0) {
+    throw new Error(`Expected a positive integer, got: ${val}`);
+  }
+  return val;
+}
+
+/**
  * Build a WHERE clause from column-value pairs.
  * Entries with `undefined` values are skipped.
  */

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -57,8 +57,10 @@ export async function migrate(db: DbConnection): Promise<void> {
       await db.exec(statement);
     }
 
-    await db.exec(
-      `INSERT INTO _migrations (id, name) VALUES (${migration.id}, '${migration.name}')`,
+    await db.queryRun(
+      "INSERT INTO _migrations (id, name) VALUES (?1, ?2)",
+      migration.id,
+      migration.name,
     );
   }
 }

--- a/src/db/tasks.ts
+++ b/src/db/tasks.ts
@@ -1,5 +1,5 @@
 import type { DbConnection } from "./connection.ts";
-import { buildSetClauses, buildWhereClause } from "./query.ts";
+import { buildSetClauses, buildWhereClause, sanitizeInt } from "./query.ts";
 import { uuidv7 } from "./uuid.ts";
 
 export const TASK_PRIORITIES = ["low", "medium", "high"] as const;
@@ -112,7 +112,7 @@ export async function listTasks(
     ["status", filters?.status],
     ["priority", filters?.priority],
   ]);
-  const limit = filters?.limit ? `LIMIT ${filters.limit}` : "";
+  const limit = filters?.limit ? `LIMIT ${sanitizeInt(filters.limit)}` : "";
 
   const rows = await db.queryAll<TaskRow>(
     `SELECT * FROM tasks ${where}
@@ -272,51 +272,42 @@ export async function claimNextTask(
        created_at ASC`,
   );
 
-  // Find the first task whose blockers are all complete
-  let claimableRow: TaskRow | null = null;
   for (const row of allPending) {
     const blockedBy: string[] = JSON.parse(row.blocked_by || "[]");
-    if (blockedBy.length === 0) {
-      claimableRow = row;
-      break;
-    }
-    // Check if all blockers are complete
-    let allComplete = true;
-    for (const blockerId of blockedBy) {
-      const blocker = await db.queryGet<{ status: string }>(
-        "SELECT status FROM tasks WHERE id = ?1",
-        blockerId,
-      );
-      if (!blocker || blocker.status !== "complete") {
-        allComplete = false;
-        break;
+    if (blockedBy.length > 0) {
+      // Check if all blockers are complete
+      let allComplete = true;
+      for (const blockerId of blockedBy) {
+        const blocker = await db.queryGet<{ status: string }>(
+          "SELECT status FROM tasks WHERE id = ?1",
+          blockerId,
+        );
+        if (!blocker || blocker.status !== "complete") {
+          allComplete = false;
+          break;
+        }
       }
+      if (!allComplete) continue;
     }
-    if (allComplete) {
-      claimableRow = row;
-      break;
+
+    // Attempt atomic claim — RETURNING confirms we actually got it
+    const claimed = await db.queryGet<TaskRow>(
+      `UPDATE tasks
+       SET status = 'in_progress',
+           claimed_by = ?1,
+           claimed_at = current_timestamp::VARCHAR,
+           updated_at = current_timestamp::VARCHAR
+       WHERE id = ?2 AND status = 'pending'
+       RETURNING *`,
+      claimedBy,
+      row.id,
+    );
+
+    if (claimed) {
+      return rowToTask(claimed);
     }
+    // Another process claimed it — try next candidate
   }
 
-  if (!claimableRow) return null;
-  const task = rowToTask(claimableRow);
-
-  // Claim it
-  await db.queryRun(
-    `UPDATE tasks
-     SET status = 'in_progress',
-         claimed_by = ?1,
-         claimed_at = current_timestamp::VARCHAR,
-         updated_at = current_timestamp::VARCHAR
-     WHERE id = ?2 AND status = 'pending'`,
-    claimedBy,
-    task.id,
-  );
-
-  return {
-    ...task,
-    status: "in_progress",
-    claimed_by: claimedBy,
-    claimed_at: new Date(),
-  };
+  return null;
 }

--- a/test/config/schemas.test.ts
+++ b/test/config/schemas.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_CONFIG } from "../../src/config/schemas.ts";
+
+describe("DEFAULT_CONFIG", () => {
+  test("has all expected fields", () => {
+    expect(DEFAULT_CONFIG).toHaveProperty("anthropic_api_key");
+    expect(DEFAULT_CONFIG).toHaveProperty("openai_api_key");
+    expect(DEFAULT_CONFIG).toHaveProperty("model");
+    expect(DEFAULT_CONFIG).toHaveProperty("chunker_model");
+    expect(DEFAULT_CONFIG).toHaveProperty("embedding_model");
+    expect(DEFAULT_CONFIG).toHaveProperty("embedding_dimension");
+    expect(DEFAULT_CONFIG).toHaveProperty("tick_interval_seconds");
+    expect(DEFAULT_CONFIG).toHaveProperty("max_tick_duration_seconds");
+    expect(DEFAULT_CONFIG).toHaveProperty("system_prompt_override");
+    expect(DEFAULT_CONFIG).toHaveProperty("max_turns");
+  });
+
+  test("tick_interval_seconds is positive", () => {
+    expect(DEFAULT_CONFIG.tick_interval_seconds).toBeGreaterThan(0);
+  });
+
+  test("max_tick_duration_seconds is positive", () => {
+    expect(DEFAULT_CONFIG.max_tick_duration_seconds).toBeGreaterThan(0);
+  });
+
+  test("embedding_dimension is a positive integer", () => {
+    expect(DEFAULT_CONFIG.embedding_dimension).toBeGreaterThan(0);
+    expect(Number.isInteger(DEFAULT_CONFIG.embedding_dimension)).toBe(true);
+  });
+
+  test("model names are non-empty strings", () => {
+    expect(DEFAULT_CONFIG.model.length).toBeGreaterThan(0);
+    expect(DEFAULT_CONFIG.chunker_model.length).toBeGreaterThan(0);
+    expect(DEFAULT_CONFIG.embedding_model.length).toBeGreaterThan(0);
+  });
+
+  test("API keys default to empty strings", () => {
+    expect(DEFAULT_CONFIG.anthropic_api_key).toBe("");
+    expect(DEFAULT_CONFIG.openai_api_key).toBe("");
+  });
+
+  test("system_prompt_override defaults to empty string", () => {
+    expect(DEFAULT_CONFIG.system_prompt_override).toBe("");
+  });
+
+  test("max_turns defaults to 0 (unlimited)", () => {
+    expect(DEFAULT_CONFIG.max_turns).toBe(0);
+  });
+
+  test("tick_interval is longer than max_tick_duration", () => {
+    expect(DEFAULT_CONFIG.tick_interval_seconds).toBeGreaterThan(
+      DEFAULT_CONFIG.max_tick_duration_seconds,
+    );
+  });
+});

--- a/test/daemon/context.test.ts
+++ b/test/daemon/context.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, mock } from "bun:test";
 import type { MessageParam } from "@anthropic-ai/sdk/resources/messages";
 import { fitToContextWindow } from "../../src/daemon/context.ts";
+import { MockAnthropicModels } from "../helpers.ts";
+
+mock.module("@anthropic-ai/sdk", () => ({ default: MockAnthropicModels }));
+
+const { getMaxInputTokens } = await import("../../src/daemon/context.ts");
 
 describe("fitToContextWindow", () => {
   const defaultLimit = 200_000;
@@ -87,5 +92,79 @@ describe("fitToContextWindow", () => {
     ];
     const result = fitToContextWindow(messages, "Be helpful.", defaultLimit);
     expect(result).toHaveLength(3);
+  });
+
+  it("handles system prompt that fills the entire budget", () => {
+    // A system prompt that consumes all tokens — budget becomes <= 0
+    const hugeSystemPrompt = "x".repeat(defaultLimit * 4); // way over
+    const messages: MessageParam[] = [
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hi" },
+    ];
+    // Should not throw, should return messages unchanged (warning logged)
+    const result = fitToContextWindow(messages, hugeSystemPrompt, defaultLimit);
+    expect(result).toHaveLength(2);
+  });
+
+  it("does not truncate tool results under the threshold", () => {
+    const smallContent = "x".repeat(1000);
+    const messages: MessageParam[] = [
+      { role: "user", content: "Hello" },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "test-id",
+            content: smallContent,
+          },
+        ],
+      },
+    ];
+
+    fitToContextWindow(messages, "system", defaultLimit);
+    const block = (messages[1]?.content as Array<{ content: string }>)[0];
+    expect(block?.content).toBe(smallContent);
+    expect(block?.content).not.toContain("[truncated:");
+  });
+
+  it("handles messages with mixed content block types", () => {
+    const messages: MessageParam[] = [
+      { role: "user", content: "Start" },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "I'll call a tool." },
+          {
+            type: "tool_use",
+            id: "tool_1",
+            name: "test",
+            input: { key: "value" },
+          },
+        ],
+      },
+    ];
+    // Should not crash on mixed block types
+    const result = fitToContextWindow(messages, "system", defaultLimit);
+    expect(result).toHaveLength(2);
+  });
+});
+
+describe("getMaxInputTokens", () => {
+  it("returns the model's max_input_tokens from API", async () => {
+    const result = await getMaxInputTokens("test-key", "test-model-unique");
+    expect(result).toBe(100_000);
+  });
+
+  it("caches results for same model", async () => {
+    // First call hits API, second uses cache
+    const r1 = await getMaxInputTokens("test-key", "cached-model");
+    const r2 = await getMaxInputTokens("test-key", "cached-model");
+    expect(r1).toBe(r2);
+  });
+
+  it("returns default when API fails", async () => {
+    const result = await getMaxInputTokens("test-key", "fail-model");
+    expect(result).toBe(200_000); // DEFAULT_MAX_INPUT_TOKENS
   });
 });

--- a/test/daemon/llm.test.ts
+++ b/test/daemon/llm.test.ts
@@ -2,25 +2,13 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import type { DbConnection } from "../../src/db/connection.ts";
 import { createTask } from "../../src/db/tasks.ts";
 import { createThread, getThread } from "../../src/db/threads.ts";
-import { setupTestDb } from "../helpers.ts";
+import { completionResponse, setupTestDb, TEST_CONFIG } from "../helpers.ts";
 
 let mockCreate: ReturnType<typeof mock>;
 
 // Mock the Anthropic SDK
 mock.module("@anthropic-ai/sdk", () => {
-  mockCreate = mock(async () => ({
-    content: [
-      { type: "text", text: "Done." },
-      {
-        type: "tool_use",
-        id: "tool_1",
-        name: "complete_task",
-        input: { summary: "Task completed" },
-      },
-    ],
-    stop_reason: "tool_use",
-    usage: { input_tokens: 100, output_tokens: 50 },
-  }));
+  mockCreate = mock(async () => completionResponse("Task completed"));
 
   return {
     default: class MockAnthropic {
@@ -33,18 +21,7 @@ const { runAgentLoop } = await import("../../src/daemon/llm.ts");
 
 let conn: DbConnection;
 
-const testConfig = {
-  anthropic_api_key: "test-key",
-  openai_api_key: "",
-  model: "claude-opus-4-20250514",
-  chunker_model: "claude-haiku-4-20250514",
-  embedding_model: "text-embedding-3-small",
-  embedding_dimension: 1536,
-  tick_interval_seconds: 300,
-  max_tick_duration_seconds: 120,
-  max_turns: 10,
-  system_prompt_override: "",
-};
+const testConfig = { ...TEST_CONFIG, max_turns: 10 };
 
 beforeEach(async () => {
   conn = await setupTestDb();

--- a/test/daemon/prompt.test.ts
+++ b/test/daemon/prompt.test.ts
@@ -3,23 +3,15 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { serializeContextFile } from "../../src/utils/frontmatter.ts";
+import { mockEmbedSingle, silentLogger } from "../helpers.ts";
 
 // Mock the embedder to avoid loading the real model
 mock.module("../../src/context/embedder.ts", () => ({
-  embedSingle: async () => new Array(384).fill(0),
+  embedSingle: mockEmbedSingle,
 }));
 
 // Mock the logger to suppress output
-mock.module("../../src/utils/logger.ts", () => ({
-  logger: {
-    info: () => {},
-    success: () => {},
-    warn: () => {},
-    error: () => {},
-    debug: () => {},
-    dim: () => {},
-  },
-}));
+mock.module("../../src/utils/logger.ts", () => silentLogger);
 
 const { buildSystemPrompt } = await import("../../src/daemon/prompt.ts");
 

--- a/test/daemon/schedules.test.ts
+++ b/test/daemon/schedules.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import type { DbConnection } from "../../src/db/connection.ts";
 import { createSchedule, getSchedule } from "../../src/db/schedules.ts";
 import { listTasks } from "../../src/db/tasks.ts";
-import { setupTestDb } from "../helpers.ts";
+import { setupTestDb, TEST_CONFIG } from "../helpers.ts";
 
 let mockResponse: Record<string, unknown> = {};
 
@@ -27,19 +27,6 @@ const { evaluateSchedule, processSchedules } = await import(
 
 let conn: DbConnection;
 
-const testConfig = {
-  anthropic_api_key: "test-key",
-  openai_api_key: "",
-  model: "claude-opus-4-20250514",
-  chunker_model: "claude-haiku-4-20250514",
-  embedding_model: "text-embedding-3-small",
-  embedding_dimension: 1536,
-  tick_interval_seconds: 300,
-  max_tick_duration_seconds: 120,
-  max_turns: 0,
-  system_prompt_override: "",
-};
-
 beforeEach(async () => {
   conn = await setupTestDb();
   mockResponse = {};
@@ -60,7 +47,7 @@ describe("evaluateSchedule", () => {
       frequency: "every morning",
     });
 
-    const result = await evaluateSchedule(testConfig, schedule);
+    const result = await evaluateSchedule(TEST_CONFIG, schedule);
     expect(result.isDue).toBe(true);
     expect(result.tasksToCreate).toHaveLength(1);
     expect(result.tasksToCreate[0]?.name).toBe("Check email");
@@ -78,7 +65,7 @@ describe("evaluateSchedule", () => {
       frequency: "every 4 hours",
     });
 
-    const result = await evaluateSchedule(testConfig, schedule);
+    const result = await evaluateSchedule(TEST_CONFIG, schedule);
     expect(result.isDue).toBe(false);
     expect(result.tasksToCreate).toHaveLength(0);
   });
@@ -107,7 +94,7 @@ describe("evaluateSchedule", () => {
       frequency: "daily",
     });
 
-    const result = await evalFresh(testConfig, schedule);
+    const result = await evalFresh(TEST_CONFIG, schedule);
     expect(result.isDue).toBe(false);
     expect(result.reasoning).toContain("failed");
 
@@ -145,7 +132,7 @@ describe("evaluateSchedule", () => {
       frequency: "daily",
     });
 
-    const result = await evaluateSchedule(testConfig, schedule);
+    const result = await evaluateSchedule(TEST_CONFIG, schedule);
     expect(result.tasksToCreate).toHaveLength(2);
     expect(result.tasksToCreate[1]?.depends_on).toEqual([0]);
   });
@@ -166,7 +153,7 @@ describe("processSchedules", () => {
       frequency: "every morning",
     });
 
-    await processSchedules(conn, testConfig);
+    await processSchedules(conn, TEST_CONFIG);
 
     const tasks = await listTasks(conn);
     expect(tasks).toHaveLength(1);
@@ -185,7 +172,7 @@ describe("processSchedules", () => {
       frequency: "daily",
     });
 
-    await processSchedules(conn, testConfig);
+    await processSchedules(conn, TEST_CONFIG);
 
     const updated = await getSchedule(conn, schedule.id);
     expect(updated?.last_run_at).not.toBeNull();
@@ -203,7 +190,7 @@ describe("processSchedules", () => {
       frequency: "weekly",
     });
 
-    await processSchedules(conn, testConfig);
+    await processSchedules(conn, TEST_CONFIG);
 
     const tasks = await listTasks(conn);
     expect(tasks).toHaveLength(0);
@@ -224,7 +211,7 @@ describe("processSchedules", () => {
     const { updateSchedule } = await import("../../src/db/schedules.ts");
     await updateSchedule(conn, schedule.id, { enabled: false });
 
-    await processSchedules(conn, testConfig);
+    await processSchedules(conn, TEST_CONFIG);
 
     const tasks = await listTasks(conn);
     expect(tasks).toHaveLength(0);
@@ -250,7 +237,7 @@ describe("processSchedules", () => {
       frequency: "daily",
     });
 
-    await processSchedules(conn, testConfig);
+    await processSchedules(conn, TEST_CONFIG);
 
     const tasks = await listTasks(conn);
     expect(tasks).toHaveLength(2);
@@ -265,7 +252,7 @@ describe("processSchedules", () => {
 
   test("does nothing with no enabled schedules", async () => {
     // No schedules at all — should return immediately
-    await processSchedules(conn, testConfig);
+    await processSchedules(conn, TEST_CONFIG);
 
     const tasks = await listTasks(conn);
     expect(tasks).toHaveLength(0);

--- a/test/daemon/tick.test.ts
+++ b/test/daemon/tick.test.ts
@@ -2,26 +2,14 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import type { DbConnection } from "../../src/db/connection.ts";
 import { createTask, getTask } from "../../src/db/tasks.ts";
 import { getThread, listThreads } from "../../src/db/threads.ts";
-import { setupTestDb } from "../helpers.ts";
+import { completionResponse, setupTestDb, TEST_CONFIG } from "../helpers.ts";
 
 // Mock the Anthropic SDK before importing tick
 mock.module("@anthropic-ai/sdk", () => {
   return {
     default: class MockAnthropic {
       messages = {
-        create: async () => ({
-          content: [
-            { type: "text", text: "I'll complete this task." },
-            {
-              type: "tool_use",
-              id: "tool_1",
-              name: "complete_task",
-              input: { summary: "Task done successfully" },
-            },
-          ],
-          stop_reason: "tool_use",
-          usage: { input_tokens: 100, output_tokens: 50 },
-        }),
+        create: async () => completionResponse(),
       };
     },
   };
@@ -43,18 +31,7 @@ describe("daemon tick", () => {
       description: "Do a thing",
     });
 
-    await tick("/tmp/test-project", conn, {
-      anthropic_api_key: "test-key",
-      openai_api_key: "",
-      model: "claude-opus-4-20250514",
-      chunker_model: "claude-haiku-4-20250514",
-      embedding_model: "text-embedding-3-small",
-      embedding_dimension: 1536,
-      tick_interval_seconds: 300,
-      max_tick_duration_seconds: 120,
-      max_turns: 0,
-      system_prompt_override: "",
-    });
+    await tick("/tmp/test-project", conn, TEST_CONFIG);
 
     // Task should be completed
     const updated = await getTask(conn, task.id);
@@ -67,18 +44,7 @@ describe("daemon tick", () => {
       description: "Do a thing",
     });
 
-    await tick("/tmp/test-project", conn, {
-      anthropic_api_key: "test-key",
-      openai_api_key: "",
-      model: "claude-opus-4-20250514",
-      chunker_model: "claude-haiku-4-20250514",
-      embedding_model: "text-embedding-3-small",
-      embedding_dimension: 1536,
-      tick_interval_seconds: 300,
-      max_tick_duration_seconds: 120,
-      max_turns: 0,
-      system_prompt_override: "",
-    });
+    await tick("/tmp/test-project", conn, TEST_CONFIG);
 
     // Should have created a thread
     const threads = await listThreads(conn, { type: "daemon_tick" });
@@ -100,18 +66,7 @@ describe("daemon tick", () => {
   });
 
   test("does nothing when no tasks available", async () => {
-    await tick("/tmp/test-project", conn, {
-      anthropic_api_key: "test-key",
-      openai_api_key: "",
-      model: "claude-opus-4-20250514",
-      chunker_model: "claude-haiku-4-20250514",
-      embedding_model: "text-embedding-3-small",
-      embedding_dimension: 1536,
-      tick_interval_seconds: 300,
-      max_tick_duration_seconds: 120,
-      max_turns: 0,
-      system_prompt_override: "",
-    });
+    await tick("/tmp/test-project", conn, TEST_CONFIG);
 
     // No threads created
     const threads = await listThreads(conn);
@@ -137,18 +92,7 @@ describe("daemon tick", () => {
       description: "LLM will error",
     });
 
-    await tickFresh("/tmp/test-project", conn, {
-      anthropic_api_key: "test-key",
-      openai_api_key: "",
-      model: "claude-opus-4-20250514",
-      chunker_model: "claude-haiku-4-20250514",
-      embedding_model: "text-embedding-3-small",
-      embedding_dimension: 1536,
-      tick_interval_seconds: 300,
-      max_tick_duration_seconds: 120,
-      max_turns: 0,
-      system_prompt_override: "",
-    });
+    await tickFresh("/tmp/test-project", conn, TEST_CONFIG);
 
     const updated = await getTask(conn, task.id);
     expect(updated?.status).toBe("failed");
@@ -163,19 +107,7 @@ describe("daemon tick", () => {
     mock.module("@anthropic-ai/sdk", () => ({
       default: class MockAnthropic {
         messages = {
-          create: async () => ({
-            content: [
-              { type: "text", text: "I'll complete this task." },
-              {
-                type: "tool_use",
-                id: "tool_1",
-                name: "complete_task",
-                input: { summary: "Task done successfully" },
-              },
-            ],
-            stop_reason: "tool_use",
-            usage: { input_tokens: 100, output_tokens: 50 },
-          }),
+          create: async () => completionResponse(),
         };
       },
     }));
@@ -194,18 +126,7 @@ describe("daemon tick", () => {
       priority: "high",
     });
 
-    await tick("/tmp/test-project", conn, {
-      anthropic_api_key: "test-key",
-      openai_api_key: "",
-      model: "claude-opus-4-20250514",
-      chunker_model: "claude-haiku-4-20250514",
-      embedding_model: "text-embedding-3-small",
-      embedding_dimension: 1536,
-      tick_interval_seconds: 300,
-      max_tick_duration_seconds: 120,
-      max_turns: 0,
-      system_prompt_override: "",
-    });
+    await tick("/tmp/test-project", conn, TEST_CONFIG);
 
     // High priority task should be completed
     const updatedHigh = await getTask(conn, highTask.id);

--- a/test/db/context.test.ts
+++ b/test/db/context.test.ts
@@ -277,6 +277,58 @@ describe("mutations", () => {
     expect(item.content).toBe("a\nB\nc\nD\ne");
   });
 
+  test("applyPatches — throws for nonexistent item", async () => {
+    await expect(
+      applyPatchesToContextItem(conn, "/does-not-exist.md", [
+        { start_line: 1, end_line: 1, content: "x" },
+      ]),
+    ).rejects.toThrow("Not found");
+  });
+
+  test("applyPatches — throws for null content", async () => {
+    await createContextItem(conn, {
+      title: "Binary",
+      contextPath: "/binary.bin",
+      isTextual: false,
+    });
+
+    await expect(
+      applyPatchesToContextItem(conn, "/binary.bin", [
+        { start_line: 1, end_line: 1, content: "x" },
+      ]),
+    ).rejects.toThrow("No text content");
+  });
+
+  test("applyPatches — out-of-bounds start_line extends content", async () => {
+    await createContextItem(conn, {
+      title: "Short",
+      contextPath: "/short.md",
+      content: "only-one-line",
+    });
+
+    // start_line 5 on a 1-line file — splice inserts at end
+    const { item } = await applyPatchesToContextItem(conn, "/short.md", [
+      { start_line: 5, end_line: 0, content: "appended" },
+    ]);
+
+    expect(item.content).toContain("only-one-line");
+    expect(item.content).toContain("appended");
+  });
+
+  test("applyPatches — replace single line with multiple lines", async () => {
+    await createContextItem(conn, {
+      title: "Test",
+      contextPath: "/test.md",
+      content: "a\nb\nc",
+    });
+
+    const { item } = await applyPatchesToContextItem(conn, "/test.md", [
+      { start_line: 2, end_line: 2, content: "x\ny\nz" },
+    ]);
+
+    expect(item.content).toBe("a\nx\ny\nz\nc");
+  });
+
   test("copyContextItem", async () => {
     await createContextItem(conn, {
       title: "Original",

--- a/test/db/query-sanitize.test.ts
+++ b/test/db/query-sanitize.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { sanitizeInt } from "../../src/db/query.ts";
+
+describe("sanitizeInt", () => {
+  test("valid positive integers pass through", () => {
+    expect(sanitizeInt(1)).toBe(1);
+    expect(sanitizeInt(10)).toBe(10);
+    expect(sanitizeInt(100)).toBe(100);
+    expect(sanitizeInt(999999)).toBe(999999);
+  });
+
+  test("zero throws", () => {
+    expect(() => sanitizeInt(0)).toThrow("Expected a positive integer");
+  });
+
+  test("negative numbers throw", () => {
+    expect(() => sanitizeInt(-1)).toThrow("Expected a positive integer");
+    expect(() => sanitizeInt(-100)).toThrow("Expected a positive integer");
+  });
+
+  test("non-integers throw", () => {
+    expect(() => sanitizeInt(1.5)).toThrow("Expected a positive integer");
+    expect(() => sanitizeInt(0.1)).toThrow("Expected a positive integer");
+  });
+
+  test("NaN throws", () => {
+    expect(() => sanitizeInt(NaN)).toThrow("Expected a positive integer");
+  });
+
+  test("Infinity throws", () => {
+    expect(() => sanitizeInt(Infinity)).toThrow("Expected a positive integer");
+    expect(() => sanitizeInt(-Infinity)).toThrow("Expected a positive integer");
+  });
+
+  test("returns the validated number", () => {
+    const result = sanitizeInt(42);
+    expect(result).toBe(42);
+    expect(typeof result).toBe("number");
+  });
+});

--- a/test/db/query.test.ts
+++ b/test/db/query.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+import { buildSetClauses, buildWhereClause } from "../../src/db/query.ts";
+
+describe("buildWhereClause", () => {
+  test("builds clause from single filter", () => {
+    const result = buildWhereClause([["name", "alice"]]);
+    expect(result.where).toBe("WHERE name = ?1");
+    expect(result.params).toEqual(["alice"]);
+  });
+
+  test("builds clause from multiple filters", () => {
+    const result = buildWhereClause([
+      ["status", "active"],
+      ["priority", "high"],
+    ]);
+    expect(result.where).toBe("WHERE status = ?1 AND priority = ?2");
+    expect(result.params).toEqual(["active", "high"]);
+  });
+
+  test("skips undefined values", () => {
+    const result = buildWhereClause([
+      ["status", "active"],
+      ["priority", undefined],
+      ["name", "bob"],
+    ]);
+    expect(result.where).toBe("WHERE status = ?1 AND name = ?2");
+    expect(result.params).toEqual(["active", "bob"]);
+  });
+
+  test("returns empty string for empty filters", () => {
+    const result = buildWhereClause([]);
+    expect(result.where).toBe("");
+    expect(result.params).toEqual([]);
+  });
+
+  test("returns empty string when all values are undefined", () => {
+    const result = buildWhereClause([
+      ["a", undefined],
+      ["b", undefined],
+    ]);
+    expect(result.where).toBe("");
+    expect(result.params).toEqual([]);
+  });
+
+  test("handles null values", () => {
+    const result = buildWhereClause([["deleted_at", null]]);
+    expect(result.where).toBe("WHERE deleted_at = ?1");
+    expect(result.params).toEqual([null]);
+  });
+
+  test("handles numeric values", () => {
+    const result = buildWhereClause([
+      ["enabled", 1],
+      ["max_retries", 5],
+    ]);
+    expect(result.where).toBe("WHERE enabled = ?1 AND max_retries = ?2");
+    expect(result.params).toEqual([1, 5]);
+  });
+});
+
+describe("buildSetClauses", () => {
+  test("builds set clauses from single field", () => {
+    const result = buildSetClauses([["name", "alice"]]);
+    expect(result.setClauses).toEqual(["name = ?1"]);
+    expect(result.params).toEqual(["alice"]);
+  });
+
+  test("builds set clauses from multiple fields", () => {
+    const result = buildSetClauses([
+      ["name", "alice"],
+      ["status", "done"],
+    ]);
+    expect(result.setClauses).toEqual(["name = ?1", "status = ?2"]);
+    expect(result.params).toEqual(["alice", "done"]);
+  });
+
+  test("skips undefined values", () => {
+    const result = buildSetClauses([
+      ["name", "alice"],
+      ["description", undefined],
+      ["status", "done"],
+    ]);
+    expect(result.setClauses).toEqual(["name = ?1", "status = ?2"]);
+    expect(result.params).toEqual(["alice", "done"]);
+  });
+
+  test("returns empty arrays when all values are undefined", () => {
+    const result = buildSetClauses([
+      ["a", undefined],
+      ["b", undefined],
+    ]);
+    expect(result.setClauses).toEqual([]);
+    expect(result.params).toEqual([]);
+  });
+
+  test("returns empty arrays for empty input", () => {
+    const result = buildSetClauses([]);
+    expect(result.setClauses).toEqual([]);
+    expect(result.params).toEqual([]);
+  });
+
+  test("parameter numbering is sequential across non-undefined values", () => {
+    const result = buildSetClauses([
+      ["a", undefined],
+      ["b", "val1"],
+      ["c", undefined],
+      ["d", "val2"],
+      ["e", "val3"],
+    ]);
+    expect(result.setClauses).toEqual(["b = ?1", "d = ?2", "e = ?3"]);
+    expect(result.params).toEqual(["val1", "val2", "val3"]);
+  });
+});

--- a/test/db/tasks-claim-race.test.ts
+++ b/test/db/tasks-claim-race.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import type { DbConnection } from "../../src/db/connection.ts";
+import {
+  claimNextTask,
+  createTask,
+  updateTaskStatus,
+} from "../../src/db/tasks.ts";
+import { setupTestDb } from "../helpers.ts";
+
+let conn: DbConnection;
+
+beforeEach(async () => {
+  conn = await setupTestDb();
+});
+
+describe("claimNextTask race condition", () => {
+  test("skips already-claimed task and claims next candidate", async () => {
+    // Create two pending tasks — high priority first
+    const high = await createTask(conn, {
+      name: "High priority",
+      priority: "high",
+    });
+    await createTask(conn, {
+      name: "Low priority",
+      priority: "low",
+    });
+
+    // Simulate race: manually claim the high-priority task between read and update
+    await updateTaskStatus(conn, high.id, "in_progress");
+
+    // claimNextTask should skip the already-claimed high and claim the low
+    const claimed = await claimNextTask(conn);
+    expect(claimed).not.toBeNull();
+    expect(claimed?.name).toBe("Low priority");
+    expect(claimed?.status).toBe("in_progress");
+    expect(claimed?.claimed_by).toBe("daemon");
+  });
+
+  test("returns null when all candidates are already claimed", async () => {
+    const task = await createTask(conn, { name: "Only task" });
+
+    // Claim it externally before claimNextTask runs
+    await updateTaskStatus(conn, task.id, "in_progress");
+
+    const claimed = await claimNextTask(conn);
+    expect(claimed).toBeNull();
+  });
+
+  test("skips multiple already-claimed tasks", async () => {
+    const t1 = await createTask(conn, { name: "T1", priority: "high" });
+    const t2 = await createTask(conn, { name: "T2", priority: "medium" });
+    await createTask(conn, { name: "T3", priority: "low" });
+
+    // Claim both high and medium externally
+    await updateTaskStatus(conn, t1.id, "in_progress");
+    await updateTaskStatus(conn, t2.id, "in_progress");
+
+    const claimed = await claimNextTask(conn);
+    expect(claimed).not.toBeNull();
+    expect(claimed?.name).toBe("T3");
+  });
+
+  test("claims with custom claimedBy value", async () => {
+    await createTask(conn, { name: "Task", priority: "medium" });
+
+    const claimed = await claimNextTask(conn, "worker-2");
+    expect(claimed).not.toBeNull();
+    expect(claimed?.claimed_by).toBe("worker-2");
+  });
+});

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,3 +1,4 @@
+import type { BotholomewConfig } from "../src/config/schemas.ts";
 import { DEFAULT_CONFIG } from "../src/config/schemas.ts";
 import { EMBEDDING_DIMENSION } from "../src/constants.ts";
 import { type DbConnection, getConnection } from "../src/db/connection.ts";
@@ -5,9 +6,89 @@ import { createContextItem } from "../src/db/context.ts";
 import { migrate } from "../src/db/schema.ts";
 import type { ToolContext } from "../src/tools/tool.ts";
 
+// ---------------------------------------------------------------------------
+// Mock helpers — Anthropic SDK
+// ---------------------------------------------------------------------------
+
+/** Standard LLM response shape returned by mock Anthropic clients. */
+export interface MockLLMResponse {
+  content: Array<
+    | { type: "text"; text: string }
+    | { type: "tool_use"; id: string; name: string; input: unknown }
+  >;
+  stop_reason: string;
+  usage: { input_tokens: number; output_tokens: number };
+}
+
+/** Build a simple "complete_task" response for mock LLM. */
+export function completionResponse(
+  summary = "Task done successfully",
+): MockLLMResponse {
+  return {
+    content: [
+      { type: "text", text: "I'll complete this task." },
+      {
+        type: "tool_use",
+        id: "tool_1",
+        name: "complete_task",
+        input: { summary },
+      },
+    ],
+    stop_reason: "tool_use",
+    usage: { input_tokens: 100, output_tokens: 50 },
+  };
+}
+
+/**
+ * Mock Anthropic SDK module value for `beta.models.retrieve()`.
+ *
+ * Returns `max_input_tokens: 100_000` for most models, throws for `"fail-model"`.
+ * Use with `mock.module("@anthropic-ai/sdk", () => ({ default: MockAnthropicModels }))`.
+ */
+export class MockAnthropicModels {
+  beta = {
+    models: {
+      retrieve: async (model: string) => {
+        if (model === "fail-model") throw new Error("API error");
+        return { max_input_tokens: 100_000 };
+      },
+    },
+  };
+}
+
+/** Suppressed logger — all methods are no-ops. Usable with `mock.module()`. */
+export const silentLogger = {
+  logger: {
+    info: () => {},
+    success: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    dim: () => {},
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Mock helpers — embeddings
+// ---------------------------------------------------------------------------
+
 /** Mock embedder that returns zero vectors without calling a real API. */
 export const mockEmbed = async (texts: string[]) =>
   texts.map(() => new Array(EMBEDDING_DIMENSION).fill(0));
+
+/** Mock single-text embedder (returns a zero vector). */
+export const mockEmbedSingle = async () =>
+  new Array(EMBEDDING_DIMENSION).fill(0);
+
+// ---------------------------------------------------------------------------
+// Test config
+// ---------------------------------------------------------------------------
+
+/** Daemon config suitable for tests — includes a fake API key. */
+export const TEST_CONFIG: Required<BotholomewConfig> = {
+  ...DEFAULT_CONFIG,
+  anthropic_api_key: "test-key",
+};
 
 /** Create a fresh in-memory database with migrations applied. */
 export async function setupTestDb(): Promise<DbConnection> {

--- a/test/tools/context-tools.test.ts
+++ b/test/tools/context-tools.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  clearLargeResults,
+  storeLargeResult,
+} from "../../src/daemon/large-results.ts";
+import { readLargeResultTool } from "../../src/tools/context/read-large-result.ts";
+import { updateBeliefsTool } from "../../src/tools/context/update-beliefs.ts";
+import { updateGoalsTool } from "../../src/tools/context/update-goals.ts";
+import type { ToolContext } from "../../src/tools/tool.ts";
+import { setupToolContext } from "../helpers.ts";
+
+let ctx: ToolContext;
+let projectDir: string;
+
+beforeEach(async () => {
+  ({ ctx } = await setupToolContext());
+  // Use a real temp directory so Bun.write / Bun.file work
+  projectDir = await mkdtemp(join(tmpdir(), "botholomew-ctx-test-"));
+  const { mkdir } = await import("node:fs/promises");
+  await mkdir(join(projectDir, ".botholomew"), { recursive: true });
+  ctx.projectDir = projectDir;
+});
+
+afterEach(async () => {
+  clearLargeResults();
+  await rm(projectDir, { recursive: true, force: true });
+});
+
+// ── update_beliefs ─────────────────────────────────────────
+
+describe("update_beliefs", () => {
+  test("creates beliefs.md when it does not exist", async () => {
+    const result = await updateBeliefsTool.execute(
+      { content: "The sky is blue." },
+      ctx,
+    );
+    expect(result.is_error).toBe(false);
+    expect(result.message).toContain("Updated beliefs.md");
+
+    const written = await Bun.file(
+      join(projectDir, ".botholomew", "beliefs.md"),
+    ).text();
+    expect(written).toContain("The sky is blue.");
+  });
+
+  test("preserves frontmatter on update", async () => {
+    const initial = [
+      "---",
+      "loading: always",
+      "agent-modification: true",
+      "---",
+      "Old beliefs content",
+    ].join("\n");
+    await Bun.write(join(projectDir, ".botholomew", "beliefs.md"), initial);
+
+    const result = await updateBeliefsTool.execute(
+      { content: "New beliefs content" },
+      ctx,
+    );
+    expect(result.is_error).toBe(false);
+
+    const written = await Bun.file(
+      join(projectDir, ".botholomew", "beliefs.md"),
+    ).text();
+    expect(written).toContain("loading: always");
+    expect(written).toContain("New beliefs content");
+    expect(written).not.toContain("Old beliefs content");
+  });
+
+  test("rejects update when agent-modification is false", async () => {
+    const locked = [
+      "---",
+      "loading: always",
+      "agent-modification: false",
+      "---",
+      "Locked content",
+    ].join("\n");
+    await Bun.write(join(projectDir, ".botholomew", "beliefs.md"), locked);
+
+    const result = await updateBeliefsTool.execute(
+      { content: "Attempted update" },
+      ctx,
+    );
+    expect(result.is_error).toBe(true);
+    expect(result.message).toContain("not allowed");
+  });
+});
+
+// ── update_goals ───────────────────────────────────────────
+
+describe("update_goals", () => {
+  test("creates goals.md when it does not exist", async () => {
+    const result = await updateGoalsTool.execute({ content: "Ship v1.0" }, ctx);
+    expect(result.is_error).toBe(false);
+    expect(result.message).toContain("Updated goals.md");
+
+    const written = await Bun.file(
+      join(projectDir, ".botholomew", "goals.md"),
+    ).text();
+    expect(written).toContain("Ship v1.0");
+  });
+
+  test("preserves frontmatter on update", async () => {
+    const initial = [
+      "---",
+      "loading: always",
+      "agent-modification: true",
+      "---",
+      "Old goals",
+    ].join("\n");
+    await Bun.write(join(projectDir, ".botholomew", "goals.md"), initial);
+
+    const result = await updateGoalsTool.execute({ content: "New goals" }, ctx);
+    expect(result.is_error).toBe(false);
+
+    const written = await Bun.file(
+      join(projectDir, ".botholomew", "goals.md"),
+    ).text();
+    expect(written).toContain("loading: always");
+    expect(written).toContain("New goals");
+    expect(written).not.toContain("Old goals");
+  });
+
+  test("rejects update when agent-modification is false", async () => {
+    const locked = [
+      "---",
+      "loading: always",
+      "agent-modification: false",
+      "---",
+      "Locked goals",
+    ].join("\n");
+    await Bun.write(join(projectDir, ".botholomew", "goals.md"), locked);
+
+    const result = await updateGoalsTool.execute(
+      { content: "Attempted update" },
+      ctx,
+    );
+    expect(result.is_error).toBe(true);
+    expect(result.message).toContain("not allowed");
+  });
+});
+
+// ── read_large_result ──────────────────────────────────────
+
+describe("read_large_result", () => {
+  test("reads page from stored large result", async () => {
+    const id = storeLargeResult("test_tool", "Hello, world!");
+    const result = await readLargeResultTool.execute({ id, page: 1 });
+    expect(result.is_error).toBe(false);
+    expect(result.content).toBe("Hello, world!");
+    expect(result.page).toBe(1);
+    expect(result.totalPages).toBe(1);
+  });
+
+  test("paginates multi-page results", async () => {
+    // Create content larger than PAGE_SIZE_CHARS (8000)
+    const content = "x".repeat(20_000);
+    const id = storeLargeResult("big_tool", content);
+
+    const page1 = await readLargeResultTool.execute({ id, page: 1 });
+    expect(page1.is_error).toBe(false);
+    expect(page1.page).toBe(1);
+    expect(page1.totalPages).toBe(3);
+    expect(page1.content.length).toBe(8_000);
+
+    const page2 = await readLargeResultTool.execute({ id, page: 2 });
+    expect(page2.page).toBe(2);
+    expect(page2.content.length).toBe(8_000);
+
+    const page3 = await readLargeResultTool.execute({ id, page: 3 });
+    expect(page3.page).toBe(3);
+    expect(page3.content.length).toBe(4_000);
+  });
+
+  test("throws for invalid id", async () => {
+    await expect(
+      readLargeResultTool.execute({ id: "lr_nonexistent", page: 1 }),
+    ).rejects.toThrow("No result found");
+  });
+
+  test("throws for out-of-range page", async () => {
+    const id = storeLargeResult("tool", "short");
+    await expect(
+      readLargeResultTool.execute({ id, page: 999 }),
+    ).rejects.toThrow("No result found");
+  });
+});


### PR DESCRIPTION
## Summary
- **SQL injection fixes**: Added `sanitizeInt()` validator for LIMIT/OFFSET interpolation in `context.ts` and `tasks.ts`; fixed string interpolation in migration recording (`schema.ts`); added runtime assertion for `EMBEDDING_DIMENSION` in `embeddings.ts`
- **Race condition fix**: Rewrote `claimNextTask()` to use `UPDATE...RETURNING *` for atomic claim verification — if another process claims the task first, it retries the next candidate instead of returning stale data
- **New tests** (30 tests across 4 new files): `sanitizeInt` validation, task claim race condition, context tools (update-beliefs, update-goals, read-large-result), config schema defaults
- **Consolidated test mocks**: Extracted shared helpers (`TEST_CONFIG`, `completionResponse()`, `MockAnthropicModels`, `silentLogger`, `mockEmbedSingle`) into `test/helpers.ts`, eliminating ~150 lines of duplicated mock setup
- **Extended existing tests**: `buildWhereClause`/`buildSetClauses` (13 tests), context patching edge cases, daemon context window management

## Test plan
- [x] `bun test` — 511 tests pass, 0 failures
- [x] `bun run lint` — clean (tsc + biome)

🤖 Generated with [Claude Code](https://claude.com/claude-code)