### PR TITLE
Skip sleep after completing a task, only sleep when idle

### DIFF
--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -36,12 +36,15 @@ export async function startDaemon(projectDir: string): Promise<void> {
   logger.info(`Tick interval: ${config.tick_interval_seconds}s`);
 
   while (true) {
+    let didWork = false;
     try {
-      await tick(projectDir, conn, config, mcpxClient);
+      didWork = await tick(projectDir, conn, config, mcpxClient);
     } catch (err) {
       logger.error(`Tick failed: ${err}`);
     }
 
-    await Bun.sleep(config.tick_interval_seconds * 1000);
+    if (!didWork) {
+      await Bun.sleep(config.tick_interval_seconds * 1000);
+    }
   }
 }

--- a/src/daemon/tick.ts
+++ b/src/daemon/tick.ts
@@ -18,7 +18,7 @@ export async function tick(
   conn: DbConnection,
   config: Required<BotholomewConfig>,
   mcpxClient?: McpxClient | null,
-): Promise<void> {
+): Promise<boolean> {
   logger.debug("Tick starting...");
 
   // Reset stale tasks stuck in in_progress
@@ -43,7 +43,7 @@ export async function tick(
   const task = await claimNextTask(conn);
   if (!task) {
     logger.debug("No tasks to work on. Sleeping.");
-    return;
+    return false;
   }
 
   logger.info(`Working on task: ${task.name} (${task.id})`);
@@ -104,4 +104,6 @@ export async function tick(
   } finally {
     await endThread(conn, threadId);
   }
+
+  return true;
 }

--- a/test/daemon/tick.test.ts
+++ b/test/daemon/tick.test.ts
@@ -43,7 +43,7 @@ describe("daemon tick", () => {
       description: "Do a thing",
     });
 
-    await tick("/tmp/test-project", conn, {
+    const didWork = await tick("/tmp/test-project", conn, {
       anthropic_api_key: "test-key",
       openai_api_key: "",
       model: "claude-opus-4-20250514",
@@ -59,6 +59,9 @@ describe("daemon tick", () => {
     // Task should be completed
     const updated = await getTask(conn, task.id);
     expect(updated?.status).toBe("complete");
+
+    // tick should signal that work was done
+    expect(didWork).toBe(true);
   });
 
   test("creates a thread with interactions", async () => {
@@ -100,7 +103,7 @@ describe("daemon tick", () => {
   });
 
   test("does nothing when no tasks available", async () => {
-    await tick("/tmp/test-project", conn, {
+    const didWork = await tick("/tmp/test-project", conn, {
       anthropic_api_key: "test-key",
       openai_api_key: "",
       model: "claude-opus-4-20250514",
@@ -116,6 +119,9 @@ describe("daemon tick", () => {
     // No threads created
     const threads = await listThreads(conn);
     expect(threads).toHaveLength(0);
+
+    // tick should signal no work was done
+    expect(didWork).toBe(false);
   });
 
   test("marks task as failed when LLM throws an error", async () => {


### PR DESCRIPTION
## Summary
- Daemon now immediately loops back to check for more work after completing a task
- Only sleeps for `tick_interval_seconds` when no pending tasks are available
- `tick()` returns a boolean indicating whether work was performed
- On error, still sleeps to avoid tight error loops

## Test plan
- [x] `bun run lint` passes
- [x] `bun test test/daemon/tick.test.ts` — tick returns `true` when task processed, `false` when idle
- [x] `bun test` — all 461 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)