### PR TITLE
Move search CLI commands under context subcommand

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,7 +12,6 @@ import { registerPrepareCommand } from "./commands/prepare.ts";
 import { registerScheduleCommand } from "./commands/schedule.ts";
 import { registerTaskCommand } from "./commands/task.ts";
 import { registerThreadCommand } from "./commands/thread.ts";
-import { registerToolCommands } from "./commands/tools.ts";
 import { registerUpgradeCommand } from "./commands/upgrade.ts";
 import { maybeCheckForUpdate } from "./update/background.ts";
 
@@ -39,7 +38,6 @@ registerScheduleCommand(program);
 registerChatCommand(program);
 registerContextCommand(program);
 registerMcpxCommand(program);
-registerToolCommands(program);
 registerPrepareCommand(program);
 registerCheckUpdateCommand(program);
 registerUpgradeCommand(program);

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -25,7 +25,10 @@ import {
 } from "../db/context.ts";
 import { getEmbeddingsForItem, hybridSearch } from "../db/embeddings.ts";
 import { logger } from "../utils/logger.ts";
-import { registerContextToolSubcommands } from "./tools.ts";
+import {
+  registerContextToolSubcommands,
+  registerSearchToolSubcommands,
+} from "./tools.ts";
 import { withDb } from "./with-db.ts";
 
 function fmtDate(d: Date): string {
@@ -237,12 +240,17 @@ export function registerContextCommand(program: Command) {
       }),
     );
 
-  ctx
-    .command("search <query>")
+  const search = ctx
+    .command("search")
     .description("Search context entries")
+    .argument("[query]", "search query (hybrid keyword + semantic)")
     .option("-k, --top-k <n>", "max results", Number.parseInt, 10)
     .action((query, opts) =>
       withDb(program, async (conn, dir) => {
+        if (!query) {
+          search.help();
+          return;
+        }
         const config = await loadConfig(dir);
         const queryVec = await embedSingle(query, config);
         const results = await hybridSearch(conn, query, queryVec, opts.topK);
@@ -268,6 +276,8 @@ export function registerContextCommand(program: Command) {
         }
       }),
     );
+
+  registerSearchToolSubcommands(search);
   ctx
     .command("delete <path>")
     .description("Delete a context entry by path")

--- a/src/commands/tools.ts
+++ b/src/commands/tools.ts
@@ -28,14 +28,13 @@ export function registerContextToolSubcommands(parent: Command) {
   }
 }
 
-export function registerToolCommands(program: Command) {
-  // The "search" group has its own top-level command
-  for (const group of ["search"]) {
-    const groupCmd = program.command(group).description("Search context");
-
-    for (const tool of getToolsByGroup(group)) {
-      registerToolAsCLI(groupCmd, tool);
-    }
+/**
+ * Register search tool subcommands (grep, semantic) onto an
+ * existing Commander command (e.g. the "context search" group).
+ */
+export function registerSearchToolSubcommands(parent: Command) {
+  for (const tool of getToolsByGroup("search")) {
+    registerToolAsCLI(parent, tool);
   }
 }
 


### PR DESCRIPTION
## Summary
- Moves `search grep` and `search semantic` from top-level CLI commands to `context search grep` and `context search semantic`
- Converts `context search <query>` from a standalone command to a subcommand group, preserving the existing hybrid search as the default action
- Removes the now-empty `registerToolCommands` in favor of a new `registerSearchToolSubcommands` helper

## Test plan
- [x] `bun run lint` passes
- [x] `bun test` — all 522 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)