### PR TITLE
Add navigation options to `context tree` (max-depth, items-per-dir)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "An AI agent for knowledge work",
   "type": "module",
   "bin": {

--- a/src/db/context.ts
+++ b/src/db/context.ts
@@ -231,6 +231,29 @@ export async function contextPathExists(
   return row != null;
 }
 
+export async function countContextItemsByPrefix(
+  db: DbConnection,
+  prefix: string,
+  opts?: { recursive?: boolean },
+): Promise<number> {
+  const normalizedPrefix = prefix.endsWith("/") ? prefix : `${prefix}/`;
+  let row: { cnt: number } | null;
+  if (opts?.recursive !== false) {
+    row = await db.queryGet<{ cnt: number }>(
+      `SELECT COUNT(*) AS cnt FROM context_items WHERE context_path LIKE ?1`,
+      `${normalizedPrefix}%`,
+    );
+  } else {
+    row = await db.queryGet<{ cnt: number }>(
+      `SELECT COUNT(*) AS cnt FROM context_items
+       WHERE context_path LIKE ?1 AND context_path NOT LIKE ?2`,
+      `${normalizedPrefix}%`,
+      `${normalizedPrefix}%/%`,
+    );
+  }
+  return row ? Number(row.cnt) : 0;
+}
+
 export async function getDistinctDirectories(
   db: DbConnection,
   prefix?: string,

--- a/src/tools/dir/tree.ts
+++ b/src/tools/dir/tree.ts
@@ -1,91 +1,275 @@
 import { z } from "zod";
-import { listContextItemsByPrefix } from "../../db/context.ts";
+import {
+  countContextItemsByPrefix,
+  listContextItemsByPrefix,
+} from "../../db/context.ts";
 import type { ToolDefinition } from "../tool.ts";
 
-const DEFAULT_MAX_ITEMS = 200;
+const DEFAULT_MAX_DEPTH = 3;
+const DEFAULT_ITEMS_PER_DIR = 15;
+const HARD_FETCH_CAP = 1000;
 
 const inputSchema = z.object({
   path: z
     .string()
     .optional()
     .describe("Root path for the tree (defaults to /)"),
-  max_items: z
+  max_depth: z
     .number()
+    .int()
+    .positive()
     .optional()
-    .default(DEFAULT_MAX_ITEMS)
+    .default(DEFAULT_MAX_DEPTH)
     .describe(
-      `Maximum number of items to include (defaults to ${DEFAULT_MAX_ITEMS})`,
+      `Maximum depth of directories to render (defaults to ${DEFAULT_MAX_DEPTH}). Use a deeper path to drill in.`,
     ),
+  items_per_dir: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .default(DEFAULT_ITEMS_PER_DIR)
+    .describe(
+      `Maximum entries shown per directory (defaults to ${DEFAULT_ITEMS_PER_DIR}). Overflow shown as "(+N more)".`,
+    ),
+});
+
+const TruncatedDirSchema = z.object({
+  path: z.string(),
+  shown: z.number(),
+  total: z.number(),
 });
 
 const outputSchema = z.object({
   tree: z.string(),
   is_error: z.boolean(),
+  total_items: z.number(),
+  truncated_dirs: z.array(TruncatedDirSchema),
+  hint: z.string(),
 });
+
+interface DirNode {
+  name: string;
+  fullPath: string;
+  isDir: true;
+  children: TreeEntry[];
+}
+
+interface FileNode {
+  name: string;
+  fullPath: string;
+  isDir: false;
+}
+
+type TreeEntry = DirNode | FileNode;
 
 export const contextTreeTool = {
   name: "context_tree",
-  description: "Render a directory as a markdown-style tree in context.",
+  description:
+    "Render a directory as a markdown-style tree. Use max_depth and items_per_dir to bound output; drill in by passing a deeper path.",
   group: "context",
   inputSchema,
   outputSchema,
   execute: async (input, ctx) => {
     const path = input.path ?? "/";
-    const maxItems = input.max_items ?? DEFAULT_MAX_ITEMS;
-    const items = await listContextItemsByPrefix(ctx.conn, path, {
-      recursive: true,
-      limit: maxItems,
-    });
-
-    if (items.length === 0) {
-      return { tree: `${path}\n  (empty)`, is_error: false };
-    }
-
+    const maxDepth = input.max_depth ?? DEFAULT_MAX_DEPTH;
+    const itemsPerDir = input.items_per_dir ?? DEFAULT_ITEMS_PER_DIR;
     const normalizedPath = path.endsWith("/") ? path : `${path}/`;
 
-    // Build tree structure
-    const lines: string[] = [path];
+    const totalItems = await countContextItemsByPrefix(ctx.conn, path, {
+      recursive: true,
+    });
 
-    // Collect all paths and sort
-    const paths = items.map((i) => i.context_path).sort();
+    if (totalItems === 0) {
+      return {
+        tree: `${path}\n  (empty)`,
+        is_error: false,
+        total_items: 0,
+        truncated_dirs: [],
+        hint: "Directory is empty.",
+      };
+    }
 
-    // Collect all directory prefixes
-    const dirSet = new Set<string>();
-    for (const p of paths) {
-      const relative = p.slice(normalizedPath.length);
-      const parts = relative.split("/");
-      for (let i = 1; i < parts.length; i++) {
-        dirSet.add(parts.slice(0, i).join("/"));
+    const items = await listContextItemsByPrefix(ctx.conn, path, {
+      recursive: true,
+      limit: HARD_FETCH_CAP,
+    });
+
+    // Build tree structure: dirs map child name -> child node
+    const root: DirNode = {
+      name: path,
+      fullPath: path,
+      isDir: true,
+      children: [],
+    };
+    const dirIndex = new Map<string, DirNode>();
+    dirIndex.set(stripTrailingSlash(path), root);
+
+    for (const item of items) {
+      const relative = item.context_path.slice(normalizedPath.length);
+      if (relative.length === 0) continue; // root itself, skip
+      const parts = relative.split("/").filter((p) => p.length > 0);
+      const isExplicitDir = item.mime_type === "inode/directory";
+
+      // Walk segments, creating intermediate directories as needed
+      let parentDir = root;
+      let currentRel = "";
+      for (let i = 0; i < parts.length; i++) {
+        const segment = parts[i];
+        if (!segment) continue;
+        currentRel = currentRel ? `${currentRel}/${segment}` : segment;
+        const fullPath = `${normalizedPath}${currentRel}`;
+        const isLeaf = i === parts.length - 1;
+        const isDirHere = !isLeaf || isExplicitDir;
+
+        if (isDirHere) {
+          const key = stripTrailingSlash(fullPath);
+          let dir = dirIndex.get(key);
+          if (!dir) {
+            dir = {
+              name: segment,
+              fullPath,
+              isDir: true,
+              children: [],
+            };
+            dirIndex.set(key, dir);
+            parentDir.children.push(dir);
+          }
+          parentDir = dir;
+        } else {
+          parentDir.children.push({
+            name: segment,
+            fullPath,
+            isDir: false,
+          });
+        }
       }
     }
 
-    // Merge dirs and files, sort
-    const allEntries = [
-      ...Array.from(dirSet).map((d) => ({ path: d, isDir: true })),
-      ...paths.map((p) => ({
-        path: p.slice(normalizedPath.length),
-        isDir: false,
-      })),
-    ].sort((a, b) => a.path.localeCompare(b.path));
-
-    for (let i = 0; i < allEntries.length; i++) {
-      const entry = allEntries[i];
-      if (!entry) continue;
-      const depth = entry.path.split("/").length - 1;
-      const isLast =
-        i === allEntries.length - 1 ||
-        (allEntries[i + 1]?.path.split("/").length ?? 0) - 1 <= depth;
-      const prefix = isLast ? "└── " : "├── ";
-      const indent = "│   ".repeat(depth);
-      const name = entry.path.split("/").pop() ?? "";
-      const suffix = entry.isDir ? "/" : "";
-      lines.push(`${indent}${prefix}${name}${suffix}`);
+    // Sort each directory's children: dirs first, then alphabetical
+    for (const dir of dirIndex.values()) {
+      dir.children.sort((a, b) => {
+        if (a.isDir !== b.isDir) return a.isDir ? -1 : 1;
+        return a.name.localeCompare(b.name);
+      });
     }
 
-    if (items.length >= maxItems) {
-      lines.push(`... (truncated at ${maxItems} items)`);
-    }
+    const truncatedDirs: Array<{
+      path: string;
+      shown: number;
+      total: number;
+    }> = [];
+    const depthLimitedDirs: string[] = [];
 
-    return { tree: lines.join("\n"), is_error: false };
+    const lines: string[] = [path];
+
+    const render = (
+      dir: DirNode,
+      indent: string,
+      currentDepth: number,
+    ): void => {
+      const children = dir.children;
+      const total = children.length;
+      const shown = Math.min(total, itemsPerDir);
+      const visible = children.slice(0, shown);
+      const overflow = total - shown;
+
+      if (overflow > 0) {
+        truncatedDirs.push({
+          path: stripTrailingSlash(dir.fullPath),
+          shown,
+          total,
+        });
+      }
+
+      for (let i = 0; i < visible.length; i++) {
+        const child = visible[i];
+        if (!child) continue;
+        const isLastVisible = i === visible.length - 1 && overflow === 0;
+        const connector = isLastVisible ? "└── " : "├── ";
+        const childIndent = isLastVisible ? "    " : "│   ";
+
+        if (child.isDir) {
+          const atDepthLimit = currentDepth + 1 >= maxDepth;
+          if (atDepthLimit && child.children.length > 0) {
+            depthLimitedDirs.push(stripTrailingSlash(child.fullPath));
+            const subCount = countDescendants(child);
+            lines.push(
+              `${indent}${connector}${child.name}/ (${subCount} ${
+                subCount === 1 ? "item" : "items"
+              }, drill in)`,
+            );
+          } else {
+            lines.push(`${indent}${connector}${child.name}/`);
+            render(child, indent + childIndent, currentDepth + 1);
+          }
+        } else {
+          lines.push(`${indent}${connector}${child.name}`);
+        }
+      }
+
+      if (overflow > 0) {
+        lines.push(`${indent}└── ... (+${overflow} more)`);
+      }
+    };
+
+    render(root, "", 0);
+
+    const hint = buildHint({
+      truncatedDirs,
+      depthLimitedDirs,
+      totalItems,
+    });
+
+    return {
+      tree: lines.join("\n"),
+      is_error: false,
+      total_items: totalItems,
+      truncated_dirs: truncatedDirs,
+      hint,
+    };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;
+
+function stripTrailingSlash(p: string): string {
+  return p.length > 1 && p.endsWith("/") ? p.slice(0, -1) : p;
+}
+
+function countDescendants(dir: DirNode): number {
+  let count = 0;
+  for (const child of dir.children) {
+    count += 1;
+    if (child.isDir) count += countDescendants(child);
+  }
+  return count;
+}
+
+function buildHint(args: {
+  truncatedDirs: Array<{ path: string; shown: number; total: number }>;
+  depthLimitedDirs: string[];
+  totalItems: number;
+}): string {
+  const { truncatedDirs, depthLimitedDirs } = args;
+  const parts: string[] = [];
+
+  if (truncatedDirs.length > 0) {
+    const first = truncatedDirs[0];
+    if (first) {
+      parts.push(
+        `${truncatedDirs.length} ${truncatedDirs.length === 1 ? "directory was" : "directories were"} capped by items_per_dir; raise items_per_dir or call context_tree with path="${first.path}".`,
+      );
+    }
+  }
+
+  if (depthLimitedDirs.length > 0) {
+    const first = depthLimitedDirs[0];
+    if (first) {
+      parts.push(
+        `${depthLimitedDirs.length} ${depthLimitedDirs.length === 1 ? "directory was" : "directories were"} not expanded due to max_depth; raise max_depth or call context_tree with path="${first}".`,
+      );
+    }
+  }
+
+  if (parts.length === 0) return "Tree is complete.";
+  return parts.join(" ");
+}

--- a/test/tools/dir.test.ts
+++ b/test/tools/dir.test.ts
@@ -134,31 +134,82 @@ describe("context_tree", () => {
     await seedFile(conn, "/tree/a.txt", "a");
     await seedFile(conn, "/tree/sub/b.txt", "b");
     const result = await contextTreeTool.execute(
-      { path: "/tree", max_items: 200 },
+      { path: "/tree", max_depth: 3, items_per_dir: 15 },
       ctx,
     );
     expect(result.tree).toContain("/tree");
     expect(result.tree).toContain("a.txt");
     expect(result.tree).toContain("b.txt");
+    expect(result.total_items).toBe(2);
+    expect(result.truncated_dirs).toEqual([]);
+    expect(result.hint).toBe("Tree is complete.");
   });
 
   test("shows (empty) for empty directory", async () => {
     const result = await contextTreeTool.execute(
-      { path: "/void", max_items: 200 },
+      { path: "/void", max_depth: 3, items_per_dir: 15 },
       ctx,
     );
     expect(result.tree).toContain("(empty)");
+    expect(result.total_items).toBe(0);
+    expect(result.truncated_dirs).toEqual([]);
   });
 
-  test("respects max_items", async () => {
-    // Seed more items than max_items
-    for (let i = 0; i < 5; i++) {
+  test("respects items_per_dir and reports overflow", async () => {
+    for (let i = 0; i < 10; i++) {
       await seedFile(conn, `/many/file${i}.txt`, `content ${i}`);
     }
     const result = await contextTreeTool.execute(
-      { path: "/many", max_items: 3 },
+      { path: "/many", max_depth: 3, items_per_dir: 3 },
       ctx,
     );
-    expect(result.tree).toContain("truncated");
+    expect(result.tree).toContain("(+7 more)");
+    expect(result.truncated_dirs).toHaveLength(1);
+    expect(result.truncated_dirs[0]).toEqual({
+      path: "/many",
+      shown: 3,
+      total: 10,
+    });
+    expect(result.hint).toContain("items_per_dir");
+    expect(result.hint).toContain("/many");
+  });
+
+  test("respects max_depth and reports depth-limited dirs", async () => {
+    await seedFile(conn, "/deep/a/b/c/file.txt", "deep");
+    const result = await contextTreeTool.execute(
+      { path: "/deep", max_depth: 2, items_per_dir: 15 },
+      ctx,
+    );
+    // a/ is depth 1, b/ is depth 2 — b should be shown but its contents not expanded
+    expect(result.tree).toContain("a/");
+    expect(result.tree).toContain("b/");
+    expect(result.tree).not.toContain("file.txt");
+    expect(result.tree).toContain("drill in");
+    expect(result.hint).toContain("max_depth");
+  });
+
+  test("total_items reflects recursive count", async () => {
+    await seedFile(conn, "/count/a.txt", "a");
+    await seedFile(conn, "/count/sub/b.txt", "b");
+    await seedFile(conn, "/count/sub/c.txt", "c");
+    const result = await contextTreeTool.execute(
+      { path: "/count", max_depth: 5, items_per_dir: 50 },
+      ctx,
+    );
+    expect(result.total_items).toBe(3);
+  });
+
+  test("sorts directories before files", async () => {
+    await seedFile(conn, "/order/zfile.txt", "z");
+    await seedFile(conn, "/order/adir/x.txt", "x");
+    const result = await contextTreeTool.execute(
+      { path: "/order", max_depth: 3, items_per_dir: 15 },
+      ctx,
+    );
+    const adirIdx = result.tree.indexOf("adir/");
+    const zfileIdx = result.tree.indexOf("zfile.txt");
+    expect(adirIdx).toBeGreaterThan(-1);
+    expect(zfileIdx).toBeGreaterThan(-1);
+    expect(adirIdx).toBeLessThan(zfileIdx);
   });
 });


### PR DESCRIPTION
## Summary

- Replaces the blunt `max_items` global cap on `context_tree` with two predictable controls: `max_depth` (default 3) and `items_per_dir` (default 15).
- Adds structured navigation metadata to the output: `total_items`, `truncated_dirs[]` (`{path, shown, total}`), and a `hint` string with concrete drill-in paths.
- Renders depth-limited dirs as `name/ (N items, drill in)` and per-dir overflow as `... (+N more)`, so the agent always knows where more content exists.
- Adds `countContextItemsByPrefix()` helper in `src/db/context.ts` and updates tests for the new params, depth limiting, overflow reporting, and sort order.

## Test plan

- [x] `bun run lint` passes
- [x] `bun test` — 560/560 pass
- [x] Manual verification of tree rendering with overflow, depth limits, and hints

🤖 Generated with [Claude Code](https://claude.com/claude-code)