### PR TITLE
Bump @evantahler/mcpx to 0.18.6 and add weekly auto-bump workflow

### DIFF
--- a/.github/workflows/bump-mcpx.yml
+++ b/.github/workflows/bump-mcpx.yml
@@ -1,0 +1,86 @@
+name: Bump mcpx
+
+on:
+  schedule:
+    - cron: "0 13 * * 1" # Mondays at 13:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Determine versions
+        id: versions
+        run: |
+          CURRENT=$(jq -r '.dependencies["@evantahler/mcpx"]' package.json)
+          LATEST=$(bun info @evantahler/mcpx version 2>/dev/null | tail -n1 | tr -d '[:space:]')
+          if [ -z "$LATEST" ] || [ "$LATEST" = "null" ]; then
+            echo "Failed to resolve latest @evantahler/mcpx version" >&2
+            exit 1
+          fi
+          echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "latest=$LATEST" >> "$GITHUB_OUTPUT"
+          if [ "$CURRENT" = "$LATEST" ]; then
+            echo "up_to_date=true" >> "$GITHUB_OUTPUT"
+            echo "Already on $CURRENT."
+          else
+            echo "up_to_date=false" >> "$GITHUB_OUTPUT"
+            echo "Bumping $CURRENT -> $LATEST."
+          fi
+
+      - name: Bump dependency and project version
+        if: steps.versions.outputs.up_to_date == 'false'
+        run: |
+          jq --arg v "${{ steps.versions.outputs.latest }}" \
+            '.dependencies["@evantahler/mcpx"] = $v' package.json > package.json.tmp
+          mv package.json.tmp package.json
+
+          CUR=$(jq -r .version package.json)
+          IFS='.' read -r MAJ MIN PAT <<< "$CUR"
+          NEW="$MAJ.$MIN.$((PAT + 1))"
+          jq --arg v "$NEW" '.version = $v' package.json > package.json.tmp
+          mv package.json.tmp package.json
+
+          bun install
+
+      - name: Lint
+        if: steps.versions.outputs.up_to_date == 'false'
+        run: bun run lint
+
+      - name: Test
+        if: steps.versions.outputs.up_to_date == 'false'
+        run: bun test
+
+      - name: Create Pull Request
+        id: pr
+        if: steps.versions.outputs.up_to_date == 'false'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: bot/bump-mcpx
+          delete-branch: true
+          commit-message: "Bump @evantahler/mcpx to ${{ steps.versions.outputs.latest }}"
+          title: "Bump @evantahler/mcpx to ${{ steps.versions.outputs.latest }}"
+          body: |
+            Automated bump of `@evantahler/mcpx`: `${{ steps.versions.outputs.current }}` → `${{ steps.versions.outputs.latest }}`.
+
+            Release notes: https://github.com/evantahler/mcpx/releases/tag/v${{ steps.versions.outputs.latest }}
+
+            `bun run lint` and `bun test` passed in the bump workflow. Auto-merge is enabled; the PR will squash-merge once any required status checks pass (or immediately if none are required).
+
+            ---
+
+            _Note: PRs opened by `GITHUB_TOKEN` do not trigger other workflows. To gate auto-merge on CI, set a `BOT_TOKEN` secret (a fine-scoped PAT with `contents: write` + `pull-requests: write`) and set `token: ${{ secrets.BOT_TOKEN }}` on the `peter-evans/create-pull-request` step._
+
+      - name: Enable auto-merge
+        if: steps.versions.outputs.up_to_date == 'false' && steps.pr.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.pull-request-number }}
+        run: gh pr merge "$PR_NUMBER" --auto --squash

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.88.0",
         "@duckdb/node-api": "^1.5.2-r.1",
-        "@evantahler/mcpx": "0.18.3",
+        "@evantahler/mcpx": "0.18.6",
         "ansis": "^4.2.0",
         "commander": "^14.0.0",
         "gray-matter": "^4.0.3",
@@ -72,7 +72,7 @@
 
     "@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
 
-    "@evantahler/mcpx": ["@evantahler/mcpx@0.18.3", "", { "dependencies": { "@huggingface/transformers": "^3.8.1", "@modelcontextprotocol/sdk": "^1.27.1", "@types/picomatch": "^4.0.2", "ajv": "^8.18.0", "ansis": "^4.2.0", "commander": "^14.0.3", "nanospinner": "^1.2.2", "picomatch": "^4.0.3" }, "peerDependencies": { "typescript": "^5" }, "bin": { "mcpx": "src/cli.ts" } }, "sha512-Wi5RUShAf5oaNxDrx34BLJAHQ4/K8VV7XezxfRf6Fn5xR3Cy5LUK9wnP1Aifv/UwqYS+R0sGLDPvj7EVefql5Q=="],
+    "@evantahler/mcpx": ["@evantahler/mcpx@0.18.6", "", { "dependencies": { "@huggingface/transformers": "^3.8.1", "@modelcontextprotocol/sdk": "^1.27.1", "@types/picomatch": "^4.0.2", "ajv": "^8.18.0", "ansis": "^4.2.0", "commander": "^14.0.3", "nanospinner": "^1.2.2", "picomatch": "^4.0.3" }, "peerDependencies": { "typescript": "^5" }, "bin": { "mcpx": "src/cli.ts" } }, "sha512-EMRQ+neceTyaMRNEtee53dR4b22iAJ/amXG/GtQSiep0f+l24kwE5qGX6v13gx9EQX4/eyznieUzpIA/xx6XtQ=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "An AI agent for knowledge work",
   "type": "module",
   "bin": {
@@ -24,7 +24,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.88.0",
     "@duckdb/node-api": "^1.5.2-r.1",
-    "@evantahler/mcpx": "0.18.3",
+    "@evantahler/mcpx": "0.18.6",
     "ansis": "^4.2.0",
     "commander": "^14.0.0",
     "gray-matter": "^4.0.3",


### PR DESCRIPTION
## Summary
- Bumps `@evantahler/mcpx` from `0.18.3` → `0.18.6` to pick up the [security fix](https://github.com/evantahler/mcpx/releases/tag/v0.18.6) (shell injection, validation bypass, credential exposure). Project version bumped to `0.6.3` per repo convention.
- Adds `.github/workflows/bump-mcpx.yml`: weekly scheduled job (plus `workflow_dispatch`) that compares the pinned mcpx version against npm `latest`, bumps `package.json` + project version, runs `bun install` / `bun run lint` / `bun test`, opens/updates a PR via `peter-evans/create-pull-request@v7`, and enables squash auto-merge.

## Test plan
- [x] \`bun run lint\` passes locally
- [x] \`bun test\` passes (560/560)
- [ ] After merge: run the new workflow manually (\`workflow_dispatch\`) to confirm it no-ops when already current
- [ ] Confirm "Allow auto-merge" is enabled in repo settings so \`gh pr merge --auto\` succeeds on the first bump PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)