### PR TITLE
Stream daemon chat to stdio in foreground mode

### DIFF
--- a/src/commands/daemon.ts
+++ b/src/commands/daemon.ts
@@ -12,7 +12,7 @@ export function registerDaemonCommand(program: Command) {
     .action(async () => {
       const dir = program.opts().dir;
       const { startDaemon } = await import("../daemon/index.ts");
-      await startDaemon(dir);
+      await startDaemon(dir, { foreground: true });
     });
 
   daemon

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1,3 +1,4 @@
+import ansis from "ansis";
 import { loadConfig } from "../config/loader.ts";
 import { getDbPath } from "../constants.ts";
 import { getConnection } from "../db/connection.ts";
@@ -5,9 +6,47 @@ import { migrate } from "../db/schema.ts";
 import { createMcpxClient } from "../mcpx/client.ts";
 import { logger } from "../utils/logger.ts";
 import { removePidFile, writePidFile } from "../utils/pid.ts";
+import type { DaemonStreamCallbacks } from "./llm.ts";
 import { tick } from "./tick.ts";
 
-export async function startDaemon(projectDir: string): Promise<void> {
+function buildForegroundCallbacks(): DaemonStreamCallbacks {
+  return {
+    onTaskStart(task) {
+      process.stdout.write(
+        `\n${ansis.bold.blue(`Task: ${task.name}`)} ${ansis.dim(`(${task.id})`)}\n`,
+      );
+      if (task.description) {
+        process.stdout.write(`${ansis.dim(task.description)}\n`);
+      }
+      process.stdout.write("\n");
+    },
+    onToken(text) {
+      process.stdout.write(text);
+    },
+    onToolStart(name, input) {
+      process.stdout.write(
+        `  ${ansis.yellow("▶")} ${ansis.bold(name)} ${ansis.dim(input)}\n`,
+      );
+    },
+    onToolEnd(name, _output, isError, durationMs) {
+      const seconds = (durationMs / 1000).toFixed(1);
+      if (isError) {
+        process.stdout.write(
+          `  ${ansis.red("✗")} ${ansis.bold(name)} ${ansis.red("error")} ${ansis.dim(`(${seconds}s)`)}\n`,
+        );
+      } else {
+        process.stdout.write(
+          `  ${ansis.green("✓")} ${ansis.bold(name)} ${ansis.dim(`(${seconds}s)`)}\n`,
+        );
+      }
+    },
+  };
+}
+
+export async function startDaemon(
+  projectDir: string,
+  options?: { foreground?: boolean },
+): Promise<void> {
   const config = await loadConfig(projectDir);
   const dbPath = getDbPath(projectDir);
   const conn = await getConnection(dbPath);
@@ -32,12 +71,16 @@ export async function startDaemon(projectDir: string): Promise<void> {
   process.on("SIGTERM", shutdown);
   process.on("SIGINT", shutdown);
 
+  const callbacks = options?.foreground
+    ? buildForegroundCallbacks()
+    : undefined;
+
   logger.info(`Daemon started for ${projectDir} (PID ${process.pid})`);
   logger.info(`Tick interval: ${config.tick_interval_seconds}s`);
 
   while (true) {
     try {
-      await tick(projectDir, conn, config, mcpxClient);
+      await tick(projectDir, conn, config, mcpxClient, callbacks);
     } catch (err) {
       logger.error(`Tick failed: ${err}`);
     }

--- a/src/daemon/llm.ts
+++ b/src/daemon/llm.ts
@@ -1,5 +1,6 @@
 import Anthropic from "@anthropic-ai/sdk";
 import type {
+  Message,
   MessageParam,
   ToolResultBlockParam,
   ToolUseBlock,
@@ -15,6 +16,18 @@ import { fitToContextWindow, getMaxInputTokens } from "./context.ts";
 import { clearLargeResults, maybeStoreResult } from "./large-results.ts";
 
 registerAllTools();
+
+export interface DaemonStreamCallbacks {
+  onToken: (text: string) => void;
+  onToolStart: (name: string, input: string) => void;
+  onToolEnd: (
+    name: string,
+    output: string,
+    isError: boolean,
+    durationMs: number,
+  ) => void;
+  onTaskStart: (task: Task) => void;
+}
 
 export interface AgentLoopResult {
   status: "complete" | "failed" | "waiting";
@@ -35,8 +48,10 @@ export async function runAgentLoop(input: {
   threadId: string;
   projectDir: string;
   mcpxClient?: McpxClient | null;
+  callbacks?: DaemonStreamCallbacks;
 }): Promise<AgentLoopResult> {
-  const { systemPrompt, task, config, conn, threadId, projectDir } = input;
+  const { systemPrompt, task, config, conn, threadId, projectDir, callbacks } =
+    input;
 
   const client = new Anthropic({
     apiKey: config.anthropic_api_key || undefined,
@@ -71,13 +86,40 @@ export async function runAgentLoop(input: {
   for (let turn = 0; !maxTurns || turn < maxTurns; turn++) {
     const startTime = Date.now();
     fitToContextWindow(messages, systemPrompt, maxInputTokens);
-    const response = await client.messages.create({
-      model: config.model,
-      max_tokens: 4096,
-      system: systemPrompt,
-      messages,
-      tools: daemonTools,
-    });
+
+    let response: Message;
+    let streamedText = "";
+
+    if (callbacks) {
+      const stream = client.messages.stream({
+        model: config.model,
+        max_tokens: 4096,
+        system: systemPrompt,
+        messages,
+        tools: daemonTools,
+      });
+
+      stream.on("text", (text) => {
+        streamedText += text;
+        callbacks.onToken(text);
+      });
+
+      response = await stream.finalMessage();
+
+      // Ensure a newline after streamed text before tool output
+      if (streamedText) {
+        callbacks.onToken("\n");
+      }
+    } else {
+      response = await client.messages.create({
+        model: config.model,
+        max_tokens: 4096,
+        system: systemPrompt,
+        messages,
+        tools: daemonTools,
+      });
+    }
+
     const durationMs = Date.now() - startTime;
     const tokenCount =
       response.usage.input_tokens + response.usage.output_tokens;
@@ -112,12 +154,14 @@ export async function runAgentLoop(input: {
 
     // Log all tool_use entries
     for (const toolUse of toolUseBlocks) {
+      const toolInput = JSON.stringify(toolUse.input);
+      callbacks?.onToolStart(toolUse.name, toolInput);
       await logInteraction(conn, threadId, {
         role: "assistant",
         kind: "tool_use",
         content: `Calling ${toolUse.name}`,
         toolName: toolUse.name,
-        toolInput: JSON.stringify(toolUse.input),
+        toolInput,
       });
     }
 
@@ -126,7 +170,14 @@ export async function runAgentLoop(input: {
       toolUseBlocks.map(async (toolUse) => {
         const start = Date.now();
         const result = await executeToolCall(toolUse, toolCtx);
-        return { toolUse, result, durationMs: Date.now() - start };
+        const elapsed = Date.now() - start;
+        callbacks?.onToolEnd(
+          toolUse.name,
+          result.output,
+          result.isError,
+          elapsed,
+        );
+        return { toolUse, result, durationMs: elapsed };
       }),
     );
 

--- a/src/daemon/tick.ts
+++ b/src/daemon/tick.ts
@@ -9,6 +9,7 @@ import {
 import { createThread, endThread, logInteraction } from "../db/threads.ts";
 import { logger } from "../utils/logger.ts";
 import { generateThreadTitle } from "../utils/title.ts";
+import type { DaemonStreamCallbacks } from "./llm.ts";
 import { runAgentLoop } from "./llm.ts";
 import { buildSystemPrompt } from "./prompt.ts";
 import { processSchedules } from "./schedules.ts";
@@ -18,6 +19,7 @@ export async function tick(
   conn: DbConnection,
   config: Required<BotholomewConfig>,
   mcpxClient?: McpxClient | null,
+  callbacks?: DaemonStreamCallbacks,
 ): Promise<void> {
   logger.debug("Tick starting...");
 
@@ -47,6 +49,7 @@ export async function tick(
   }
 
   logger.info(`Working on task: ${task.name} (${task.id})`);
+  callbacks?.onTaskStart(task);
 
   // Create a thread for this tick
   const threadId = await createThread(
@@ -70,6 +73,7 @@ export async function tick(
       threadId,
       projectDir,
       mcpxClient,
+      callbacks,
     });
 
     // Update task status


### PR DESCRIPTION
## Summary
- When running `daemon run` (foreground), LLM responses now stream token-by-token to stdout with colored markers for tool calls
- Adds optional `DaemonStreamCallbacks` to `runAgentLoop` — when provided, uses the streaming API (`client.messages.stream()`) instead of the batch API
- Background mode (`daemon start`) is completely unaffected — no callbacks, no streaming, no behavior change

## Test plan
- [x] `bun run lint` passes
- [x] `bun test` passes (461 tests)
- [ ] Run `bun run dev daemon run --dir <project>` with a pending task and verify streamed output appears
- [ ] Run `daemon start` and verify no stdout output in background

🤖 Generated with [Claude Code](https://claude.com/claude-code)