### PR TITLE
Fix CLI tool commands not loading project config

### DIFF
--- a/src/commands/tools.ts
+++ b/src/commands/tools.ts
@@ -1,7 +1,6 @@
 import type { Command } from "commander";
 import { z } from "zod";
-import type { BotholomewConfig } from "../config/schemas.ts";
-import { DEFAULT_CONFIG } from "../config/schemas.ts";
+import { loadConfig } from "../config/loader.ts";
 import { registerAllTools } from "../tools/registry.ts";
 import {
   type AnyToolDefinition,
@@ -108,7 +107,7 @@ function registerToolAsCLI(parent: Command, tool: AnyToolDefinition) {
         const ctx: ToolContext = {
           conn,
           projectDir: dir,
-          config: DEFAULT_CONFIG as Required<BotholomewConfig>,
+          config: await loadConfig(dir),
           mcpxClient: null,
         };
 


### PR DESCRIPTION
## Summary
- CLI tool commands (e.g. `search semantic`) used hardcoded `DEFAULT_CONFIG` instead of calling `loadConfig()`, so API keys from `.botholomew/config.json` and environment variables were never picked up.
- Replaced `DEFAULT_CONFIG` with `await loadConfig(dir)` in `src/commands/tools.ts` so the `ToolContext` gets the real project config.

## Test plan
- [x] `bun run lint` passes
- [x] `bun test` passes (522 tests)
- [ ] Run `bun dev search semantic <query>` with `openai_api_key` set in config — should no longer error

🤖 Generated with [Claude Code](https://claude.com/claude-code)