### PR TITLE
Unify agent tool terminology on 'context' language

### DIFF
--- a/src/chat/agent.ts
+++ b/src/chat/agent.ts
@@ -25,7 +25,7 @@ const CHAT_TOOL_NAMES = new Set([
   "create_task",
   "list_tasks",
   "view_task",
-  "search_context",
+  "context_search",
   "search_grep",
   "search_semantic",
   "list_threads",

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -25,6 +25,7 @@ import {
 } from "../db/context.ts";
 import { getEmbeddingsForItem, hybridSearch } from "../db/embeddings.ts";
 import { logger } from "../utils/logger.ts";
+import { registerContextToolSubcommands } from "./tools.ts";
 import { withDb } from "./with-db.ts";
 
 function fmtDate(d: Date): string {
@@ -33,11 +34,11 @@ function fmtDate(d: Date): string {
 }
 
 export function registerContextCommand(program: Command) {
-  const ctx = program.command("context").description("Manage context items");
+  const ctx = program.command("context").description("Manage context");
 
   ctx
     .command("list")
-    .description("List context items")
+    .description("List context entries")
     .option("--path <prefix>", "filter by path prefix")
     .option("-l, --limit <n>", "max number of items", Number.parseInt)
     .option("-o, --offset <n>", "skip first N items", Number.parseInt)
@@ -55,7 +56,7 @@ export function registerContextCommand(program: Command) {
             });
 
         if (items.length === 0) {
-          logger.dim("No context items found.");
+          logger.dim("No context entries found.");
           return;
         }
 
@@ -82,12 +83,12 @@ export function registerContextCommand(program: Command) {
 
   ctx
     .command("show <path>")
-    .description("Show details and content of a context item")
+    .description("Show details and content of a context entry")
     .action((path: string) =>
       withDb(program, async (conn) => {
         const item = await getContextItemByPath(conn, path);
         if (!item) {
-          logger.error(`Context item not found: ${path}`);
+          logger.error(`Context entry not found: ${path}`);
           process.exit(1);
         }
 
@@ -238,7 +239,7 @@ export function registerContextCommand(program: Command) {
 
   ctx
     .command("search <query>")
-    .description("Search context items")
+    .description("Search context entries")
     .option("-k, --top-k <n>", "max results", Number.parseInt, 10)
     .action((query, opts) =>
       withDb(program, async (conn, dir) => {
@@ -269,25 +270,25 @@ export function registerContextCommand(program: Command) {
     );
   ctx
     .command("delete <path>")
-    .description("Delete a context item by path")
+    .description("Delete a context entry by path")
     .action((path: string) =>
       withDb(program, async (conn) => {
         const deleted = await deleteContextItemByPath(conn, path);
         if (!deleted) {
-          logger.error(`Context item not found: ${path}`);
+          logger.error(`Context entry not found: ${path}`);
           process.exit(1);
         }
-        logger.success(`Deleted context item: ${path}`);
+        logger.success(`Deleted context entry: ${path}`);
       }),
     );
   ctx
     .command("chunks <path>")
-    .description("Show chunks and embeddings for a context item")
+    .description("Show chunks and embeddings for a context entry")
     .action((path: string) =>
       withDb(program, async (conn) => {
         const item = await getContextItemByPath(conn, path);
         if (!item) {
-          logger.error(`Context item not found: ${path}`);
+          logger.error(`Context entry not found: ${path}`);
           process.exit(1);
         }
 
@@ -336,7 +337,7 @@ export function registerContextCommand(program: Command) {
       withDb(program, async (conn, dir) => {
         const items = await resolveItems(conn, path, !!opts.all);
         if (items.length === 0) {
-          logger.error("No matching context items found.");
+          logger.error("No matching context entries found.");
           process.exit(1);
         }
 
@@ -436,6 +437,10 @@ export function registerContextCommand(program: Command) {
         );
       }),
     );
+
+  // Register context tool subcommands (read, write, edit, list-dir, etc.)
+  // Must come after management subcommands so collision detection works.
+  registerContextToolSubcommands(ctx);
 }
 
 async function resolveItems(
@@ -454,7 +459,7 @@ async function resolveItems(
   return listContextItemsByPrefix(conn, p, { recursive: true });
 }
 
-/** Upsert a file into the context DB. Returns the item ID if textual, null otherwise. */
+/** Upsert a file into context. Returns the item ID if textual, null otherwise. */
 async function addFile(
   conn: DbConnection,
   filePath: string,

--- a/src/commands/tools.ts
+++ b/src/commands/tools.ts
@@ -13,31 +13,39 @@ import { withDb } from "./with-db.ts";
 
 registerAllTools();
 
-const GROUP_DESCRIPTIONS: Record<string, string> = {
-  dir: "Directory operations on the virtual filesystem",
-  file: "File operations on the virtual filesystem",
-  search: "Search the virtual filesystem",
-};
+/**
+ * Register context tool subcommands (read, write, edit, etc.) onto an
+ * existing Commander command. Skips tools whose derived subcommand name
+ * collides with an already-registered subcommand on the parent.
+ */
+export function registerContextToolSubcommands(parent: Command) {
+  const existing = new Set(parent.commands.map((c: Command) => c.name()));
+
+  for (const tool of getToolsByGroup("context")) {
+    const subName = deriveSubName(tool.name);
+    if (existing.has(subName)) continue; // skip conflicts with management subcommands
+    registerToolAsCLI(parent, tool);
+  }
+}
 
 export function registerToolCommands(program: Command) {
-  for (const group of ["dir", "file", "search"]) {
-    const groupCmd = program
-      .command(group)
-      .description(GROUP_DESCRIPTIONS[group] ?? `${group} tools`);
+  // The "search" group has its own top-level command
+  for (const group of ["search"]) {
+    const groupCmd = program.command(group).description("Search context");
 
     for (const tool of getToolsByGroup(group)) {
-      registerToolAsCLI(groupCmd, tool, program);
+      registerToolAsCLI(groupCmd, tool);
     }
   }
 }
 
-function registerToolAsCLI(
-  parent: Command,
-  tool: AnyToolDefinition,
-  program: Command,
-) {
-  // Derive subcommand name: "file_read" → "read", "file_count_lines" → "count-lines"
-  const subName = tool.name.replace(/^[^_]+_/, "").replace(/_/g, "-");
+/** Derive CLI subcommand name from tool name: "context_read" → "read", "context_list_dir" → "list-dir" */
+function deriveSubName(toolName: string): string {
+  return toolName.replace(/^[^_]+_/, "").replace(/_/g, "-");
+}
+
+function registerToolAsCLI(parent: Command, tool: AnyToolDefinition) {
+  const subName = deriveSubName(tool.name);
 
   // Inspect zod schema to determine positional args and options
   const shape = tool.inputSchema.shape as Record<string, z.ZodType>;
@@ -93,7 +101,7 @@ function registerToolAsCLI(
   }
 
   cmd.action((...args: unknown[]) =>
-    withDb(program, async (conn, dir) => {
+    withDb(parent.parent ?? parent, async (conn, dir) => {
       try {
         const input = buildInput(tool, positionals, options, shape, args);
 
@@ -224,20 +232,20 @@ function formatOutput(result: unknown, _toolName: string) {
 function isPositionalArg(key: string, toolName: string): boolean {
   // These keys are treated as positional arguments
   const positionalKeys: Record<string, string[]> = {
-    dir_create: ["path"],
-    dir_list: ["path"],
-    dir_tree: ["path"],
-    dir_size: ["path"],
-    file_read: ["path"],
-    file_write: ["path"],
-    file_edit: ["path"],
-    file_delete: ["path"],
-    file_copy: ["src", "dst"],
-    file_move: ["src", "dst"],
-    file_info: ["path"],
-    file_exists: ["path"],
-    file_count_lines: ["path"],
-    search_find: ["pattern"],
+    context_create_dir: ["path"],
+    context_list_dir: ["path"],
+    context_tree: ["path"],
+    context_dir_size: ["path"],
+    context_read: ["path"],
+    context_write: ["path"],
+    context_edit: ["path"],
+    context_delete: ["path"],
+    context_copy: ["src", "dst"],
+    context_move: ["src", "dst"],
+    context_info: ["path"],
+    context_exists: ["path"],
+    context_count_lines: ["path"],
+    context_search: ["query"],
     search_grep: ["pattern"],
     search_semantic: ["query"],
   };

--- a/src/db/context.ts
+++ b/src/db/context.ts
@@ -90,7 +90,7 @@ export async function createContextItem(
  *
  * DuckDB implements UPDATE as delete+insert on tables with unique indexes,
  * which violates foreign keys from the embeddings table. We must delete
- * embeddings before updating; callers (context add, file_write) re-create
+ * embeddings before updating; callers (context add, context_write) re-create
  * them in their ingestion phase.
  */
 export async function upsertContextItem(

--- a/src/tools/context/search.ts
+++ b/src/tools/context/search.ts
@@ -22,9 +22,9 @@ const outputSchema = z.object({
   is_error: z.boolean(),
 });
 
-export const searchContextTool = {
-  name: "search_context",
-  description: "Search the context database by keyword.",
+export const contextSearchTool = {
+  name: "context_search",
+  description: "Search context by keyword.",
   group: "context",
   inputSchema,
   outputSchema,

--- a/src/tools/dir/create.ts
+++ b/src/tools/dir/create.ts
@@ -16,10 +16,10 @@ const outputSchema = z.object({
   is_error: z.boolean(),
 });
 
-export const dirCreateTool = {
-  name: "dir_create",
-  description: "Create a directory in the virtual filesystem.",
-  group: "dir",
+export const contextCreateDirTool = {
+  name: "context_create_dir",
+  description: "Create a directory in context.",
+  group: "context",
   inputSchema,
   outputSchema,
   execute: async (input, ctx) => {

--- a/src/tools/dir/list.ts
+++ b/src/tools/dir/list.ts
@@ -36,10 +36,10 @@ const outputSchema = z.object({
   is_error: z.boolean(),
 });
 
-export const dirListTool = {
-  name: "dir_list",
-  description: "List directory contents in the virtual filesystem.",
-  group: "dir",
+export const contextListDirTool = {
+  name: "context_list_dir",
+  description: "List directory contents in context.",
+  group: "context",
   inputSchema,
   outputSchema,
   execute: async (input, ctx) => {

--- a/src/tools/dir/size.ts
+++ b/src/tools/dir/size.ts
@@ -24,10 +24,10 @@ const outputSchema = z.object({
   is_error: z.boolean(),
 });
 
-export const dirSizeTool = {
-  name: "dir_size",
-  description: "Get the total size of files in a directory.",
-  group: "dir",
+export const contextDirSizeTool = {
+  name: "context_dir_size",
+  description: "Get the total size of context items in a directory.",
+  group: "context",
   inputSchema,
   outputSchema,
   execute: async (input, ctx) => {

--- a/src/tools/dir/tree.ts
+++ b/src/tools/dir/tree.ts
@@ -23,11 +23,10 @@ const outputSchema = z.object({
   is_error: z.boolean(),
 });
 
-export const dirTreeTool = {
-  name: "dir_tree",
-  description:
-    "Render a directory as a markdown-style tree in the virtual filesystem.",
-  group: "dir",
+export const contextTreeTool = {
+  name: "context_tree",
+  description: "Render a directory as a markdown-style tree in context.",
+  group: "context",
   inputSchema,
   outputSchema,
   execute: async (input, ctx) => {

--- a/src/tools/file/copy.ts
+++ b/src/tools/file/copy.ts
@@ -18,10 +18,10 @@ const outputSchema = z.object({
   is_error: z.boolean(),
 });
 
-export const fileCopyTool = {
-  name: "file_copy",
-  description: "Copy a file in the virtual filesystem.",
-  group: "file",
+export const contextCopyTool = {
+  name: "context_copy",
+  description: "Copy a context item.",
+  group: "context",
   inputSchema,
   outputSchema,
   execute: async (input, ctx) => {

--- a/src/tools/file/count-lines.ts
+++ b/src/tools/file/count-lines.ts
@@ -11,10 +11,10 @@ const outputSchema = z.object({
   is_error: z.boolean(),
 });
 
-export const fileCountLinesTool = {
-  name: "file_count_lines",
-  description: "Count the number of lines in a text file.",
-  group: "file",
+export const contextCountLinesTool = {
+  name: "context_count_lines",
+  description: "Count the number of lines in a text context item.",
+  group: "context",
   inputSchema,
   outputSchema,
   execute: async (input, ctx) => {

--- a/src/tools/file/delete.ts
+++ b/src/tools/file/delete.ts
@@ -22,10 +22,10 @@ const outputSchema = z.object({
   is_error: z.boolean(),
 });
 
-export const fileDeleteTool = {
-  name: "file_delete",
-  description: "Delete a file or directory from the virtual filesystem.",
-  group: "file",
+export const contextDeleteTool = {
+  name: "context_delete",
+  description: "Delete a context item or directory.",
+  group: "context",
   inputSchema,
   outputSchema,
   execute: async (input, ctx) => {

--- a/src/tools/file/edit.ts
+++ b/src/tools/file/edit.ts
@@ -24,11 +24,11 @@ const outputSchema = z.object({
   is_error: z.boolean(),
 });
 
-export const fileEditTool = {
-  name: "file_edit",
+export const contextEditTool = {
+  name: "context_edit",
   description:
-    "Apply git-style patches to a file. Each patch specifies a line range to replace.",
-  group: "file",
+    "Apply git-style patches to a context item. Each patch specifies a line range to replace.",
+  group: "context",
   inputSchema,
   outputSchema,
   execute: async (input, ctx) => {

--- a/src/tools/file/exists.ts
+++ b/src/tools/file/exists.ts
@@ -11,10 +11,10 @@ const outputSchema = z.object({
   is_error: z.boolean(),
 });
 
-export const fileExistsTool = {
-  name: "file_exists",
-  description: "Check if a file exists in the virtual filesystem.",
-  group: "file",
+export const contextExistsTool = {
+  name: "context_exists",
+  description: "Check if a context item exists.",
+  group: "context",
   inputSchema,
   outputSchema,
   execute: async (input, ctx) => {

--- a/src/tools/file/info.ts
+++ b/src/tools/file/info.ts
@@ -22,10 +22,11 @@ const outputSchema = z.object({
   is_error: z.boolean(),
 });
 
-export const fileInfoTool = {
-  name: "file_info",
-  description: "Show file metadata (size, MIME type, line count, etc.).",
-  group: "file",
+export const contextInfoTool = {
+  name: "context_info",
+  description:
+    "Show context item metadata (size, MIME type, line count, etc.).",
+  group: "context",
   inputSchema,
   outputSchema,
   execute: async (input, ctx) => {

--- a/src/tools/file/move.ts
+++ b/src/tools/file/move.ts
@@ -17,10 +17,10 @@ const outputSchema = z.object({
   is_error: z.boolean(),
 });
 
-export const fileMoveTool = {
-  name: "file_move",
-  description: "Move or rename a file in the virtual filesystem.",
-  group: "file",
+export const contextMoveTool = {
+  name: "context_move",
+  description: "Move or rename a context item.",
+  group: "context",
   inputSchema,
   outputSchema,
   execute: async (input, ctx) => {

--- a/src/tools/file/read.ts
+++ b/src/tools/file/read.ts
@@ -16,10 +16,10 @@ const outputSchema = z.object({
   is_error: z.boolean(),
 });
 
-export const fileReadTool = {
-  name: "file_read",
-  description: "Read a file's contents from the virtual filesystem.",
-  group: "file",
+export const contextReadTool = {
+  name: "context_read",
+  description: "Read a context item's contents.",
+  group: "context",
   inputSchema,
   outputSchema,
   execute: async (input, ctx) => {

--- a/src/tools/file/write.ts
+++ b/src/tools/file/write.ts
@@ -38,11 +38,11 @@ const outputSchema = z.object({
   is_error: z.boolean(),
 });
 
-export const fileWriteTool = {
-  name: "file_write",
+export const contextWriteTool = {
+  name: "context_write",
   description:
-    "Write content to a file in the virtual filesystem. Creates the file if it doesn't exist, or overwrites if it does.",
-  group: "file",
+    "Write content to a context item. Creates the item if it doesn't exist, or overwrites if it does.",
+  group: "context",
   inputSchema,
   outputSchema,
   execute: async (input, ctx) => {

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -1,23 +1,24 @@
 // Context tools
+
 import { readLargeResultTool } from "./context/read-large-result.ts";
-import { searchContextTool } from "./context/search.ts";
+import { contextSearchTool } from "./context/search.ts";
 import { updateBeliefsTool } from "./context/update-beliefs.ts";
 import { updateGoalsTool } from "./context/update-goals.ts";
-// Directory tools
-import { dirCreateTool } from "./dir/create.ts";
-import { dirListTool } from "./dir/list.ts";
-import { dirSizeTool } from "./dir/size.ts";
-import { dirTreeTool } from "./dir/tree.ts";
-import { fileCopyTool } from "./file/copy.ts";
-import { fileCountLinesTool } from "./file/count-lines.ts";
-import { fileDeleteTool } from "./file/delete.ts";
-import { fileEditTool } from "./file/edit.ts";
-import { fileExistsTool } from "./file/exists.ts";
-import { fileInfoTool } from "./file/info.ts";
-import { fileMoveTool } from "./file/move.ts";
-// File tools
-import { fileReadTool } from "./file/read.ts";
-import { fileWriteTool } from "./file/write.ts";
+// Context — directory operations
+import { contextCreateDirTool } from "./dir/create.ts";
+import { contextListDirTool } from "./dir/list.ts";
+import { contextDirSizeTool } from "./dir/size.ts";
+import { contextTreeTool } from "./dir/tree.ts";
+// Context — file operations
+import { contextCopyTool } from "./file/copy.ts";
+import { contextCountLinesTool } from "./file/count-lines.ts";
+import { contextDeleteTool } from "./file/delete.ts";
+import { contextEditTool } from "./file/edit.ts";
+import { contextExistsTool } from "./file/exists.ts";
+import { contextInfoTool } from "./file/info.ts";
+import { contextMoveTool } from "./file/move.ts";
+import { contextReadTool } from "./file/read.ts";
+import { contextWriteTool } from "./file/write.ts";
 // MCP tools
 import { mcpExecTool } from "./mcp/exec.ts";
 import { mcpInfoTool } from "./mcp/info.ts";
@@ -52,22 +53,24 @@ export function registerAllTools(): void {
   registerTool(listTasksTool);
   registerTool(viewTaskTool);
 
-  // Directory
-  registerTool(dirCreateTool);
-  registerTool(dirListTool);
-  registerTool(dirTreeTool);
-  registerTool(dirSizeTool);
-
-  // File
-  registerTool(fileReadTool);
-  registerTool(fileWriteTool);
-  registerTool(fileEditTool);
-  registerTool(fileDeleteTool);
-  registerTool(fileCopyTool);
-  registerTool(fileMoveTool);
-  registerTool(fileInfoTool);
-  registerTool(fileExistsTool);
-  registerTool(fileCountLinesTool);
+  // Context
+  registerTool(contextCreateDirTool);
+  registerTool(contextListDirTool);
+  registerTool(contextTreeTool);
+  registerTool(contextDirSizeTool);
+  registerTool(contextReadTool);
+  registerTool(contextWriteTool);
+  registerTool(contextEditTool);
+  registerTool(contextDeleteTool);
+  registerTool(contextCopyTool);
+  registerTool(contextMoveTool);
+  registerTool(contextInfoTool);
+  registerTool(contextExistsTool);
+  registerTool(contextCountLinesTool);
+  registerTool(contextSearchTool);
+  registerTool(updateBeliefsTool);
+  registerTool(updateGoalsTool);
+  registerTool(readLargeResultTool);
 
   // Schedule
   registerTool(createScheduleTool);
@@ -80,12 +83,6 @@ export function registerAllTools(): void {
   // Thread
   registerTool(listThreadsTool);
   registerTool(viewThreadTool);
-
-  // Context
-  registerTool(searchContextTool);
-  registerTool(updateBeliefsTool);
-  registerTool(updateGoalsTool);
-  registerTool(readLargeResultTool);
 
   // MCP
   registerTool(mcpListToolsTool);

--- a/test/chat/agent.test.ts
+++ b/test/chat/agent.test.ts
@@ -12,7 +12,7 @@ describe("getChatTools", () => {
     expect(names).toContain("view_task");
     expect(names).toContain("list_threads");
     expect(names).toContain("view_thread");
-    expect(names).toContain("search_context");
+    expect(names).toContain("context_search");
     expect(names).toContain("update_beliefs");
     expect(names).toContain("update_goals");
     expect(names).toContain("list_schedules");
@@ -24,9 +24,9 @@ describe("getChatTools", () => {
     expect(names).not.toContain("wait_task");
 
     // Should NOT include destructive file tools
-    expect(names).not.toContain("file_write");
-    expect(names).not.toContain("file_delete");
-    expect(names).not.toContain("file_edit");
+    expect(names).not.toContain("context_write");
+    expect(names).not.toContain("context_delete");
+    expect(names).not.toContain("context_edit");
   });
 
   test("returns valid Anthropic tool format", () => {

--- a/test/commands/context-delete.test.ts
+++ b/test/commands/context-delete.test.ts
@@ -55,7 +55,7 @@ describe("context delete CLI", () => {
     const result = await run(["context", "delete", "/docs/test.md"]);
     expect(result.code).toBe(0);
     expect(result.stdout + result.stderr).toContain(
-      "Deleted context item: /docs/test.md",
+      "Deleted context entry: /docs/test.md",
     );
 
     // Verify it's actually gone
@@ -73,7 +73,7 @@ describe("context delete CLI", () => {
     const result = await run(["context", "delete", "/no/such/path.md"]);
     expect(result.code).toBe(1);
     expect(result.stdout + result.stderr).toContain(
-      "Context item not found: /no/such/path.md",
+      "Context entry not found: /no/such/path.md",
     );
   });
 });

--- a/test/commands/context-show.test.ts
+++ b/test/commands/context-show.test.ts
@@ -68,7 +68,7 @@ describe("context show CLI", () => {
     const result = await run(["context", "show", "/no/such/path.md"]);
     expect(result.code).toBe(1);
     expect(result.stdout + result.stderr).toContain(
-      "Context item not found: /no/such/path.md",
+      "Context entry not found: /no/such/path.md",
     );
   });
 

--- a/test/daemon/llm.test.ts
+++ b/test/daemon/llm.test.ts
@@ -163,14 +163,14 @@ describe("runAgentLoop", () => {
     const threadId = await createThread(conn, "daemon_tick", task.id);
 
     // Always return a non-terminal tool use so the loop continues.
-    // Use file_exists which never throws (always returns a result).
+    // Use context_exists which never throws (always returns a result).
     let turnCounter = 0;
     mockCreate.mockImplementation(async () => ({
       content: [
         {
           type: "tool_use",
           id: `tool_${++turnCounter}`,
-          name: "file_exists",
+          name: "context_exists",
           input: { path: "/anything.txt" },
         },
       ],
@@ -260,13 +260,13 @@ describe("runAgentLoop", () => {
             {
               type: "tool_use",
               id: "tool_a",
-              name: "file_exists",
+              name: "context_exists",
               input: { path: "/a.txt" },
             },
             {
               type: "tool_use",
               id: "tool_b",
-              name: "file_exists",
+              name: "context_exists",
               input: { path: "/b.txt" },
             },
           ],
@@ -304,13 +304,13 @@ describe("runAgentLoop", () => {
     // Verify both tool results were logged
     const threadData = await getThread(conn, threadId);
     const toolResults = threadData?.interactions.filter(
-      (i) => i.kind === "tool_result" && i.tool_name === "file_exists",
+      (i) => i.kind === "tool_result" && i.tool_name === "context_exists",
     );
     expect(toolResults?.length).toBe(2);
 
     // Verify both tool_use entries were logged
     const toolUses = threadData?.interactions.filter(
-      (i) => i.kind === "tool_use" && i.tool_name === "file_exists",
+      (i) => i.kind === "tool_use" && i.tool_name === "context_exists",
     );
     expect(toolUses?.length).toBe(2);
   });

--- a/test/db/threads.test.ts
+++ b/test/db/threads.test.ts
@@ -97,7 +97,7 @@ describe("interaction logging", () => {
       role: "assistant",
       kind: "tool_use",
       content: "Calling search tool",
-      toolName: "search_context",
+      toolName: "context_search",
       toolInput: '{"query": "relevant docs"}',
     });
 
@@ -105,7 +105,7 @@ describe("interaction logging", () => {
       role: "tool",
       kind: "tool_result",
       content: "Found 3 results",
-      toolName: "search_context",
+      toolName: "context_search",
       durationMs: 150,
     });
 
@@ -126,7 +126,7 @@ describe("interaction logging", () => {
     // Verify content
     expect(result?.interactions[0]?.role).toBe("user");
     expect(result?.interactions[0]?.kind).toBe("message");
-    expect(result?.interactions[2]?.tool_name).toBe("search_context");
+    expect(result?.interactions[2]?.tool_name).toBe("context_search");
     expect(result?.interactions[2]?.tool_input).toBe(
       '{"query": "relevant docs"}',
     );

--- a/test/tools/context-search.test.ts
+++ b/test/tools/context-search.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test } from "bun:test";
-import { searchContextTool } from "../../src/tools/context/search.ts";
+import { contextSearchTool } from "../../src/tools/context/search.ts";
 import type { ToolContext } from "../../src/tools/tool.ts";
 import { seedFile, setupToolContext } from "../helpers.ts";
 
@@ -9,9 +9,9 @@ beforeEach(async () => {
   ({ ctx } = await setupToolContext());
 });
 
-describe("search_context", () => {
+describe("context_search", () => {
   test("returns empty results for no matches", async () => {
-    const result = await searchContextTool.execute(
+    const result = await contextSearchTool.execute(
       { query: "nonexistent" },
       ctx,
     );
@@ -25,7 +25,7 @@ describe("search_context", () => {
       "/notes/meeting.md",
       "Discussed quarterly revenue",
     );
-    const result = await searchContextTool.execute({ query: "revenue" }, ctx);
+    const result = await contextSearchTool.execute({ query: "revenue" }, ctx);
     expect(result.count).toBe(1);
     expect(result.results[0]?.context_path).toBe("/notes/meeting.md");
   });
@@ -34,7 +34,7 @@ describe("search_context", () => {
     await seedFile(ctx.conn, "/reports/budget.md", "Numbers here", {
       title: "Budget Report",
     });
-    const result = await searchContextTool.execute({ query: "budget" }, ctx);
+    const result = await contextSearchTool.execute({ query: "budget" }, ctx);
     expect(result.count).toBe(1);
   });
 
@@ -42,7 +42,7 @@ describe("search_context", () => {
     await seedFile(ctx.conn, "/a.md", "test content");
     await seedFile(ctx.conn, "/b.md", "test content");
     await seedFile(ctx.conn, "/c.md", "test content");
-    const result = await searchContextTool.execute(
+    const result = await contextSearchTool.execute(
       { query: "test", limit: 2 },
       ctx,
     );
@@ -51,7 +51,7 @@ describe("search_context", () => {
 
   test("returns content preview", async () => {
     await seedFile(ctx.conn, "/doc.md", "A very long document about testing");
-    const result = await searchContextTool.execute({ query: "testing" }, ctx);
+    const result = await contextSearchTool.execute({ query: "testing" }, ctx);
     expect(result.results[0]?.content_preview).toContain("testing");
   });
 });

--- a/test/tools/dir.test.ts
+++ b/test/tools/dir.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import type { DbConnection } from "../../src/db/connection.ts";
-import { dirCreateTool } from "../../src/tools/dir/create.ts";
-import { dirListTool } from "../../src/tools/dir/list.ts";
-import { dirSizeTool } from "../../src/tools/dir/size.ts";
-import { dirTreeTool } from "../../src/tools/dir/tree.ts";
+import { contextCreateDirTool } from "../../src/tools/dir/create.ts";
+import { contextListDirTool } from "../../src/tools/dir/list.ts";
+import { contextDirSizeTool } from "../../src/tools/dir/size.ts";
+import { contextTreeTool } from "../../src/tools/dir/tree.ts";
 import type { ToolContext } from "../../src/tools/tool.ts";
 import { seedDir, seedFile, setupToolContext } from "../helpers.ts";
 
@@ -14,30 +14,33 @@ beforeEach(async () => {
   ({ conn, ctx } = await setupToolContext());
 });
 
-// ── dir_create ──────────────────────────────────────────────
+// ── context_create_dir ──────────────────────────────────────────
 
-describe("dir_create", () => {
+describe("context_create_dir", () => {
   test("creates a new directory", async () => {
-    const result = await dirCreateTool.execute({ path: "/mydir" }, ctx);
+    const result = await contextCreateDirTool.execute({ path: "/mydir" }, ctx);
     expect(result.created).toBe(true);
     expect(result.path).toBe("/mydir");
   });
 
   test("returns created=false if directory already exists", async () => {
     await seedDir(conn, "/existing");
-    const result = await dirCreateTool.execute({ path: "/existing" }, ctx);
+    const result = await contextCreateDirTool.execute(
+      { path: "/existing" },
+      ctx,
+    );
     expect(result.created).toBe(false);
     expect(result.path).toBe("/existing");
   });
 });
 
-// ── dir_list ────────────────────────────────────────────────
+// ── context_list_dir ────────────────────────────────────────────
 
-describe("dir_list", () => {
+describe("context_list_dir", () => {
   test("lists files at root", async () => {
     await seedFile(conn, "/a.txt", "aaa");
     await seedFile(conn, "/b.txt", "bbb");
-    const result = await dirListTool.execute(
+    const result = await contextListDirTool.execute(
       { path: "/", recursive: true, limit: 100, offset: 0 },
       ctx,
     );
@@ -52,14 +55,14 @@ describe("dir_list", () => {
     await seedFile(conn, "/p2.txt", "2");
     await seedFile(conn, "/p3.txt", "3");
 
-    const page1 = await dirListTool.execute(
+    const page1 = await contextListDirTool.execute(
       { path: "/", recursive: true, limit: 2, offset: 0 },
       ctx,
     );
     expect(page1.entries.length).toBeLessThanOrEqual(2);
     expect(page1.total).toBeGreaterThanOrEqual(3);
 
-    const page2 = await dirListTool.execute(
+    const page2 = await contextListDirTool.execute(
       { path: "/", recursive: true, limit: 2, offset: 2 },
       ctx,
     );
@@ -67,7 +70,7 @@ describe("dir_list", () => {
   });
 
   test("returns empty for empty directory", async () => {
-    const result = await dirListTool.execute(
+    const result = await contextListDirTool.execute(
       { path: "/empty", recursive: true, limit: 100, offset: 0 },
       ctx,
     );
@@ -78,7 +81,7 @@ describe("dir_list", () => {
   test("non-recursive lists only immediate children", async () => {
     await seedFile(conn, "/top/child.txt", "child");
     await seedFile(conn, "/top/sub/deep.txt", "deep");
-    const result = await dirListTool.execute(
+    const result = await contextListDirTool.execute(
       { path: "/top", recursive: false, limit: 100, offset: 0 },
       ctx,
     );
@@ -88,7 +91,7 @@ describe("dir_list", () => {
 
   test("entries include type and size", async () => {
     await seedFile(conn, "/typed.txt", "content");
-    const result = await dirListTool.execute(
+    const result = await contextListDirTool.execute(
       { path: "/", recursive: true, limit: 100, offset: 0 },
       ctx,
     );
@@ -99,19 +102,19 @@ describe("dir_list", () => {
   });
 });
 
-// ── dir_size ────────────────────────────────────────────────
+// ── context_dir_size ────────────────────────────────────────────
 
-describe("dir_size", () => {
+describe("context_dir_size", () => {
   test("returns total size of files", async () => {
     await seedFile(conn, "/size/a.txt", "hello"); // 5 bytes
     await seedFile(conn, "/size/b.txt", "world!"); // 6 bytes
-    const result = await dirSizeTool.execute({ path: "/size" }, ctx);
+    const result = await contextDirSizeTool.execute({ path: "/size" }, ctx);
     expect(result.bytes).toBe(11);
     expect(result.formatted).toBeTruthy();
   });
 
   test("returns 0 for empty directory", async () => {
-    const result = await dirSizeTool.execute({ path: "/nothing" }, ctx);
+    const result = await contextDirSizeTool.execute({ path: "/nothing" }, ctx);
     expect(result.bytes).toBe(0);
     expect(result.formatted).toBe("0 B");
   });
@@ -119,18 +122,18 @@ describe("dir_size", () => {
   test("includes subdirectories by default", async () => {
     await seedFile(conn, "/deep/a.txt", "aaa");
     await seedFile(conn, "/deep/sub/b.txt", "bbb");
-    const result = await dirSizeTool.execute({ path: "/deep" }, ctx);
+    const result = await contextDirSizeTool.execute({ path: "/deep" }, ctx);
     expect(result.bytes).toBe(6);
   });
 });
 
-// ── dir_tree ────────────────────────────────────────────────
+// ── context_tree ────────────────────────────────────────────────
 
-describe("dir_tree", () => {
+describe("context_tree", () => {
   test("renders a tree with files", async () => {
     await seedFile(conn, "/tree/a.txt", "a");
     await seedFile(conn, "/tree/sub/b.txt", "b");
-    const result = await dirTreeTool.execute(
+    const result = await contextTreeTool.execute(
       { path: "/tree", max_items: 200 },
       ctx,
     );
@@ -140,7 +143,7 @@ describe("dir_tree", () => {
   });
 
   test("shows (empty) for empty directory", async () => {
-    const result = await dirTreeTool.execute(
+    const result = await contextTreeTool.execute(
       { path: "/void", max_items: 200 },
       ctx,
     );
@@ -152,7 +155,7 @@ describe("dir_tree", () => {
     for (let i = 0; i < 5; i++) {
       await seedFile(conn, `/many/file${i}.txt`, `content ${i}`);
     }
-    const result = await dirTreeTool.execute(
+    const result = await contextTreeTool.execute(
       { path: "/many", max_items: 3 },
       ctx,
     );

--- a/test/tools/file.test.ts
+++ b/test/tools/file.test.ts
@@ -1,14 +1,14 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import type { DbConnection } from "../../src/db/connection.ts";
-import { fileCopyTool } from "../../src/tools/file/copy.ts";
-import { fileCountLinesTool } from "../../src/tools/file/count-lines.ts";
-import { fileDeleteTool } from "../../src/tools/file/delete.ts";
-import { fileEditTool } from "../../src/tools/file/edit.ts";
-import { fileExistsTool } from "../../src/tools/file/exists.ts";
-import { fileInfoTool } from "../../src/tools/file/info.ts";
-import { fileMoveTool } from "../../src/tools/file/move.ts";
-import { fileReadTool } from "../../src/tools/file/read.ts";
-import { fileWriteTool } from "../../src/tools/file/write.ts";
+import { contextCopyTool } from "../../src/tools/file/copy.ts";
+import { contextCountLinesTool } from "../../src/tools/file/count-lines.ts";
+import { contextDeleteTool } from "../../src/tools/file/delete.ts";
+import { contextEditTool } from "../../src/tools/file/edit.ts";
+import { contextExistsTool } from "../../src/tools/file/exists.ts";
+import { contextInfoTool } from "../../src/tools/file/info.ts";
+import { contextMoveTool } from "../../src/tools/file/move.ts";
+import { contextReadTool } from "../../src/tools/file/read.ts";
+import { contextWriteTool } from "../../src/tools/file/write.ts";
 import type { ToolContext } from "../../src/tools/tool.ts";
 import { seedBinaryFile, seedFile, setupToolContext } from "../helpers.ts";
 
@@ -19,35 +19,35 @@ beforeEach(async () => {
   ({ conn, ctx } = await setupToolContext());
 });
 
-// ── file_write ──────────────────────────────────────────────
+// ── context_write ──────────────────────────────────────────────
 
-describe("file_write", () => {
+describe("context_write", () => {
   test("creates a new file", async () => {
-    const result = await fileWriteTool.execute(
+    const result = await contextWriteTool.execute(
       { path: "/hello.txt", content: "hello world" },
       ctx,
     );
     expect(result.path).toBe("/hello.txt");
     expect(result.id).toBeTruthy();
 
-    const read = await fileReadTool.execute({ path: "/hello.txt" }, ctx);
+    const read = await contextReadTool.execute({ path: "/hello.txt" }, ctx);
     expect(read.content).toBe("hello world");
   });
 
   test("overwrites existing file", async () => {
     await seedFile(conn, "/overwrite.txt", "original");
-    const result = await fileWriteTool.execute(
+    const result = await contextWriteTool.execute(
       { path: "/overwrite.txt", content: "updated" },
       ctx,
     );
     expect(result.path).toBe("/overwrite.txt");
 
-    const read = await fileReadTool.execute({ path: "/overwrite.txt" }, ctx);
+    const read = await contextReadTool.execute({ path: "/overwrite.txt" }, ctx);
     expect(read.content).toBe("updated");
   });
 
   test("sets title and description", async () => {
-    await fileWriteTool.execute(
+    await contextWriteTool.execute(
       {
         path: "/doc.md",
         content: "# Doc",
@@ -56,14 +56,14 @@ describe("file_write", () => {
       },
       ctx,
     );
-    const info = await fileInfoTool.execute({ path: "/doc.md" }, ctx);
+    const info = await contextInfoTool.execute({ path: "/doc.md" }, ctx);
     expect(info.title).toBe("My Doc");
     expect(info.description).toBe("A document");
   });
 
   test("writes base64 content", async () => {
     const b64 = btoa("binary data");
-    const result = await fileWriteTool.execute(
+    const result = await contextWriteTool.execute(
       { path: "/data.bin", content: "", content_base64: b64 },
       ctx,
     );
@@ -71,18 +71,18 @@ describe("file_write", () => {
   });
 });
 
-// ── file_read ───────────────────────────────────────────────
+// ── context_read ───────────────────────────────────────────────
 
-describe("file_read", () => {
+describe("context_read", () => {
   test("reads existing file", async () => {
     await seedFile(conn, "/readme.md", "line1\nline2\nline3");
-    const result = await fileReadTool.execute({ path: "/readme.md" }, ctx);
+    const result = await contextReadTool.execute({ path: "/readme.md" }, ctx);
     expect(result.content).toBe("line1\nline2\nline3");
   });
 
   test("reads with offset and limit", async () => {
     await seedFile(conn, "/lines.txt", "a\nb\nc\nd\ne");
-    const result = await fileReadTool.execute(
+    const result = await contextReadTool.execute(
       { path: "/lines.txt", offset: 2, limit: 2 },
       ctx,
     );
@@ -90,25 +90,25 @@ describe("file_read", () => {
   });
 
   test("throws for nonexistent file", async () => {
-    expect(fileReadTool.execute({ path: "/nope.txt" }, ctx)).rejects.toThrow(
+    expect(contextReadTool.execute({ path: "/nope.txt" }, ctx)).rejects.toThrow(
       "Not found",
     );
   });
 
   test("throws for file with no text content", async () => {
     await seedBinaryFile(conn, "/image.png");
-    expect(fileReadTool.execute({ path: "/image.png" }, ctx)).rejects.toThrow(
-      "No text content",
-    );
+    expect(
+      contextReadTool.execute({ path: "/image.png" }, ctx),
+    ).rejects.toThrow("No text content");
   });
 });
 
-// ── file_edit ───────────────────────────────────────────────
+// ── context_edit ───────────────────────────────────────────────
 
-describe("file_edit", () => {
+describe("context_edit", () => {
   test("replaces lines with a patch", async () => {
     await seedFile(conn, "/edit.txt", "line1\nline2\nline3");
-    const result = await fileEditTool.execute(
+    const result = await contextEditTool.execute(
       {
         path: "/edit.txt",
         patches: [{ start_line: 2, end_line: 2, content: "replaced" }],
@@ -122,7 +122,7 @@ describe("file_edit", () => {
 
   test("inserts lines when end_line is 0", async () => {
     await seedFile(conn, "/insert.txt", "line1\nline2");
-    const result = await fileEditTool.execute(
+    const result = await contextEditTool.execute(
       {
         path: "/insert.txt",
         patches: [{ start_line: 2, end_line: 0, content: "inserted" }],
@@ -137,7 +137,7 @@ describe("file_edit", () => {
 
   test("deletes lines with empty content", async () => {
     await seedFile(conn, "/delete.txt", "line1\nline2\nline3");
-    const result = await fileEditTool.execute(
+    const result = await contextEditTool.execute(
       {
         path: "/delete.txt",
         patches: [{ start_line: 2, end_line: 2, content: "" }],
@@ -150,7 +150,7 @@ describe("file_edit", () => {
 
   test("throws for nonexistent file", async () => {
     expect(
-      fileEditTool.execute(
+      contextEditTool.execute(
         {
           path: "/nope.txt",
           patches: [{ start_line: 1, end_line: 1, content: "x" }],
@@ -161,26 +161,32 @@ describe("file_edit", () => {
   });
 });
 
-// ── file_delete ─────────────────────────────────────────────
+// ── context_delete ─────────────────────────────────────────────
 
-describe("file_delete", () => {
+describe("context_delete", () => {
   test("deletes an existing file", async () => {
     await seedFile(conn, "/remove.txt", "bye");
-    const result = await fileDeleteTool.execute({ path: "/remove.txt" }, ctx);
+    const result = await contextDeleteTool.execute(
+      { path: "/remove.txt" },
+      ctx,
+    );
     expect(result.deleted).toBe(1);
 
-    const exists = await fileExistsTool.execute({ path: "/remove.txt" }, ctx);
+    const exists = await contextExistsTool.execute(
+      { path: "/remove.txt" },
+      ctx,
+    );
     expect(exists.exists).toBe(false);
   });
 
   test("throws when deleting nonexistent without force", async () => {
-    expect(fileDeleteTool.execute({ path: "/ghost.txt" }, ctx)).rejects.toThrow(
-      "Not found",
-    );
+    expect(
+      contextDeleteTool.execute({ path: "/ghost.txt" }, ctx),
+    ).rejects.toThrow("Not found");
   });
 
   test("does not throw with force flag", async () => {
-    const result = await fileDeleteTool.execute(
+    const result = await contextDeleteTool.execute(
       { path: "/ghost.txt", force: true },
       ctx,
     );
@@ -190,7 +196,7 @@ describe("file_delete", () => {
   test("recursive delete removes children", async () => {
     await seedFile(conn, "/dir/a.txt", "a");
     await seedFile(conn, "/dir/b.txt", "b");
-    const result = await fileDeleteTool.execute(
+    const result = await contextDeleteTool.execute(
       { path: "/dir", recursive: true },
       ctx,
     );
@@ -198,18 +204,18 @@ describe("file_delete", () => {
   });
 });
 
-// ── file_copy ───────────────────────────────────────────────
+// ── context_copy ───────────────────────────────────────────────
 
-describe("file_copy", () => {
+describe("context_copy", () => {
   test("copies a file", async () => {
     await seedFile(conn, "/orig.txt", "content");
-    const result = await fileCopyTool.execute(
+    const result = await contextCopyTool.execute(
       { src: "/orig.txt", dst: "/copy.txt" },
       ctx,
     );
     expect(result.path).toBe("/copy.txt");
 
-    const read = await fileReadTool.execute({ path: "/copy.txt" }, ctx);
+    const read = await contextReadTool.execute({ path: "/copy.txt" }, ctx);
     expect(read.content).toBe("content");
   });
 
@@ -217,14 +223,14 @@ describe("file_copy", () => {
     await seedFile(conn, "/src.txt", "a");
     await seedFile(conn, "/dst.txt", "b");
     expect(
-      fileCopyTool.execute({ src: "/src.txt", dst: "/dst.txt" }, ctx),
+      contextCopyTool.execute({ src: "/src.txt", dst: "/dst.txt" }, ctx),
     ).rejects.toThrow("Destination already exists");
   });
 
   test("overwrites when overwrite is true", async () => {
     await seedFile(conn, "/src.txt", "new");
     await seedFile(conn, "/dst.txt", "old");
-    const result = await fileCopyTool.execute(
+    const result = await contextCopyTool.execute(
       { src: "/src.txt", dst: "/dst.txt", overwrite: true },
       ctx,
     );
@@ -233,26 +239,26 @@ describe("file_copy", () => {
 
   test("throws when source does not exist", async () => {
     expect(
-      fileCopyTool.execute({ src: "/missing.txt", dst: "/dst.txt" }, ctx),
+      contextCopyTool.execute({ src: "/missing.txt", dst: "/dst.txt" }, ctx),
     ).rejects.toThrow();
   });
 });
 
-// ── file_move ───────────────────────────────────────────────
+// ── context_move ───────────────────────────────────────────────
 
-describe("file_move", () => {
+describe("context_move", () => {
   test("moves a file", async () => {
     await seedFile(conn, "/old.txt", "data");
-    const result = await fileMoveTool.execute(
+    const result = await contextMoveTool.execute(
       { src: "/old.txt", dst: "/new.txt" },
       ctx,
     );
     expect(result.path).toBe("/new.txt");
 
-    const exists = await fileExistsTool.execute({ path: "/old.txt" }, ctx);
+    const exists = await contextExistsTool.execute({ path: "/old.txt" }, ctx);
     expect(exists.exists).toBe(false);
 
-    const read = await fileReadTool.execute({ path: "/new.txt" }, ctx);
+    const read = await contextReadTool.execute({ path: "/new.txt" }, ctx);
     expect(read.content).toBe("data");
   });
 
@@ -260,14 +266,14 @@ describe("file_move", () => {
     await seedFile(conn, "/a.txt", "a");
     await seedFile(conn, "/b.txt", "b");
     expect(
-      fileMoveTool.execute({ src: "/a.txt", dst: "/b.txt" }, ctx),
+      contextMoveTool.execute({ src: "/a.txt", dst: "/b.txt" }, ctx),
     ).rejects.toThrow("Destination already exists");
   });
 
   test("overwrites when overwrite is true", async () => {
     await seedFile(conn, "/a.txt", "a");
     await seedFile(conn, "/b.txt", "b");
-    const result = await fileMoveTool.execute(
+    const result = await contextMoveTool.execute(
       { src: "/a.txt", dst: "/b.txt", overwrite: true },
       ctx,
     );
@@ -276,20 +282,20 @@ describe("file_move", () => {
 
   test("throws when source does not exist", async () => {
     expect(
-      fileMoveTool.execute({ src: "/missing.txt", dst: "/dst.txt" }, ctx),
+      contextMoveTool.execute({ src: "/missing.txt", dst: "/dst.txt" }, ctx),
     ).rejects.toThrow();
   });
 });
 
-// ── file_info ───────────────────────────────────────────────
+// ── context_info ───────────────────────────────────────────────
 
-describe("file_info", () => {
+describe("context_info", () => {
   test("returns metadata for existing file", async () => {
     await seedFile(conn, "/meta.txt", "hello\nworld", {
       title: "Meta",
       description: "A test file",
     });
-    const info = await fileInfoTool.execute({ path: "/meta.txt" }, ctx);
+    const info = await contextInfoTool.execute({ path: "/meta.txt" }, ctx);
     expect(info.title).toBe("Meta");
     expect(info.description).toBe("A test file");
     expect(info.mime_type).toBe("text/plain");
@@ -302,33 +308,33 @@ describe("file_info", () => {
   });
 
   test("throws for nonexistent file", async () => {
-    expect(fileInfoTool.execute({ path: "/nope.txt" }, ctx)).rejects.toThrow(
+    expect(contextInfoTool.execute({ path: "/nope.txt" }, ctx)).rejects.toThrow(
       "Not found",
     );
   });
 });
 
-// ── file_exists ─────────────────────────────────────────────
+// ── context_exists ─────────────────────────────────────────────
 
-describe("file_exists", () => {
+describe("context_exists", () => {
   test("returns true for existing file", async () => {
     await seedFile(conn, "/there.txt", "hi");
-    const result = await fileExistsTool.execute({ path: "/there.txt" }, ctx);
+    const result = await contextExistsTool.execute({ path: "/there.txt" }, ctx);
     expect(result.exists).toBe(true);
   });
 
   test("returns false for missing file", async () => {
-    const result = await fileExistsTool.execute({ path: "/nope.txt" }, ctx);
+    const result = await contextExistsTool.execute({ path: "/nope.txt" }, ctx);
     expect(result.exists).toBe(false);
   });
 });
 
-// ── file_count_lines ────────────────────────────────────────
+// ── context_count_lines ────────────────────────────────────────
 
-describe("file_count_lines", () => {
+describe("context_count_lines", () => {
   test("counts lines in a file", async () => {
     await seedFile(conn, "/lines.txt", "a\nb\nc");
-    const result = await fileCountLinesTool.execute(
+    const result = await contextCountLinesTool.execute(
       { path: "/lines.txt" },
       ctx,
     );
@@ -337,7 +343,7 @@ describe("file_count_lines", () => {
 
   test("single line file returns 1", async () => {
     await seedFile(conn, "/single.txt", "only one line");
-    const result = await fileCountLinesTool.execute(
+    const result = await contextCountLinesTool.execute(
       { path: "/single.txt" },
       ctx,
     );
@@ -346,31 +352,34 @@ describe("file_count_lines", () => {
 
   test("throws for nonexistent file", async () => {
     expect(
-      fileCountLinesTool.execute({ path: "/nope.txt" }, ctx),
+      contextCountLinesTool.execute({ path: "/nope.txt" }, ctx),
     ).rejects.toThrow("Not found");
   });
 
   test("throws for non-textual file", async () => {
     await seedBinaryFile(conn, "/bin.dat");
     expect(
-      fileCountLinesTool.execute({ path: "/bin.dat" }, ctx),
+      contextCountLinesTool.execute({ path: "/bin.dat" }, ctx),
     ).rejects.toThrow("No text content");
   });
 });
 
-// ── edge cases ─────────────────────────────────────────────
+// ── edge cases ─────────────────────────────────────────────────
 
-describe("file edge cases", () => {
+describe("context edge cases", () => {
   test("write and read file with empty content", async () => {
-    await fileWriteTool.execute({ path: "/empty.txt", content: "" }, ctx);
-    const result = await fileReadTool.execute({ path: "/empty.txt" }, ctx);
+    await contextWriteTool.execute({ path: "/empty.txt", content: "" }, ctx);
+    const result = await contextReadTool.execute({ path: "/empty.txt" }, ctx);
     expect(result.content).toBe("");
   });
 
   test("write file with very long single line", async () => {
     const longLine = "x".repeat(10000);
-    await fileWriteTool.execute({ path: "/long.txt", content: longLine }, ctx);
-    const result = await fileReadTool.execute({ path: "/long.txt" }, ctx);
+    await contextWriteTool.execute(
+      { path: "/long.txt", content: longLine },
+      ctx,
+    );
+    const result = await contextReadTool.execute({ path: "/long.txt" }, ctx);
     expect(result.content).toBe(longLine);
   });
 
@@ -380,7 +389,7 @@ describe("file edge cases", () => {
       "/multi-edit.txt",
       "line1\nline2\nline3\nline4\nline5",
     );
-    const result = await fileEditTool.execute(
+    const result = await contextEditTool.execute(
       {
         path: "/multi-edit.txt",
         patches: [
@@ -397,13 +406,13 @@ describe("file edge cases", () => {
   });
 
   test("copy preserves content exactly", async () => {
-    const content = "Special chars: \t\n\r\nUnicode: \u00e9\u00e8\u00ea";
+    const content = "Special chars: \t\n\r\nUnicode: éèê";
     await seedFile(conn, "/special.txt", content);
-    await fileCopyTool.execute(
+    await contextCopyTool.execute(
       { src: "/special.txt", dst: "/special-copy.txt" },
       ctx,
     );
-    const result = await fileReadTool.execute(
+    const result = await contextReadTool.execute(
       { path: "/special-copy.txt" },
       ctx,
     );
@@ -412,18 +421,18 @@ describe("file edge cases", () => {
 
   test("move source no longer exists", async () => {
     await seedFile(conn, "/src-move.txt", "moving data");
-    await fileMoveTool.execute(
+    await contextMoveTool.execute(
       { src: "/src-move.txt", dst: "/dst-move.txt" },
       ctx,
     );
 
-    const srcExists = await fileExistsTool.execute(
+    const srcExists = await contextExistsTool.execute(
       { path: "/src-move.txt" },
       ctx,
     );
     expect(srcExists.exists).toBe(false);
 
-    const dstExists = await fileExistsTool.execute(
+    const dstExists = await contextExistsTool.execute(
       { path: "/dst-move.txt" },
       ctx,
     );
@@ -433,14 +442,14 @@ describe("file edge cases", () => {
   test("info returns correct size for multi-byte content", async () => {
     const content = "Hello";
     await seedFile(conn, "/sized.txt", content);
-    const info = await fileInfoTool.execute({ path: "/sized.txt" }, ctx);
+    const info = await contextInfoTool.execute({ path: "/sized.txt" }, ctx);
     expect(info.size).toBe(5);
     expect(info.lines).toBe(1);
   });
 
   test("read with offset beyond file length returns empty", async () => {
     await seedFile(conn, "/short.txt", "only\ntwo");
-    const result = await fileReadTool.execute(
+    const result = await contextReadTool.execute(
       { path: "/short.txt", offset: 100 },
       ctx,
     );
@@ -451,9 +460,12 @@ describe("file edge cases", () => {
     await seedFile(conn, "/keep/a.txt", "keep me");
     await seedFile(conn, "/remove-dir/b.txt", "remove me");
 
-    await fileDeleteTool.execute({ path: "/remove-dir", recursive: true }, ctx);
+    await contextDeleteTool.execute(
+      { path: "/remove-dir", recursive: true },
+      ctx,
+    );
 
-    const kept = await fileExistsTool.execute({ path: "/keep/a.txt" }, ctx);
+    const kept = await contextExistsTool.execute({ path: "/keep/a.txt" }, ctx);
     expect(kept.exists).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Renames all `file_*` and `dir_*` agent tools to `context_*` so the LLM agent uses the same "context" vocabulary that users see in the CLI. Tool subcommands (read, write, edit, list-dir, etc.) are merged into the existing `botholomew context` CLI command alongside management subcommands (list, show, add, search, delete, chunks, refresh). The `search` group remains top-level for `search_grep` and `search_semantic`. Internal DB layer (`src/db/context.ts`) is unchanged.

## Test plan

- [x] `bun run lint` passes (tsc + biome)
- [x] All 515 tests pass
- [ ] Manual: `bun run dev context read <path>`, `context list-dir /`, `context tree` work
- [ ] Verify TUI tab 3 still functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)