### PR TITLE
Fix --dir option not propagating to nested CLI subcommands

### DIFF
--- a/src/commands/tools.ts
+++ b/src/commands/tools.ts
@@ -98,8 +98,10 @@ function registerToolAsCLI(parent: Command, tool: AnyToolDefinition) {
     }
   }
 
-  cmd.action((...args: unknown[]) =>
-    withDb(parent.parent ?? parent, async (conn, dir) => {
+  cmd.action((...args: unknown[]) => {
+    let root: Command = parent;
+    while (root.parent) root = root.parent;
+    return withDb(root, async (conn, dir) => {
       try {
         const input = buildInput(tool, positionals, options, shape, args);
 
@@ -116,8 +118,8 @@ function registerToolAsCLI(parent: Command, tool: AnyToolDefinition) {
         logger.error(String(err));
         process.exit(1);
       }
-    }),
-  );
+    });
+  });
 }
 
 function buildInput(


### PR DESCRIPTION
## Summary

- Fix crash in deeply nested CLI commands like `context search grep` where `--dir` option was `undefined`
- `registerToolAsCLI` only walked one level up (`parent.parent`), reaching the `context` command instead of the root program where `--dir` is defined
- Now walks the full Commander parent chain to the root command

🤖 Generated with [Claude Code](https://claude.com/claude-code)