### PR TITLE
Show item IDs in `context list` output

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "An AI agent for knowledge work",
   "type": "module",
   "bin": {

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -63,7 +63,7 @@ export function registerContextCommand(program: Command) {
           return;
         }
 
-        const header = `${ansis.bold("Path".padEnd(35))} ${"Title".padEnd(20)} ${"Description".padEnd(30)} ${"Type".padEnd(15)} ${"Updated".padEnd(18)} Indexed`;
+        const header = `${ansis.bold("ID".padEnd(36))} ${ansis.bold("Path".padEnd(35))} ${"Title".padEnd(20)} ${"Description".padEnd(30)} ${"Type".padEnd(15)} ${"Updated".padEnd(18)} Indexed`;
         console.log(header);
         console.log("-".repeat(header.length));
 
@@ -75,8 +75,9 @@ export function registerContextCommand(program: Command) {
           const desc = item.description
             ? ansis.dim(item.description.slice(0, 29).padEnd(30))
             : ansis.dim("".padEnd(30));
+          const id = ansis.dim(item.id.padEnd(36));
           console.log(
-            `${item.context_path.slice(0, 34).padEnd(35)} ${item.title.slice(0, 19).padEnd(20)} ${desc} ${item.mime_type.slice(0, 14).padEnd(15)} ${updated} ${indexed}`,
+            `${id} ${item.context_path.slice(0, 34).padEnd(35)} ${item.title.slice(0, 19).padEnd(20)} ${desc} ${item.mime_type.slice(0, 14).padEnd(15)} ${updated} ${indexed}`,
           );
         }
 


### PR DESCRIPTION
## Summary
- Add a dimmed full-UUID `ID` column as the first column in the `context list` output, matching the convention already used by `task list` and `thread list`.
- This makes listed context items directly addressable by the commands that now accept context item IDs (#95, #97).
- Bump version to 0.6.3.

## Test plan
- [x] `bun run lint`
- [x] `bun test` (560 pass)
- [x] Manually exercised `context list` and `context list --path /` against a seeded workspace; confirmed the printed UUID is usable as input to `context read <id>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)