### PR TITLE
Move ID to last column in context list, bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "An AI agent for knowledge work",
   "type": "module",
   "bin": {

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -63,21 +63,21 @@ export function registerContextCommand(program: Command) {
           return;
         }
 
-        const header = `${ansis.bold("ID".padEnd(36))} ${ansis.bold("Path".padEnd(35))} ${"Title".padEnd(20)} ${"Description".padEnd(30)} ${"Type".padEnd(15)} ${"Updated".padEnd(18)} Indexed`;
+        const header = `${ansis.bold("Path".padEnd(35))} ${"Title".padEnd(20)} ${"Description".padEnd(30)} ${"Type".padEnd(15)} ${"Updated".padEnd(18)} ${"Indexed".padEnd(7)} ID`;
         console.log(header);
         console.log("-".repeat(header.length));
 
         for (const item of items) {
           const indexed = item.indexed_at
-            ? ansis.green("yes")
-            : ansis.dim("no");
+            ? ansis.green("yes".padEnd(7))
+            : ansis.dim("no".padEnd(7));
           const updated = ansis.dim(fmtDate(item.updated_at).padEnd(18));
           const desc = item.description
             ? ansis.dim(item.description.slice(0, 29).padEnd(30))
             : ansis.dim("".padEnd(30));
-          const id = ansis.dim(item.id.padEnd(36));
+          const id = ansis.dim(item.id);
           console.log(
-            `${id} ${item.context_path.slice(0, 34).padEnd(35)} ${item.title.slice(0, 19).padEnd(20)} ${desc} ${item.mime_type.slice(0, 14).padEnd(15)} ${updated} ${indexed}`,
+            `${item.context_path.slice(0, 34).padEnd(35)} ${item.title.slice(0, 19).padEnd(20)} ${desc} ${item.mime_type.slice(0, 14).padEnd(15)} ${updated} ${indexed} ${id}`,
           );
         }
 


### PR DESCRIPTION
The full UUIDv7 (36 chars) as the leading column pushed rows past
common terminal widths, breaking the padded-grid alignment. Moving ID
to the end keeps primary content (Path, Title, Description) at column
0 and preserves the project convention of showing full IDs in CLI
output (per commit e9dfc0f). Bump version to 0.6.4 so auto-release
picks up #102.