### PR TITLE
Add Schedules TUI panel, show full IDs in CLI

### DIFF
--- a/src/commands/schedule.ts
+++ b/src/commands/schedule.ts
@@ -163,7 +163,7 @@ function enabledColor(enabled: boolean): string {
 }
 
 function printSchedule(s: Schedule) {
-  const id = ansis.dim(s.id.slice(0, 8));
+  const id = ansis.dim(s.id);
   const lastRun = s.last_run_at
     ? s.last_run_at.toISOString()
     : ansis.dim("never");

--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -155,7 +155,7 @@ function priorityColor(priority: Task["priority"]): string {
 }
 
 function printTask(t: Task) {
-  const id = ansis.dim(t.id.slice(0, 8));
+  const id = ansis.dim(t.id);
   console.log(
     `  ${id}  ${statusColor(t.status)}  ${priorityColor(t.priority)}  ${t.name}`,
   );

--- a/src/commands/thread.ts
+++ b/src/commands/thread.ts
@@ -1,6 +1,5 @@
 import ansis from "ansis";
 import type { Command } from "commander";
-import type { DbConnection } from "../db/connection.ts";
 import type { Interaction, Thread } from "../db/threads.ts";
 import {
   deleteThread,
@@ -48,12 +47,7 @@ export function registerThreadCommand(program: Command) {
     )
     .action((id, opts) =>
       withDb(program, async (conn) => {
-        const resolvedId = await resolveThreadId(conn, id);
-        if (!resolvedId) {
-          logger.error(`Thread not found: ${id}`);
-          process.exit(1);
-        }
-        const result = await getThread(conn, resolvedId);
+        const result = await getThread(conn, id);
         if (!result) {
           logger.error(`Thread not found: ${id}`);
           process.exit(1);
@@ -72,17 +66,12 @@ export function registerThreadCommand(program: Command) {
     .description("Delete a thread and its interactions")
     .action((id) =>
       withDb(program, async (conn) => {
-        const resolvedId = await resolveThreadId(conn, id);
-        if (!resolvedId) {
-          logger.error(`Thread not found: ${id}`);
-          process.exit(1);
-        }
-        const deleted = await deleteThread(conn, resolvedId);
+        const deleted = await deleteThread(conn, id);
         if (!deleted) {
           logger.error(`Thread not found: ${id}`);
           process.exit(1);
         }
-        logger.success(`Deleted thread: ${resolvedId}`);
+        logger.success(`Deleted thread: ${id}`);
       }),
     );
 
@@ -94,12 +83,7 @@ export function registerThreadCommand(program: Command) {
       withDb(program, async (conn) => {
         let resolvedId: string;
         if (id) {
-          const found = await resolveThreadId(conn, id);
-          if (!found) {
-            logger.error(`Thread not found: ${id}`);
-            process.exit(1);
-          }
-          resolvedId = found;
+          resolvedId = id;
         } else {
           const active = await getActiveThread(conn);
           if (!active) {
@@ -130,7 +114,7 @@ export function registerThreadCommand(program: Command) {
 
         const pollMs = opts.interval ?? 500;
         logger.info(
-          `Following thread ${ansis.dim(resolvedId.slice(0, 8))}... (Ctrl+C to stop)`,
+          `Following thread ${ansis.dim(resolvedId)}... (Ctrl+C to stop)`,
         );
 
         const interval = setInterval(async () => {
@@ -168,24 +152,6 @@ export function registerThreadCommand(program: Command) {
     );
 }
 
-async function resolveThreadId(
-  conn: DbConnection,
-  idPrefix: string,
-): Promise<string | null> {
-  if (idPrefix.length >= 36) return idPrefix;
-  const all = await listThreads(conn);
-  const matches = all.filter((t) => t.id.startsWith(idPrefix));
-  if (matches.length === 1) {
-    const match = matches[0] as Thread;
-    return match.id;
-  }
-  if (matches.length === 0) return null;
-  logger.error(
-    `Ambiguous thread prefix "${idPrefix}" matches ${matches.length} threads`,
-  );
-  process.exit(1);
-}
-
 function typeColor(type: Thread["type"]): string {
   switch (type) {
     case "daemon_tick":
@@ -213,7 +179,7 @@ function roleColor(role: Interaction["role"]): string {
 }
 
 function printThread(t: Thread) {
-  const id = ansis.dim(t.id.slice(0, 8));
+  const id = ansis.dim(t.id);
   const title = t.title || ansis.dim("(untitled)");
   console.log(`  ${id}  ${typeColor(t.type)}  ${statusLabel(t)}  ${title}`);
 }

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -456,7 +456,7 @@ export function App({
             "  d              Delete thread (with confirmation)",
             "  r              Refresh threads",
             "",
-            "Schedules (Tab 7):",
+            "Schedules (Tab 6):",
             "  ↑/↓            Navigate schedule list",
             "  Shift+↑/↓      Scroll detail pane",
             "  j/k            Scroll detail pane",
@@ -594,18 +594,18 @@ export function App({
         flexDirection="column"
         flexGrow={1}
       >
-        <HelpPanel
-          projectDir={projectDir}
-          threadId={threadId}
-          daemonRunning={daemonRunning}
-        />
+        <SchedulePanel conn={conn} isActive={activeTab === 6} />
       </Box>
       <Box
         display={activeTab === 7 ? "flex" : "none"}
         flexDirection="column"
         flexGrow={1}
       >
-        <SchedulePanel conn={conn} isActive={activeTab === 7} />
+        <HelpPanel
+          projectDir={projectDir}
+          threadId={threadId}
+          daemonRunning={daemonRunning}
+        />
       </Box>
 
       {/* Queued messages (only on Chat tab) */}

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -19,6 +19,7 @@ import {
   MessageList,
 } from "./components/MessageList.tsx";
 import { QueuePanel } from "./components/QueuePanel.tsx";
+import { SchedulePanel } from "./components/SchedulePanel.tsx";
 import { StatusBar } from "./components/StatusBar.tsx";
 import { TabBar, type TabId } from "./components/TabBar.tsx";
 import { TaskPanel } from "./components/TaskPanel.tsx";
@@ -219,7 +220,7 @@ export function App({
 
       // Tab key cycles tabs — always active (InputBar ignores tab)
       if (key.tab && !key.shift) {
-        setActiveTab((t) => ((t % 6) + 1) as TabId);
+        setActiveTab((t) => ((t % 7) + 1) as TabId);
         return;
       }
 
@@ -256,7 +257,7 @@ export function App({
       if (tab !== 1) {
         // Number keys jump to tab on non-chat tabs
         const num = Number.parseInt(input, 10);
-        if (num >= 1 && num <= 6) {
+        if (num >= 1 && num <= 7) {
           setActiveTab(num as TabId);
           return;
         }
@@ -419,7 +420,7 @@ export function App({
           content: [
             "Navigation:",
             "  Tab            Cycle between panels",
-            "  1-6            Jump to panel (when not in Chat)",
+            "  1-7            Jump to panel (when not in Chat)",
             "  Escape         Return to Chat",
             "",
             "Chat (Tab 1):",
@@ -454,6 +455,15 @@ export function App({
             "  f              Cycle type filter",
             "  d              Delete thread (with confirmation)",
             "  r              Refresh threads",
+            "",
+            "Schedules (Tab 7):",
+            "  ↑/↓            Navigate schedule list",
+            "  Shift+↑/↓      Scroll detail pane",
+            "  j/k            Scroll detail pane",
+            "  f              Cycle enabled/disabled filter",
+            "  e              Toggle enable/disable",
+            "  d              Delete schedule (with confirmation)",
+            "  r              Refresh schedules",
             "",
             "Commands:",
             "  /help           Show this help",
@@ -589,6 +599,13 @@ export function App({
           threadId={threadId}
           daemonRunning={daemonRunning}
         />
+      </Box>
+      <Box
+        display={activeTab === 7 ? "flex" : "none"}
+        flexDirection="column"
+        flexGrow={1}
+      >
+        <SchedulePanel conn={conn} isActive={activeTab === 7} />
       </Box>
 
       {/* Queued messages (only on Chat tab) */}

--- a/src/tui/components/SchedulePanel.tsx
+++ b/src/tui/components/SchedulePanel.tsx
@@ -1,0 +1,388 @@
+import { Box, Text, useInput, useStdout } from "ink";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
+import type { DbConnection } from "../../db/connection.ts";
+import {
+  deleteSchedule,
+  listSchedules,
+  type Schedule,
+  updateSchedule,
+} from "../../db/schedules.ts";
+import { ansi, theme } from "../theme.ts";
+
+interface SchedulePanelProps {
+  conn: DbConnection;
+  isActive: boolean;
+}
+
+const SIDEBAR_WIDTH = 42;
+const PAGE_SCROLL_LINES = 10;
+
+const ENABLED_FILTERS: readonly boolean[] = [true, false] as const;
+
+const ENABLED_ICONS: Record<string, string> = {
+  true: "●",
+  false: "○",
+};
+
+const ENABLED_COLORS: Record<string, string> = {
+  true: theme.success,
+  false: theme.muted,
+};
+
+const ENABLED_ANSI: Record<string, string> = {
+  true: ansi.success,
+  false: ansi.muted,
+};
+
+const ENABLED_LABELS: Record<string, string> = {
+  true: "enabled",
+  false: "disabled",
+};
+
+function buildScheduleDetailAnsi(schedule: Schedule): string {
+  const lines: string[] = [];
+
+  lines.push(`${ansi.bold}${ansi.info}${schedule.name}${ansi.reset}`);
+  lines.push("");
+
+  const enabledKey = String(schedule.enabled);
+  const statusAnsi = ENABLED_ANSI[enabledKey];
+  lines.push(
+    `${ansi.bold}${ansi.primary}Status${ansi.reset}      ${statusAnsi}${ENABLED_ICONS[enabledKey]} ${ENABLED_LABELS[enabledKey]}${ansi.reset}`,
+  );
+
+  lines.push(
+    `${ansi.bold}${ansi.primary}Frequency${ansi.reset}   ${ansi.accent}${schedule.frequency}${ansi.reset}`,
+  );
+
+  const lastRun = schedule.last_run_at
+    ? schedule.last_run_at.toLocaleString([], {
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      })
+    : "(never)";
+  lines.push(
+    `${ansi.bold}${ansi.primary}Last Run${ansi.reset}    ${ansi.dim}${lastRun}${ansi.reset}`,
+  );
+
+  const created = schedule.created_at.toLocaleString([], {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  const updated = schedule.updated_at.toLocaleString([], {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  lines.push(
+    `${ansi.bold}${ansi.primary}Created${ansi.reset}     ${ansi.dim}${created}${ansi.reset}`,
+  );
+  lines.push(
+    `${ansi.bold}${ansi.primary}Updated${ansi.reset}     ${ansi.dim}${updated}${ansi.reset}`,
+  );
+  lines.push("");
+
+  if (schedule.description) {
+    lines.push(`${ansi.bold}${ansi.primary}Description${ansi.reset}`);
+    lines.push(schedule.description);
+    lines.push("");
+  }
+
+  lines.push(
+    `${ansi.bold}${ansi.primary}ID${ansi.reset}          ${ansi.dim}${schedule.id}${ansi.reset}`,
+  );
+
+  return lines.join("\n");
+}
+
+function cycleFilter<T>(current: T | null, values: readonly T[]): T | null {
+  if (current === null) return values[0] ?? null;
+  const idx = values.indexOf(current);
+  if (idx === -1 || idx === values.length - 1) return null;
+  return values[idx + 1] ?? null;
+}
+
+export const SchedulePanel = memo(function SchedulePanel({
+  conn,
+  isActive,
+}: SchedulePanelProps) {
+  const { stdout } = useStdout();
+  const termRows = stdout?.rows ?? 24;
+  const [schedules, setSchedules] = useState<Schedule[]>([]);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [detailScroll, setDetailScroll] = useState(0);
+  const [enabledFilter, setEnabledFilter] = useState<boolean | null>(null);
+  const [refreshTick, setRefreshTick] = useState(0);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: refreshTick triggers manual refresh
+  useEffect(() => {
+    let mounted = true;
+
+    const refresh = async () => {
+      const filters: { enabled?: boolean } = {};
+      if (enabledFilter !== null) filters.enabled = enabledFilter;
+      const result = await listSchedules(conn, filters);
+      if (mounted) {
+        setSchedules(result);
+        setSelectedIndex((prev) =>
+          Math.min(prev, Math.max(0, result.length - 1)),
+        );
+      }
+    };
+
+    refresh();
+    const interval = setInterval(refresh, 5000);
+    return () => {
+      mounted = false;
+      clearInterval(interval);
+    };
+  }, [conn, enabledFilter, refreshTick]);
+
+  const selectedSchedule = schedules[selectedIndex];
+
+  const renderedDetail = useMemo(() => {
+    if (!selectedSchedule) return "";
+    return buildScheduleDetailAnsi(selectedSchedule);
+  }, [selectedSchedule]);
+
+  const detailLines = useMemo(
+    () => renderedDetail.split("\n"),
+    [renderedDetail],
+  );
+
+  const visibleRows = Math.max(1, termRows - 6);
+  const maxDetailScroll = Math.max(0, detailLines.length - visibleRows);
+  const sidebarScrollOffset = Math.max(
+    0,
+    Math.min(
+      selectedIndex - Math.floor(visibleRows / 2),
+      schedules.length - visibleRows,
+    ),
+  );
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: selectedIndex is the intentional trigger
+  useEffect(() => {
+    setDetailScroll(0);
+  }, [selectedIndex]);
+
+  const forceRefresh = useCallback(() => {
+    setRefreshTick((t) => t + 1);
+  }, []);
+
+  useInput(
+    (input, key) => {
+      // Delete confirmation mode
+      if (confirmDelete) {
+        if (input === "y" || input === "d") {
+          if (selectedSchedule) {
+            deleteSchedule(conn, selectedSchedule.id).then(() => {
+              forceRefresh();
+            });
+          }
+          setConfirmDelete(false);
+        } else {
+          setConfirmDelete(false);
+        }
+        return;
+      }
+
+      if (key.upArrow) {
+        if (key.shift) {
+          setDetailScroll((s) => Math.max(0, s - 1));
+        } else {
+          setSelectedIndex((i) => Math.max(0, i - 1));
+        }
+        return;
+      }
+      if (key.downArrow) {
+        if (key.shift) {
+          setDetailScroll((s) => Math.min(maxDetailScroll, s + 1));
+        } else {
+          setSelectedIndex((i) => Math.min(schedules.length - 1, i + 1));
+        }
+        return;
+      }
+
+      if (input === "j") {
+        setDetailScroll((s) => Math.min(maxDetailScroll, s + 1));
+        return;
+      }
+      if (input === "k") {
+        setDetailScroll((s) => Math.max(0, s - 1));
+        return;
+      }
+      if (input === "J") {
+        setDetailScroll((s) =>
+          Math.min(maxDetailScroll, s + PAGE_SCROLL_LINES),
+        );
+        return;
+      }
+      if (input === "K") {
+        setDetailScroll((s) => Math.max(0, s - PAGE_SCROLL_LINES));
+        return;
+      }
+      if (input === "g") {
+        setDetailScroll(0);
+        return;
+      }
+      if (input === "G") {
+        setDetailScroll(maxDetailScroll);
+        return;
+      }
+
+      if (input === "f") {
+        setEnabledFilter((f) => cycleFilter(f, ENABLED_FILTERS));
+        return;
+      }
+      if (input === "e" && selectedSchedule) {
+        updateSchedule(conn, selectedSchedule.id, {
+          enabled: !selectedSchedule.enabled,
+        }).then(() => {
+          forceRefresh();
+        });
+        return;
+      }
+      if (input === "d" && selectedSchedule) {
+        setConfirmDelete(true);
+        return;
+      }
+      if (input === "r") {
+        forceRefresh();
+        return;
+      }
+    },
+    { isActive },
+  );
+
+  if (schedules.length === 0) {
+    return (
+      <Box flexDirection="column" flexGrow={1} paddingX={1}>
+        <Text dimColor>
+          {enabledFilter !== null
+            ? "No schedules match the current filter. Press f to change filter."
+            : "No schedules found. Schedules will appear here as they are created."}
+        </Text>
+        {enabledFilter !== null && (
+          <Box marginTop={1}>
+            <Text color={ENABLED_COLORS[String(enabledFilter)]}>
+              {ENABLED_ICONS[String(enabledFilter)]}{" "}
+              {ENABLED_LABELS[String(enabledFilter)]}
+            </Text>
+          </Box>
+        )}
+      </Box>
+    );
+  }
+
+  const sidebarVisible = schedules.slice(
+    sidebarScrollOffset,
+    sidebarScrollOffset + visibleRows,
+  );
+
+  const detailVisible = detailLines.slice(
+    detailScroll,
+    detailScroll + visibleRows,
+  );
+
+  return (
+    <Box flexGrow={1} height={visibleRows + 1} overflow="hidden">
+      {/* Left sidebar: schedule list */}
+      <Box
+        flexDirection="column"
+        width={SIDEBAR_WIDTH}
+        height={visibleRows + 1}
+        borderStyle="single"
+        borderColor={theme.muted}
+        borderRight
+        borderTop={false}
+        borderBottom={false}
+        borderLeft={false}
+        overflow="hidden"
+      >
+        <Box paddingX={1} gap={1}>
+          <Text bold dimColor>
+            Schedules ({schedules.length})
+          </Text>
+          {enabledFilter !== null && (
+            <Text color={ENABLED_COLORS[String(enabledFilter)]}>
+              [{ENABLED_LABELS[String(enabledFilter)]}]
+            </Text>
+          )}
+        </Box>
+        {confirmDelete && selectedSchedule && (
+          <Box paddingX={1}>
+            <Text color="red" bold>
+              Delete schedule? (y/n)
+            </Text>
+          </Box>
+        )}
+        {sidebarVisible.map((schedule, vi) => {
+          const i = vi + sidebarScrollOffset;
+          const isSelected = i === selectedIndex;
+          const enabledKey = String(schedule.enabled);
+          const maxName = SIDEBAR_WIDTH - 12;
+          const nameDisplay =
+            schedule.name.length > maxName
+              ? `${schedule.name.slice(0, maxName - 1)}…`
+              : schedule.name;
+          return (
+            <Box key={schedule.id} paddingX={1}>
+              <Text
+                backgroundColor={isSelected ? theme.selectionBg : undefined}
+                bold={isSelected}
+                color={isSelected ? theme.info : undefined}
+                wrap="truncate-end"
+              >
+                {isSelected ? "▸" : " "}{" "}
+                <Text color={ENABLED_COLORS[enabledKey]} bold={false}>
+                  {ENABLED_ICONS[enabledKey]}
+                </Text>{" "}
+                {nameDisplay}
+                <Text dimColor bold={false}>
+                  {" "}
+                  {schedule.frequency}
+                </Text>
+              </Text>
+            </Box>
+          );
+        })}
+      </Box>
+
+      {/* Right detail pane */}
+      <Box
+        flexDirection="column"
+        flexGrow={1}
+        height={visibleRows + 1}
+        paddingX={1}
+        overflow="hidden"
+      >
+        {detailVisible.map((line, i) => {
+          const lineNum = detailScroll + i;
+          return <Text key={lineNum}>{line || " "}</Text>;
+        })}
+        {detailLines.length > visibleRows && (
+          <Box>
+            <Text dimColor>
+              f filter · e toggle · ↑↓ select · j/k scroll · d delete · r
+              refresh · [{detailScroll + 1}–
+              {Math.min(detailScroll + visibleRows, detailLines.length)} of{" "}
+              {detailLines.length}]
+            </Text>
+          </Box>
+        )}
+        {detailLines.length <= visibleRows && <Box flexGrow={1} />}
+        {detailLines.length <= visibleRows && (
+          <Text dimColor>
+            f filter · e toggle · ↑↓ select · d delete · r refresh
+          </Text>
+        )}
+      </Box>
+    </Box>
+  );
+});

--- a/src/tui/components/SchedulePanel.tsx
+++ b/src/tui/components/SchedulePanel.tsx
@@ -55,18 +55,6 @@ function buildScheduleDetailAnsi(schedule: Schedule): string {
     `${ansi.bold}${ansi.primary}Frequency${ansi.reset}   ${ansi.accent}${schedule.frequency}${ansi.reset}`,
   );
 
-  const lastRun = schedule.last_run_at
-    ? schedule.last_run_at.toLocaleString([], {
-        month: "short",
-        day: "numeric",
-        hour: "2-digit",
-        minute: "2-digit",
-      })
-    : "(never)";
-  lines.push(
-    `${ansi.bold}${ansi.primary}Last Run${ansi.reset}    ${ansi.dim}${lastRun}${ansi.reset}`,
-  );
-
   const created = schedule.created_at.toLocaleString([], {
     month: "short",
     day: "numeric",
@@ -84,6 +72,18 @@ function buildScheduleDetailAnsi(schedule: Schedule): string {
   );
   lines.push(
     `${ansi.bold}${ansi.primary}Updated${ansi.reset}     ${ansi.dim}${updated}${ansi.reset}`,
+  );
+
+  const lastRunDisplay = schedule.last_run_at
+    ? schedule.last_run_at.toLocaleString([], {
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      })
+    : "(never)";
+  lines.push(
+    `${ansi.bold}${ansi.primary}Last Run${ansi.reset}    ${lastRunDisplay}`,
   );
   lines.push("");
 
@@ -158,11 +158,12 @@ export const SchedulePanel = memo(function SchedulePanel({
 
   const visibleRows = Math.max(1, termRows - 6);
   const maxDetailScroll = Math.max(0, detailLines.length - visibleRows);
+  const sidebarItems = Math.max(1, Math.floor((visibleRows - 1) / 2));
   const sidebarScrollOffset = Math.max(
     0,
     Math.min(
-      selectedIndex - Math.floor(visibleRows / 2),
-      schedules.length - visibleRows,
+      selectedIndex - Math.floor(sidebarItems / 2),
+      schedules.length - sidebarItems,
     ),
   );
 
@@ -282,7 +283,7 @@ export const SchedulePanel = memo(function SchedulePanel({
 
   const sidebarVisible = schedules.slice(
     sidebarScrollOffset,
-    sidebarScrollOffset + visibleRows,
+    sidebarScrollOffset + sidebarItems,
   );
 
   const detailVisible = detailLines.slice(
@@ -326,13 +327,13 @@ export const SchedulePanel = memo(function SchedulePanel({
           const i = vi + sidebarScrollOffset;
           const isSelected = i === selectedIndex;
           const enabledKey = String(schedule.enabled);
-          const maxName = SIDEBAR_WIDTH - 12;
+          const maxName = SIDEBAR_WIDTH - 6;
           const nameDisplay =
             schedule.name.length > maxName
               ? `${schedule.name.slice(0, maxName - 1)}…`
               : schedule.name;
           return (
-            <Box key={schedule.id} paddingX={1}>
+            <Box key={schedule.id} flexDirection="column" paddingX={1}>
               <Text
                 backgroundColor={isSelected ? theme.selectionBg : undefined}
                 bold={isSelected}
@@ -344,10 +345,10 @@ export const SchedulePanel = memo(function SchedulePanel({
                   {ENABLED_ICONS[enabledKey]}
                 </Text>{" "}
                 {nameDisplay}
-                <Text dimColor bold={false}>
-                  {" "}
-                  {schedule.frequency}
-                </Text>
+              </Text>
+              <Text dimColor wrap="truncate-end">
+                {"    "}
+                {schedule.frequency}
               </Text>
             </Box>
           );

--- a/src/tui/components/TabBar.tsx
+++ b/src/tui/components/TabBar.tsx
@@ -1,6 +1,6 @@
 import { Box, Text } from "ink";
 
-export type TabId = 1 | 2 | 3 | 4 | 5 | 6;
+export type TabId = 1 | 2 | 3 | 4 | 5 | 6 | 7;
 
 const TABS: { id: TabId; label: string }[] = [
   { id: 1, label: "Chat" },
@@ -9,6 +9,7 @@ const TABS: { id: TabId; label: string }[] = [
   { id: 4, label: "Tasks" },
   { id: 5, label: "Threads" },
   { id: 6, label: "Help" },
+  { id: 7, label: "Schedules" },
 ];
 
 interface TabBarProps {

--- a/src/tui/components/TabBar.tsx
+++ b/src/tui/components/TabBar.tsx
@@ -8,8 +8,8 @@ const TABS: { id: TabId; label: string }[] = [
   { id: 3, label: "Context" },
   { id: 4, label: "Tasks" },
   { id: 5, label: "Threads" },
-  { id: 6, label: "Help" },
-  { id: 7, label: "Schedules" },
+  { id: 6, label: "Schedules" },
+  { id: 7, label: "Help" },
 ];
 
 interface TabBarProps {

--- a/test/commands/thread.test.ts
+++ b/test/commands/thread.test.ts
@@ -209,7 +209,7 @@ describe("thread view", () => {
     expect(output).toContain("Interactions (2)");
   });
 
-  test("supports short ID prefix", async () => {
+  test("supports full ID lookup", async () => {
     tempDir = await mkdtemp(join(tmpdir(), "botholomew-test-"));
     await initProject(tempDir);
 
@@ -219,13 +219,13 @@ describe("thread view", () => {
       conn,
       "chat_session",
       undefined,
-      "Prefix Test",
+      "Full ID Test",
     );
     conn.close();
 
-    const result = await run(["thread", "view", threadId.slice(0, 8)]);
+    const result = await run(["thread", "view", threadId]);
     expect(result.code).toBe(0);
-    expect(result.stdout + result.stderr).toContain("Prefix Test");
+    expect(result.stdout + result.stderr).toContain("Full ID Test");
   });
 
   test("errors on unknown thread", async () => {


### PR DESCRIPTION
## Summary
- Adds a new **Schedules** tab (tab 7) to the TUI with sidebar/detail layout, enable/disable toggle (`e`), delete with confirmation (`d`), enabled/disabled filtering (`f`), and auto-refresh
- Fixes a bug where `schedule list`, `task list`, and `thread list` showed truncated 8-char IDs that couldn't be copy-pasted into `view`/`trigger`/`delete` commands — all three now show full UUIDs
- Removes the `resolveThreadId` prefix-matching helper in favor of consistent full-ID usage across all CLI commands

## Test plan
- [x] `bun run lint` passes
- [x] `bun test` — all 461 tests pass
- [ ] Manual: `bun run dev` → Tab to panel 7, verify schedule list/detail/keybindings
- [ ] Manual: `schedule list` → copy ID → `schedule trigger <id>` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)