### PR TITLE
Fix schedule evaluation failing when LLM wraps JSON in code fences

### DIFF
--- a/src/daemon/schedules.ts
+++ b/src/daemon/schedules.ts
@@ -66,10 +66,16 @@ Is this schedule due to run? If yes, what tasks should be created?`;
       messages: [{ role: "user", content: userMessage }],
     });
 
-    const text = response.content
+    let text = response.content
       .filter((b) => b.type === "text")
       .map((b) => b.text)
       .join("");
+
+    // Strip markdown code fences the LLM may wrap around JSON
+    text = text
+      .replace(/^```(?:json)?\s*\n?/, "")
+      .replace(/\n?```\s*$/, "")
+      .trim();
 
     const parsed = JSON.parse(text);
 

--- a/test/daemon/schedules.test.ts
+++ b/test/daemon/schedules.test.ts
@@ -112,6 +112,61 @@ describe("evaluateSchedule", () => {
     }));
   });
 
+  test("handles LLM response wrapped in markdown code fences", async () => {
+    const jsonBody = JSON.stringify({
+      isDue: true,
+      reasoning: "Due now",
+      tasks: [
+        {
+          name: "Fenced task",
+          description: "From code block",
+          priority: "low",
+        },
+      ],
+    });
+
+    mock.module("@anthropic-ai/sdk", () => ({
+      default: class MockAnthropic {
+        messages = {
+          create: async () => ({
+            content: [
+              { type: "text", text: `\`\`\`json\n${jsonBody}\n\`\`\`` },
+            ],
+            stop_reason: "end_turn",
+            usage: { input_tokens: 50, output_tokens: 50 },
+          }),
+        };
+      },
+    }));
+
+    const { evaluateSchedule: evalFenced } = await import(
+      "../../src/daemon/schedules.ts"
+    );
+
+    const schedule = await createSchedule(conn, {
+      name: "Fenced",
+      frequency: "daily",
+    });
+
+    const result = await evalFenced(TEST_CONFIG, schedule);
+    expect(result.isDue).toBe(true);
+    expect(result.tasksToCreate).toHaveLength(1);
+    expect(result.tasksToCreate[0]?.name).toBe("Fenced task");
+
+    // Restore original mock
+    mock.module("@anthropic-ai/sdk", () => ({
+      default: class MockAnthropic {
+        messages = {
+          create: async () => ({
+            content: [{ type: "text", text: JSON.stringify(mockResponse) }],
+            stop_reason: "end_turn",
+            usage: { input_tokens: 50, output_tokens: 50 },
+          }),
+        };
+      },
+    }));
+  });
+
   test("handles tasks with depends_on", async () => {
     mockResponse = {
       isDue: true,


### PR DESCRIPTION
## Summary
- Strip markdown code fences (` ```json ... ``` `) from the LLM response before `JSON.parse()` in `evaluateSchedule()`
- Fixes `SyntaxError: JSON Parse error: Unrecognized token '`'` when the LLM wraps its JSON response in code blocks
- Added test for code-fenced LLM responses

## Test plan
- [x] `bun test test/daemon/schedules.test.ts` — all 11 tests pass
- [x] `bun run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)