### PR TITLE
Allow context read to accept item IDs

### DIFF
--- a/src/db/uuid.ts
+++ b/src/db/uuid.ts
@@ -1,1 +1,8 @@
 export { v7 as uuidv7 } from "uuid";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isUuid(value: string): boolean {
+  return UUID_RE.test(value);
+}

--- a/src/tools/file/read.ts
+++ b/src/tools/file/read.ts
@@ -1,9 +1,10 @@
 import { z } from "zod";
-import { getContextItemByPath } from "../../db/context.ts";
+import { getContextItem, getContextItemByPath } from "../../db/context.ts";
+import { isUuid } from "../../db/uuid.ts";
 import type { ToolDefinition } from "../tool.ts";
 
 const inputSchema = z.object({
-  path: z.string().describe("File path to read"),
+  path: z.string().describe("File path or context item ID"),
   offset: z
     .number()
     .optional()
@@ -23,7 +24,9 @@ export const contextReadTool = {
   inputSchema,
   outputSchema,
   execute: async (input, ctx) => {
-    const item = await getContextItemByPath(ctx.conn, input.path);
+    const item = isUuid(input.path)
+      ? await getContextItem(ctx.conn, input.path)
+      : await getContextItemByPath(ctx.conn, input.path);
     if (!item) throw new Error(`Not found: ${input.path}`);
     if (item.content == null) throw new Error(`No text content: ${input.path}`);
 

--- a/test/tools/file.test.ts
+++ b/test/tools/file.test.ts
@@ -89,6 +89,12 @@ describe("context_read", () => {
     expect(result.content).toBe("b\nc");
   });
 
+  test("reads by context item ID", async () => {
+    const item = await seedFile(conn, "/by-id.txt", "found by id");
+    const result = await contextReadTool.execute({ path: item.id }, ctx);
+    expect(result.content).toBe("found by id");
+  });
+
   test("throws for nonexistent file", async () => {
     expect(contextReadTool.execute({ path: "/nope.txt" }, ctx)).rejects.toThrow(
       "Not found",


### PR DESCRIPTION
## Summary
- `context read` now accepts a context item UUID in addition to a file path
- Adds `isUuid()` helper to `src/db/uuid.ts` for UUID format detection
- When the argument matches a UUID pattern, looks up by ID via `getContextItem()`; otherwise falls back to path-based lookup via `getContextItemByPath()`

## Test plan
- [x] New test: reads context item by ID
- [x] All 557 existing tests pass
- [x] `bun run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)