### PR TITLE
Format semantic search CLI output with colors instead of raw JSON

### DIFF
--- a/src/commands/tools.ts
+++ b/src/commands/tools.ts
@@ -1,3 +1,4 @@
+import ansis from "ansis";
 import type { Command } from "commander";
 import { z } from "zod";
 import { loadConfig } from "../config/loader.ts";
@@ -218,6 +219,29 @@ function formatOutput(result: unknown, _toolName: string) {
           const m = match as { path: string; line: number; content: string };
           console.log(`${m.path}:${m.line}: ${m.content}`);
         }
+      }
+      return;
+    }
+
+    if ("results" in obj && Array.isArray(obj.results)) {
+      for (const [i, r] of (
+        obj.results as {
+          path: string;
+          title: string;
+          score: number;
+          snippet: string;
+        }[]
+      ).entries()) {
+        const score = (r.score * 100).toFixed(1);
+        console.log(
+          `${ansis.bold(`${i + 1}.`)} ${ansis.cyan(r.title)} ${ansis.dim(`(${score}%)`)}`,
+        );
+        console.log(`   ${ansis.dim(r.path)}`);
+        if (r.snippet) {
+          const snippet = r.snippet.slice(0, 120).replace(/\n/g, " ");
+          console.log(`   ${snippet}...`);
+        }
+        console.log("");
       }
       return;
     }


### PR DESCRIPTION
## Summary

- `context search semantic` was falling through to the default JSON formatter in `formatOutput()` because the `results` array shape wasn't handled
- Adds a `results` handler that formats output with numbered entries, colored titles, score percentages, paths, and snippets — matching the style of `context search`

## Test plan

- [x] `bun run lint` passes
- [x] `bun test` passes (522 tests)
- [ ] Manual: `bun dev context search semantic 'query'` shows colored output instead of raw JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)