### PR TITLE
Remove beliefs/goals CLI commands (agent-only tools)

### DIFF
--- a/src/commands/tools.ts
+++ b/src/commands/tools.ts
@@ -18,10 +18,14 @@ registerAllTools();
  * existing Commander command. Skips tools whose derived subcommand name
  * collides with an already-registered subcommand on the parent.
  */
+/** Context tools that are agent-only (not exposed as CLI subcommands) */
+const AGENT_ONLY_TOOLS = new Set(["update_beliefs", "update_goals"]);
+
 export function registerContextToolSubcommands(parent: Command) {
   const existing = new Set(parent.commands.map((c: Command) => c.name()));
 
   for (const tool of getToolsByGroup("context")) {
+    if (AGENT_ONLY_TOOLS.has(tool.name)) continue;
     const subName = deriveSubName(tool.name);
     if (existing.has(subName)) continue; // skip conflicts with management subcommands
     registerToolAsCLI(parent, tool);


### PR DESCRIPTION
## Summary
- Skip `update_beliefs` and `update_goals` when registering context tools as CLI subcommands
- These are plain markdown files users can edit directly — no CLI command needed
- Agent (daemon + chat) retains full access to both tools

## Test plan
- [x] `bun run lint` passes
- [x] `bun test` passes (556 tests)
- [x] `botholomew context --help` no longer shows `update-beliefs` or `update-goals`

🤖 Generated with [Claude Code](https://claude.com/claude-code)