### PR TITLE
Rewrite README and add deep-dive docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,3 +59,30 @@ An AI agent for knowledge work. See `docs/plans/README.md` for the milestone roa
 - **Tests are required**: all new features and bug fixes must include tests. `bun test` and `bun run lint` must pass before merging.
 - Use `getConnection(":memory:")` for in-memory test databases
 - Call `migrate(conn)` in `beforeEach` to get a fresh schema each test
+
+## Documentation
+
+- **Docs must track code.** Every PR that changes user-visible behavior must update the relevant doc(s). Treat docs as part of the code — not a follow-up task.
+- The user-facing doc set lives under `docs/` and is linked from `README.md`:
+  - `docs/architecture.md` — daemon, chat, watchdog, shared DB
+  - `docs/virtual-filesystem.md` — DuckDB-as-filesystem, `file_*` / `dir_*` tools, patch format
+  - `docs/context-and-search.md` — ingestion pipeline, chunking, embeddings, hybrid search, remote loading agent, `context refresh`
+  - `docs/tasks-and-schedules.md` — task lifecycle, DAG validation, predecessor outputs, LLM schedule evaluation
+  - `docs/tools.md` — the `ToolDefinition` pattern (Zod → Anthropic + CLI)
+  - `docs/persistent-context.md` — `soul.md` / `beliefs.md` / `goals.md`, frontmatter, self-modification
+  - `docs/skills.md` — slash-command skills, `$1` / `$ARGUMENTS` substitution, tab completion
+  - `docs/mcpx.md` — `servers.json`, local servers vs. MCP gateways (Arcade), `mcp_*` meta-tools
+  - `docs/watchdog.md` — launchd/systemd, healthcheck, multi-project naming
+  - `docs/configuration.md` — every key in `config.json`
+- **When to update which doc:**
+  - Touching `src/db/sql/*.sql` or `src/db/schema.ts` → update `docs/virtual-filesystem.md` and/or `docs/context-and-search.md` with any new columns, tables, or indexes.
+  - Adding/renaming/removing a tool in `src/tools/` → update the relevant doc (`virtual-filesystem.md` for file/dir tools, `context-and-search.md` for search tools, `tools.md` if the registry pattern changed) and the CLI reference table in `README.md`.
+  - Adding a CLI subcommand in `src/commands/` → update the CLI table in `README.md` and the doc for that area.
+  - Changing config defaults in `src/config/schemas.ts` → update `docs/configuration.md`.
+  - Changing the tick loop, schedule evaluation, or agent loop (`src/daemon/*`) → update `docs/architecture.md` and/or `docs/tasks-and-schedules.md`.
+  - Adding or renaming a skill template in `src/init/templates.ts` → update `docs/skills.md` and `src/init/index.ts`.
+  - Changing watchdog install behavior (`src/daemon/watchdog.ts`, `healthcheck.ts`) → update `docs/watchdog.md`.
+  - Changing anything in persistent-context loading (`src/daemon/prompt.ts`) → update `docs/persistent-context.md`.
+- If a doc reference goes stale (links a renamed file, cites a removed behavior), fix it in the same PR — don't leave it for later.
+- When adding a new top-level feature, add a new doc under `docs/` and link it from the "Deep dives" section of `README.md`.
+- Never claim a feature exists that isn't implemented. If something is planned, say so and link to the milestone under `docs/plans/`.

--- a/README.md
+++ b/README.md
@@ -6,4 +6,222 @@
   " "
 ```
 
-An AI agent for knowledge work.
+**A local-first AI agent for knowledge work.** Botholomew is a long-running
+autonomous agent that works its way through a task queue — reading email,
+summarizing documents, researching topics, organizing notes, and maintaining
+context over time — while you sleep, work, or chat with it.
+
+Unlike coding agents, Botholomew has **no shell, no filesystem, and no network
+tools** by default. Everything it touches lives inside a single DuckDB database
+at `.botholomew/data.duckdb` and a handful of markdown files. External access
+is granted deliberately, per project, through MCP servers.
+
+---
+
+## Why Botholomew?
+
+- **Autonomous.** A background daemon ticks on a schedule, claims tasks,
+  works them with Claude, and logs every interaction. You can close the
+  terminal and come back later.
+- **Portable.** Each project is a `.botholomew/` directory — markdown +
+  DuckDB. Copy it, share it, check it in (or `.gitignore` it).
+- **Local-first.** All data stays on your machine. Embeddings are indexed in
+  DuckDB's native vector store with HNSW. Model calls go direct to Anthropic
+  and OpenAI.
+- **Extensible.** External tools come from MCP servers (Gmail, Slack,
+  GitHub, Firecrawl, …) via [MCPX](https://github.com/evantahler/mcpx).
+  Reusable workflows are defined as markdown "skills" (slash commands).
+- **Self-healing.** An OS-level watchdog (launchd on macOS, systemd on Linux)
+  restarts the daemon if it dies, rotates logs, and runs on boot.
+- **Self-modifying.** The agent maintains its own `beliefs.md` and
+  `goals.md` — it learns, updates its priors, and revises its goals as it
+  works.
+
+---
+
+## Install
+
+Requires [Bun](https://bun.sh) 1.1+.
+
+```bash
+bun install -g botholomew
+```
+
+Or run the dev build from a checkout:
+
+```bash
+git clone https://github.com/evantahler/botholomew
+cd botholomew
+bun install
+bun run dev -- --help
+```
+
+---
+
+## Quickstart
+
+```bash
+# 1. Initialize a project in the current directory
+botholomew init
+
+# 2. Add your API keys to .botholomew/config.json, or export env vars
+export ANTHROPIC_API_KEY=sk-ant-...
+export OPENAI_API_KEY=sk-...     # used for embeddings
+
+# 3. Queue some work
+botholomew task add "Summarize every markdown file in ~/notes"
+
+# 4. Start the daemon (foreground — watch it work)
+botholomew daemon start --foreground
+
+# 5. Or chat with the agent interactively
+botholomew chat
+```
+
+---
+
+## What a project looks like
+
+```
+my-project/
+  .botholomew/
+    soul.md               # always-loaded identity (not agent-editable)
+    beliefs.md            # always-loaded, agent-editable priors
+    goals.md              # always-loaded, agent-editable goals
+    config.json           # models, tick interval, API keys
+    data.duckdb           # tasks, schedules, context, embeddings, logs
+    mcpx/servers.json     # external MCP servers (Gmail, Slack, …)
+    skills/               # user-defined slash commands
+      summarize.md
+      standup.md
+    daemon.pid            # PID file for the running daemon
+    daemon.log            # rotating daemon logs
+```
+
+Everything the agent can touch is here. No surprises.
+
+---
+
+## The CLI
+
+| Command | Purpose |
+|---|---|
+| `botholomew init` | Create `.botholomew/` with templates and a fresh database |
+| `botholomew daemon start\|stop\|status` | Run, stop, or inspect the daemon |
+| `botholomew daemon install\|uninstall` | Register/remove the OS watchdog |
+| `botholomew daemon list` | List all Botholomew projects on this machine |
+| `botholomew chat` | Interactive Ink/React TUI |
+| `botholomew task list\|add\|view\|update\|reset\|delete` | Manage the task queue |
+| `botholomew schedule list\|add\|enable\|trigger\|delete` | Recurring work |
+| `botholomew context add\|list\|view\|search\|remove` | Ingest & browse knowledge |
+| `botholomew mcpx add\|list\|tools\|test` | Configure external MCP servers |
+| `botholomew skill list\|show\|create` | Manage slash-command skills |
+| `botholomew file\|dir\|search ...` | Direct access to the agent's virtual filesystem |
+| `botholomew thread list\|view` | Browse the agent's interaction history |
+| `botholomew upgrade` | Self-update |
+
+---
+
+## How it works
+
+```
+ ┌──────────────┐         ┌──────────────┐         ┌──────────────┐
+ │    Chat      │         │   Daemon     │         │  Watchdog    │
+ │   (Ink TUI)  │         │  (tick loop) │         │ launchd/     │
+ │              │         │              │         │ systemd      │
+ └──────┬───────┘         └──────┬───────┘         └──────┬───────┘
+        │                        │                        │
+        │ enqueue tasks          │ claims tasks           │ every 60s:
+        │ browse history         │ runs LLM tool loops    │ check PID
+        │ invoke skills          │ updates status         │ restart if
+        │                        │ logs to threads        │ dead
+        │                        │                        │
+        └────────────┬───────────┴────────────┬───────────┘
+                     │                        │
+               ┌─────▼────────────────────────▼─────┐
+               │        DuckDB                       │
+               │  ┌───────────┐ ┌──────────────┐    │
+               │  │  tasks    │ │ context_items│    │
+               │  │ schedules │ │  embeddings  │    │
+               │  │  threads  │ │   (HNSW)     │    │
+               │  └───────────┘ └──────────────┘    │
+               └─────┬───────────────────────────────┘
+                     │
+                     ▼
+              MCPX ─► Gmail, Slack, GitHub, Firecrawl, …
+```
+
+See [docs/architecture.md](docs/architecture.md) for a deeper tour.
+
+---
+
+## Deep dives
+
+Topics worth understanding in detail:
+
+- **[Architecture](docs/architecture.md)** — daemon, chat, watchdog, and how
+  they share a database.
+- **[The virtual filesystem](docs/virtual-filesystem.md)** — why the agent's
+  "files" are actually DuckDB rows, and how `file_read`/`file_write` work.
+- **[Context & hybrid search](docs/context-and-search.md)** — LLM-driven
+  chunking, OpenAI embeddings, and DuckDB's HNSW-accelerated keyword +
+  vector search.
+- **[Tasks & schedules](docs/tasks-and-schedules.md)** — the claim loop, DAG
+  validation, stale-task recovery, and natural-language recurring schedules.
+- **[The Tool class](docs/tools.md)** — one Zod definition, three consumers
+  (Anthropic tool-use, Commander CLI, tests).
+- **[Persistent context](docs/persistent-context.md)** — `soul.md`,
+  `beliefs.md`, `goals.md`, frontmatter flags, and agent self-modification.
+- **[Skills (slash commands)](docs/skills.md)** — reusable prompt templates
+  with positional arguments and tab completion.
+- **[MCPX integration](docs/mcpx.md)** — configuring external servers and
+  how MCP tools are merged into the agent's toolset.
+- **[The watchdog](docs/watchdog.md)** — launchd plists, systemd units, and
+  multi-project service naming.
+- **[Configuration](docs/configuration.md)** — every key in `config.json`
+  and its default.
+
+---
+
+## Tech stack
+
+- **[Bun](https://bun.sh)** + TypeScript
+- **[DuckDB](https://duckdb.org)** via `@duckdb/node-api`, with the
+  **[VSS extension](https://duckdb.org/docs/stable/extensions/vss)** for
+  native vector search
+- **[Anthropic SDK](https://docs.anthropic.com/en/api/client-sdks)** for
+  Claude — the reasoning model
+- **OpenAI embeddings API** (`text-embedding-3-small`, 1536-dim) for
+  semantic search
+- **[MCPX](https://github.com/evantahler/mcpx)** for external tools
+- **[Ink 6](https://github.com/vadimdemedes/ink)** + **React 19** for the
+  terminal UI
+- **[Commander.js](https://github.com/tj/commander.js)** for the CLI
+- **[Zod](https://zod.dev)** for tool input/output schemas
+
+---
+
+## Roadmap
+
+Botholomew is built in milestones; see [docs/plans/](docs/plans/README.md)
+for the full roadmap. Milestones 1–7 are done; M8 (remote context ingestion
+via LLM-chosen MCP tools) is next.
+
+---
+
+## Contributing
+
+```bash
+bun install
+bun test
+bun run lint            # tsc --noEmit + biome check
+```
+
+See [CLAUDE.md](CLAUDE.md) for conventions (always use `bun`, bump the
+version in `package.json` on every merge to `main`, etc.).
+
+---
+
+## License
+
+MIT.

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Everything the agent can touch is here. No surprises.
 | `botholomew chat` | Interactive Ink/React TUI |
 | `botholomew task list\|add\|view\|update\|reset\|delete` | Manage the task queue |
 | `botholomew schedule list\|add\|enable\|trigger\|delete` | Recurring work |
-| `botholomew context add\|list\|view\|search\|remove` | Ingest & browse knowledge |
+| `botholomew context add\|list\|view\|search\|refresh\|remove` | Ingest & browse knowledge (files, folders, URLs) |
 | `botholomew mcpx add\|list\|tools\|test` | Configure external MCP servers |
 | `botholomew skill list\|show\|create` | Manage slash-command skills |
 | `botholomew file\|dir\|search ...` | Direct access to the agent's virtual filesystem |

--- a/README.md
+++ b/README.md
@@ -28,9 +28,16 @@ is granted deliberately, per project, through MCP servers.
 - **Local-first.** All data stays on your machine. Embeddings are indexed in
   DuckDB's native vector store with HNSW. Model calls go direct to Anthropic
   and OpenAI.
-- **Extensible.** External tools come from MCP servers (Gmail, Slack,
-  GitHub, Firecrawl, …) via [MCPX](https://github.com/evantahler/mcpx).
+- **Extensible.** External tools come from MCP servers via
+  [MCPX](https://github.com/evantahler/mcpx) — run them locally (Gmail,
+  Slack, GitHub) or connect through an MCP gateway like
+  [Arcade.dev](https://www.arcade.dev/) to reach hundreds of
+  authenticated services without managing each server yourself.
   Reusable workflows are defined as markdown "skills" (slash commands).
+- **Safe by default.** The agent has no shell, no network, and no
+  filesystem access of its own. Everything it can touch lives in
+  `.botholomew/` — and every external capability is something you
+  explicitly add.
 - **Self-healing.** An OS-level watchdog (launchd on macOS, systemd on Linux)
   restarts the daemon if it dies, rotates logs, and runs on boot.
 - **Self-modifying.** The agent maintains its own `beliefs.md` and
@@ -198,14 +205,6 @@ Topics worth understanding in detail:
   terminal UI
 - **[Commander.js](https://github.com/tj/commander.js)** for the CLI
 - **[Zod](https://zod.dev)** for tool input/output schemas
-
----
-
-## Roadmap
-
-Botholomew is built in milestones; see [docs/plans/](docs/plans/README.md)
-for the full roadmap. Milestones 1–7 are done; M8 (remote context ingestion
-via LLM-chosen MCP tools) is next.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,6 +15,14 @@ All four share `.botholomew/data.duckdb`. Writes are serialized via
 `withRetry()` in `src/db/connection.ts`, which retries on busy with
 exponential backoff.
 
+**Safety note.** None of these processes give the agent direct access
+to your machine. The daemon is the only thing executing LLM tool
+calls, and the only tools it sees are the ones registered in
+`src/tools/` (all operating inside `.botholomew/`) plus whichever MCP
+servers you explicitly configured. There is no "just read the file
+system" escape hatch. See [the virtual filesystem
+doc](virtual-filesystem.md) for the full argument.
+
 ---
 
 ## The daemon tick loop

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,127 @@
+# Architecture
+
+Botholomew is four cooperating processes that share a single DuckDB database:
+
+1. **The daemon** — a long-running `bun` process that ticks, claims tasks,
+   and runs LLM tool loops.
+2. **The chat TUI** — an Ink/React terminal UI you run on demand; it
+   enqueues tasks and browses history.
+3. **The OS watchdog** — `launchd` on macOS, `systemd` on Linux; runs a
+   health-check every 60 seconds to keep the daemon alive.
+4. **The CLI** — everything else (`task add`, `schedule list`, `context
+   search`, …). Each invocation opens its own DuckDB connection.
+
+All four share `.botholomew/data.duckdb`. Writes are serialized via
+`withRetry()` in `src/db/connection.ts`, which retries on busy with
+exponential backoff.
+
+---
+
+## The daemon tick loop
+
+Every `tick_interval_seconds` (default 300s), the daemon performs one
+`tick()`:
+
+```
+ tick() ─┐
+         ├─► reset stale in_progress tasks (claimed > 3× max_tick_duration)
+         ├─► processSchedules() — ask the LLM which schedules are "due"
+         │                         and enqueue the tasks they describe
+         ├─► claimNextTask()   — highest-priority unblocked pending task
+         ├─► createThread()    — one thread per tick for logging
+         ├─► buildSystemPrompt() — always-context + task-relevant context
+         ├─► runAgentLoop()    — multi-turn Anthropic tool-use loop
+         │                         every message, thinking block, tool call,
+         │                         and tool result is logged as an
+         │                         `interaction` row
+         ├─► updateTaskStatus() — complete / failed / waiting
+         └─► endThread()
+```
+
+If no task is claimable and no schedule is due, `tick()` returns `false` and
+the daemon sleeps until the next interval. If work was done, it ticks again
+immediately — so a backlog drains as fast as the LLM can process it.
+
+See `src/daemon/tick.ts`.
+
+---
+
+## The chat TUI
+
+`botholomew chat` is a separate agent with its own system prompt and tool
+set — it does **not** execute long-running work itself. Instead, it:
+
+- answers questions about tasks, threads, and context,
+- creates tasks (via the `create_task` tool) that the daemon will pick up,
+- reads daemon activity (`list_threads`, `view_thread`),
+- invokes **skills** (`/review`, `/standup`, …) defined in
+  `.botholomew/skills/`,
+- edits `beliefs.md` and `goals.md` via `update_beliefs` / `update_goals`.
+
+It uses Anthropic's streaming API so tokens render in the TUI as they
+arrive. Every session is itself a `chat_session` thread with the same
+interaction log as a daemon tick.
+
+See `src/chat/` and `src/tui/`.
+
+---
+
+## Why two agents?
+
+A single-agent design would force the chat loop to wait on whatever the
+user asked — "summarize this 200-page PDF" blocks the UI for minutes. The
+split:
+
+- **Chat** is fast, streaming, and interactive. It understands the world
+  via the database but doesn't touch it much.
+- **Daemon** is slow, autonomous, and batch-oriented. It can take as long
+  as it needs per tick.
+
+Both speak to the same database, so the daemon's results are immediately
+visible to the chat agent.
+
+---
+
+## Thread logging
+
+Every interaction is persisted. A **thread** is one tick or one chat
+session; an **interaction** is a single event within it (user message,
+assistant message, tool call, tool result, thinking block, status change).
+
+This gives Botholomew total observability without a separate tracing
+stack — `botholomew thread view <id>` reads the same rows that produced
+the work. Threads are also the chat agent's way of reporting on what the
+daemon has been doing.
+
+Schema lives in `src/db/sql/2-logging_tables.sql`.
+
+---
+
+## Connection model
+
+- **Daemon**: opens one `DbConnection` at startup, holds it for the
+  process lifetime.
+- **Chat**: opens one connection per session.
+- **CLI invocations**: open a connection, do their work, close it.
+
+The DuckDB VSS extension is loaded at connect time (`INSTALL vss; LOAD
+vss;`) and HNSW persistence is enabled so vector indexes survive
+restarts. See `src/db/connection.ts`.
+
+---
+
+## Process lifecycle
+
+```
+ install           start              healthcheck          uninstall
+    │                │                     │                   │
+    ▼                ▼                     ▼                   ▼
+ launchd        PID file          every 60s:               remove
+ plist /        written to      read PID, check            plist/unit,
+ systemd       daemon.pid       isAlive(), spawn          stop service
+  unit                            daemon if not
+```
+
+The watchdog doesn't run the daemon directly (`KeepAlive: false` on
+macOS) — it runs `healthcheck.ts`, which is cheap and idempotent. See
+[the watchdog doc](watchdog.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,86 @@
+# Configuration
+
+Botholomew reads its settings from `.botholomew/config.json`. The full
+schema lives in `src/config/schemas.ts`.
+
+```json
+{
+  "anthropic_api_key": "",
+  "openai_api_key": "",
+  "model": "claude-opus-4-20250514",
+  "chunker_model": "claude-haiku-4-5-20251001",
+  "embedding_model": "text-embedding-3-small",
+  "embedding_dimension": 1536,
+  "tick_interval_seconds": 300,
+  "max_tick_duration_seconds": 120,
+  "system_prompt_override": "",
+  "max_turns": 0
+}
+```
+
+---
+
+## Keys
+
+| Key | Default | Purpose |
+|---|---|---|
+| `anthropic_api_key` | `""` | Anthropic key. `ANTHROPIC_API_KEY` env var overrides. |
+| `openai_api_key` | `""` | OpenAI key for embeddings. `OPENAI_API_KEY` env var overrides. |
+| `model` | `claude-opus-4-20250514` | Claude model for the main agent loop (daemon + chat). |
+| `chunker_model` | `claude-haiku-4-5-20251001` | Smaller/cheaper model used to propose chunk boundaries during ingestion. |
+| `embedding_model` | `text-embedding-3-small` | OpenAI embedding model. |
+| `embedding_dimension` | `1536` | Vector dimension. Must match the model; changes require re-indexing (migration 5 did this once for the switch from 384-dim local embeddings). |
+| `tick_interval_seconds` | `300` | Seconds the daemon sleeps between ticks **when there's no work**. It ticks back-to-back while a backlog exists. |
+| `max_tick_duration_seconds` | `120` | Soft cap per tick. Stale-task reset fires at `3×` this value. |
+| `system_prompt_override` | `""` | Appended to the built-in system prompt. Use this for project-specific instructions that should be always-loaded without editing `soul.md`. |
+| `max_turns` | `0` | Maximum tool-use turns per agent loop (0 = unlimited). Safety net against runaway loops. |
+
+---
+
+## Environment variables
+
+| Var | Effect |
+|---|---|
+| `ANTHROPIC_API_KEY` | Overrides `anthropic_api_key` in config. |
+| `OPENAI_API_KEY` | Overrides `openai_api_key` in config. |
+| `BOTHOLOMEW_NO_UPDATE_CHECK` | Disable the background "new version available" check. |
+
+---
+
+## Tuning guidance
+
+**For personal/low-volume use:** defaults are fine. One tick every five
+minutes is plenty when tasks are mostly "every morning, summarize my
+email".
+
+**For bursty workloads:** lower `tick_interval_seconds` to 30–60. The
+daemon only sleeps when the queue is empty, so this is safe — it just
+reduces latency between the last item landing and the next tick firing.
+
+**For model-cost sensitivity:**
+
+- Switch `model` to `claude-sonnet-4-*` or `claude-haiku-*`. Opus is the
+  default because quality on complex knowledge work matters more than
+  per-token cost for most users, but Sonnet handles the majority of
+  tasks well.
+- The `chunker_model` is already Haiku — leave it there.
+- Lower `max_turns` (e.g., 15) to hard-cap tool-use budgets.
+
+**For prompt-sensitive workflows:** use `system_prompt_override` to add
+instructions without touching `soul.md`. This keeps the default
+personality intact while layering on project-specific rules ("always
+respond in British English", "never call mcp_exec on the slack server
+without confirmation", …).
+
+---
+
+## Per-project vs. global
+
+There is no global config — everything is per-project. This is
+deliberate: different projects have different goals, different MCP
+servers, different beliefs. One Botholomew project's config shouldn't
+leak into another's.
+
+`~/.botholomew/` (the home-dir sibling of the project dir) is used for
+*registry* data — the list of projects with watchdogs installed — not
+for configuration.

--- a/docs/context-and-search.md
+++ b/docs/context-and-search.md
@@ -202,14 +202,22 @@ cases it compares the new content against what's stored, updates only
 when they differ, and re-embeds only the changed items. Missing files
 are reported, not silently dropped.
 
-To run it automatically, create a schedule — the daemon will evaluate
-it on its next tick and enqueue the refresh as a task:
+Today `refresh` lives on the CLI only — the daemon has no registered
+tool for it, so a schedule that says "run `context refresh`" will
+enqueue a task the agent can't actually work. Until
+[#105](https://github.com/evantahler/botholomew/issues/105) lands, the
+right way to run it on a schedule is an external timer:
 
 ```bash
-botholomew schedule add "Refresh remote context" \
-  --frequency "every morning" \
-  --description "Run context refresh --all and report any items that changed"
+# cron — every morning at 7
+0 7 * * * cd ~/my-project && botholomew context refresh --all
+
+# launchd / systemd — point the user-level service at the same command
 ```
+
+Once the daemon-accessible tool from #105 exists, you'll be able to
+drive it entirely from Botholomew schedules without an external
+scheduler.
 
 ---
 

--- a/docs/context-and-search.md
+++ b/docs/context-and-search.md
@@ -125,8 +125,8 @@ context is most relevant to the task at hand.
 
 ## Loading context
 
-Context gets into Botholomew two ways: local ingestion, and a remote
-loading agent that handles URLs.
+Context gets into Botholomew two ways: local ingestion, and an
+LLM-driven loading agent that handles URLs.
 
 ### Local files and folders
 
@@ -140,57 +140,76 @@ botholomew context add ~/Documents/strategy --prefix /strategy
 feeds every file through the ingestion pipeline (item → chunks →
 embeddings). Binary files (PDFs, images) are stored in `content_blob`
 with `is_textual = false`; textual files are indexed for hybrid search.
-Re-running `context add` on the same path updates in place — re-chunks,
-re-embeds, and replaces — so running it on a cron is a valid way to
-keep a folder mirrored.
+Re-running `context add` on the same path upserts — it replaces the
+stored content and re-embeds, so running it on a cron keeps a folder
+mirrored. Items are stored with `source_type = 'file'` and their
+original absolute path in `source_path`.
 
 ### Remote content via a loading agent
 
-URLs aren't just `fetch()`d — Botholomew runs a small LLM-driven agent
-whose only job is to fetch the content at a URL:
+URLs aren't `fetch()`d directly. Botholomew runs a focused LLM agent
+(`src/context/fetcher.ts`) whose only job is to retrieve the content at
+a URL using the MCP tools you have configured:
 
 ```bash
 botholomew context add https://docs.google.com/document/d/abc123/edit
 botholomew context add https://github.com/evantahler/botholomew/issues/42
 botholomew context add https://example.com/blog/post
+
+# Override the derived virtual path for a single URL
+botholomew context add https://example.com --name /articles/example.md
+
+# Hand the fetcher extra guidance (auth notes, tool hints, etc.)
+botholomew context add https://internal.corp/doc \
+  --prompt-addition "Use the corp-wiki MCP server, not Firecrawl"
 ```
 
-The loader agent:
+The fetcher runs a tool-use loop (up to 10 turns) with a small tool set:
 
-1. Inspects the URL and the list of configured MCP tools.
-2. Picks the best tool for the job — Google Docs tools for a Google
-   Docs link, a GitHub MCP server for GitHub URLs, a generic web
-   fetcher or Arcade-gateway tool for everything else.
-3. Calls that tool, cleans up the content, and hands it to the normal
-   ingestion pipeline.
-4. Falls back to a plain HTTP `fetch()` + HTML strip if no MCP tool
-   wants the URL.
+- `mcp_list_tools` / `mcp_search` — discover which MCP tools are
+  available and which might handle this URL.
+- `mcp_info` — read a tool's input schema before calling it.
+- `mcp_exec` — execute an MCP tool. The harness captures the full
+  result and sends the LLM **only a 2,000-char preview**, keyed by the
+  call's `tool_use_id`. Large pages don't explode the context window.
+- `accept_content(exec_call_id, title, mime_type?)` — terminal. The
+  agent picks which captured exec result to save by its id; the harness
+  stores the full content it already has in memory.
+- `request_http_fallback()` — terminal. Explicit signal that no MCP
+  tool fits; the harness then runs a plain `fetch()` + HTML strip.
+- `report_failure(message)` — terminal. Surfaces an actionable message
+  back to you ("this Google Doc is private — share it with your service
+  account") instead of a silent failure.
 
-The origin is stored in `context_items.source_path` (and
-`source_type = 'url'`), so provenance is tracked end-to-end.
+If no MCPX client is configured at all, or if the loop exceeds its turn
+budget, the fetcher falls back to plain HTTP with a 30s timeout and
+extracts `<title>` for textual content.
 
-### Refreshing on a schedule
+The origin URL is stored in `context_items.source_path` and
+`source_type = 'url'`, so `context list` shows a "Source" column
+distinguishing file-backed vs. URL-backed items.
 
-Remote content goes stale. Two ways to keep it fresh:
+### Refreshing stale content
 
 ```bash
-botholomew context refresh                    # refresh every url item
-botholomew context refresh /docs/strategy.md  # refresh one item
-botholomew context refresh --stale 7d         # only items older than 7 days
+botholomew context refresh /docs/strategy.md   # refresh one item
+botholomew context refresh --all               # refresh every sourced item
 ```
 
-Refresh re-fetches via the same loading agent, compares against stored
-content, and re-ingests only when there's a change. To run it
-automatically, create a schedule:
+`refresh` works for both `file` and `url` source types: for files it
+re-reads from disk, for URLs it re-runs the loading agent. In both
+cases it compares the new content against what's stored, updates only
+when they differ, and re-embeds only the changed items. Missing files
+are reported, not silently dropped.
+
+To run it automatically, create a schedule — the daemon will evaluate
+it on its next tick and enqueue the refresh as a task:
 
 ```bash
 botholomew schedule add "Refresh remote context" \
   --frequency "every morning" \
-  --description "Run context refresh --stale 1d and report any items that changed"
+  --description "Run context refresh --all and report any items that changed"
 ```
-
-The daemon will evaluate the schedule on its next tick and enqueue the
-refresh task.
 
 ---
 

--- a/docs/context-and-search.md
+++ b/docs/context-and-search.md
@@ -1,0 +1,139 @@
+# Context & hybrid search
+
+Botholomew's knowledge layer is a hybrid keyword + vector search system
+backed entirely by DuckDB. It's how the agent finds "that thing I
+mentioned last week" across thousands of ingested documents without
+calling out to a vector DB service.
+
+---
+
+## The pipeline
+
+When you add a document (`botholomew context add ./report.pdf` or the
+agent writes via `file_write`), this happens:
+
+```
+ content ─► create context_item row
+         ─► LLM-driven chunker (claude-haiku-4-5 by default)
+         ─► embedder (OpenAI text-embedding-3-small, 1536-dim)
+         ─► embeddings table (FLOAT[1536] + HNSW index)
+         ─► indexed_at set on the context_item
+```
+
+See `src/context/ingest.ts`, `src/context/chunker.ts`, and
+`src/context/embedder.ts`.
+
+---
+
+## LLM-driven chunking
+
+Fixed-size sliding-window chunking shreds structure: a heading lands in
+one chunk, its bullets in another, and semantic search returns incoherent
+fragments. Botholomew instead asks a **small, fast** model (Haiku by
+default) to propose chunk boundaries for each document:
+
+```json
+[
+  { "start": 0,   "end": 412, "title": "Q4 Overview",     "description": "..." },
+  { "start": 413, "end": 980, "title": "Revenue by region", "description": "..." },
+  ...
+]
+```
+
+The chunker has a sliding-window fallback (500 tokens, 50 overlap) if the
+LLM call fails, so ingestion never blocks on model availability.
+
+Each chunk is embedded separately; the `title` and `description` are
+stored alongside the embedding and surface in search results as the
+snippet.
+
+---
+
+## Storage
+
+Embeddings live in the `embeddings` table (see
+`src/db/sql/1-core_tables.sql`):
+
+```sql
+CREATE TABLE embeddings (
+  id TEXT PRIMARY KEY,
+  context_item_id TEXT NOT NULL,
+  chunk_index     INTEGER NOT NULL,
+  chunk_content   TEXT,
+  title           TEXT NOT NULL,
+  description     TEXT NOT NULL DEFAULT '',
+  source_path     TEXT,
+  embedding       FLOAT[1536],
+  created_at      TEXT NOT NULL DEFAULT (current_timestamp::VARCHAR),
+  UNIQUE(context_item_id, chunk_index)
+);
+```
+
+The VSS extension provides an HNSW index with cosine distance
+(`src/db/sql/6-vss_index.sql`):
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_embeddings_cosine
+  ON embeddings USING HNSW (embedding) WITH (metric = 'cosine');
+```
+
+`SET hnsw_enable_experimental_persistence = true;` is run at connection
+time so the index survives process restarts instead of being rebuilt
+every time.
+
+---
+
+## Hybrid search
+
+`hybridSearch()` in `src/db/embeddings.ts` combines two signals:
+
+1. **Keyword** — `LIKE` match on `chunk_content`, `title`, `description`.
+2. **Vector** — `array_cosine_distance(embedding, $query_embedding)` via
+   the HNSW index, which turns what would be a full scan into a
+   logarithmic probe.
+
+Results are merged, de-duplicated by `(context_item_id, chunk_index)`,
+and re-ranked. Keyword hits get a score boost when the user's query
+contains a rare token — so "AGM-84" finds the exact match, not the
+semantically-nearest chunk about missiles.
+
+Exposed to the agent as `search_semantic` and `search_grep`, and to you
+as `botholomew context search "..."`.
+
+---
+
+## Contextual loading
+
+When the daemon picks up a task, `buildSystemPrompt()`
+(`src/daemon/prompt.ts`) doesn't just dump every context file into the
+prompt — that would blow the context window. Instead:
+
+1. All markdown files with frontmatter `loading: always` are included
+   verbatim (e.g., `soul.md`, `beliefs.md`, `goals.md`).
+2. The task name + description is embedded.
+3. `hybridSearch()` finds top-N relevant chunks from the database.
+4. Those chunks are appended to the system prompt as task-specific
+   context.
+5. Markdown files with `loading: contextual` are included only if their
+   content shares keywords with the task.
+
+The result is a prompt that's always grounded in the agent's identity
+(`soul.md`), learned priors (`beliefs.md`), and whatever historical
+context is most relevant to the task at hand.
+
+---
+
+## Why OpenAI for embeddings?
+
+Earlier milestones used a local `@xenova/transformers` model
+(`bge-small-en-v1.5`, 384-dim). It worked but had drawbacks: ~500 MB of
+model weights, slow CPU inference on first load, and noticeably worse
+quality on mixed-language content. Migration 5
+(`5-reset_embeddings_for_openai.sql`) switched to OpenAI
+`text-embedding-3-small` at 1536 dimensions — faster, better, and only
+"non-local" for the index-time call. Queries at runtime still only need
+an embedding of the query string itself.
+
+If you want a fully-local setup, swap `src/context/embedder.ts` for a
+local model and adjust `EMBEDDING_DIMENSION` in `src/constants.ts` —
+everything downstream (VSS, HNSW, hybrid search) is dimension-agnostic.

--- a/docs/context-and-search.md
+++ b/docs/context-and-search.md
@@ -123,6 +123,77 @@ context is most relevant to the task at hand.
 
 ---
 
+## Loading context
+
+Context gets into Botholomew two ways: local ingestion, and a remote
+loading agent that handles URLs.
+
+### Local files and folders
+
+```bash
+botholomew context add ./notes
+botholomew context add ./report.pdf
+botholomew context add ~/Documents/strategy --prefix /strategy
+```
+
+`context add` walks directories recursively, detects mime types, and
+feeds every file through the ingestion pipeline (item → chunks →
+embeddings). Binary files (PDFs, images) are stored in `content_blob`
+with `is_textual = false`; textual files are indexed for hybrid search.
+Re-running `context add` on the same path updates in place — re-chunks,
+re-embeds, and replaces — so running it on a cron is a valid way to
+keep a folder mirrored.
+
+### Remote content via a loading agent
+
+URLs aren't just `fetch()`d — Botholomew runs a small LLM-driven agent
+whose only job is to fetch the content at a URL:
+
+```bash
+botholomew context add https://docs.google.com/document/d/abc123/edit
+botholomew context add https://github.com/evantahler/botholomew/issues/42
+botholomew context add https://example.com/blog/post
+```
+
+The loader agent:
+
+1. Inspects the URL and the list of configured MCP tools.
+2. Picks the best tool for the job — Google Docs tools for a Google
+   Docs link, a GitHub MCP server for GitHub URLs, a generic web
+   fetcher or Arcade-gateway tool for everything else.
+3. Calls that tool, cleans up the content, and hands it to the normal
+   ingestion pipeline.
+4. Falls back to a plain HTTP `fetch()` + HTML strip if no MCP tool
+   wants the URL.
+
+The origin is stored in `context_items.source_path` (and
+`source_type = 'url'`), so provenance is tracked end-to-end.
+
+### Refreshing on a schedule
+
+Remote content goes stale. Two ways to keep it fresh:
+
+```bash
+botholomew context refresh                    # refresh every url item
+botholomew context refresh /docs/strategy.md  # refresh one item
+botholomew context refresh --stale 7d         # only items older than 7 days
+```
+
+Refresh re-fetches via the same loading agent, compares against stored
+content, and re-ingests only when there's a change. To run it
+automatically, create a schedule:
+
+```bash
+botholomew schedule add "Refresh remote context" \
+  --frequency "every morning" \
+  --description "Run context refresh --stale 1d and report any items that changed"
+```
+
+The daemon will evaluate the schedule on its next tick and enqueue the
+refresh task.
+
+---
+
 ## Why OpenAI for embeddings?
 
 Earlier milestones used a local `@xenova/transformers` model

--- a/docs/mcpx.md
+++ b/docs/mcpx.md
@@ -1,0 +1,127 @@
+# MCPX integration
+
+Botholomew has no network, no shell, and no filesystem access on its
+own. Everything external — reading email, searching the web, talking to
+GitHub — comes from MCP servers, managed per project via
+[**MCPX**](https://github.com/evantahler/mcpx).
+
+Think of MCPX as the `package.json` of the agent's tools: a
+project-local manifest (`.botholomew/mcpx/servers.json`) lists the MCP
+servers this project can use, and the daemon connects to them at
+startup.
+
+---
+
+## Configuration
+
+`.botholomew/mcpx/servers.json` uses the standard MCP client config
+format:
+
+```json
+{
+  "mcpServers": {
+    "gmail": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-gmail"],
+      "env": {}
+    },
+    "firecrawl": {
+      "type": "http",
+      "url": "https://mcp.firecrawl.dev/search"
+    }
+  }
+}
+```
+
+`type: "stdio"` launches a subprocess and speaks MCP over pipes;
+`type: "http"` connects to a remote MCP server. MCPX handles both.
+
+---
+
+## Managing servers from the CLI
+
+```bash
+botholomew mcpx list                 # configured servers + connection status
+botholomew mcpx add gmail            # add interactively
+botholomew mcpx remove gmail
+botholomew mcpx tools                # list every tool from every server
+botholomew mcpx tools gmail          # filter to one server
+botholomew mcpx test gmail.search '{"query":"test"}'   # dry-run a tool call
+```
+
+`mcpx test` is the fastest way to confirm a server is wired up before
+handing it to the agent.
+
+---
+
+## Lifecycle
+
+`createMcpxClient(projectDir)` in `src/mcpx/client.ts`:
+
+1. Reads `servers.json`.
+2. Connects to every server.
+3. Returns an `McpxClient | null` (`null` if no servers are configured).
+
+The daemon holds the client for its entire lifetime and calls
+`client.close()` on SIGTERM/SIGINT. CLI commands like
+`botholomew mcpx test` open a client, do their work, and close it.
+
+---
+
+## How the agent sees MCP tools
+
+Rather than flood the model's tool list with every MCP tool from every
+server — which can easily be hundreds — Botholomew exposes a small set
+of **meta-tools** the agent uses to discover and invoke MCP tools
+dynamically:
+
+| Tool | Purpose |
+|---|---|
+| `mcp_list_tools` | List MCP servers and the tools they provide |
+| `mcp_search` | Semantic search across all MCP tool names + descriptions |
+| `mcp_info` | Get the JSON Schema for a specific tool's input |
+| `mcp_exec` | Execute a tool with validated input |
+
+So the agent's flow to "check my email" looks like:
+
+```
+ mcp_search("read email") ────► returns gmail.list_messages, gmail.get_message, ...
+ mcp_info("gmail.list_messages") ──► returns input schema
+ mcp_exec("gmail.list_messages", { maxResults: 10 }) ──► actual email
+```
+
+This keeps the primary tool list small and lets you plug in dozens of
+MCP servers without blowing the context window.
+
+See `src/tools/mcp/*.ts`.
+
+---
+
+## Logging
+
+Every MCP call is logged to the current thread as a `tool_use` /
+`tool_result` interaction pair — identical to how built-in tools are
+logged. Duration and token counts are captured. Query the `interactions`
+table (or run `botholomew thread view`) to see exactly what the agent
+sent and got back.
+
+---
+
+## When to add a server
+
+You want an MCP server when:
+
+- The agent needs to reach a specific service (Gmail, Slack, GitHub,
+  Linear, Notion).
+- You want to give the agent *write* access somewhere — sending
+  messages, creating issues, editing docs.
+- You're ingesting remote content into context — Firecrawl for web
+  pages, Google Docs MCP for docs, etc.
+
+You don't need a server when:
+
+- The work happens entirely in `.botholomew/` (the virtual filesystem,
+  embeddings, tasks, schedules).
+- You just want Claude to *read* something you already put in context —
+  `file_read` / `search_semantic` are enough.

--- a/docs/mcpx.md
+++ b/docs/mcpx.md
@@ -10,6 +10,18 @@ project-local manifest (`.botholomew/mcpx/servers.json`) lists the MCP
 servers this project can use, and the daemon connects to them at
 startup.
 
+You have two options for *how* those servers run:
+
+- **Run individual servers yourself.** Point MCPX at a stdio command
+  (`npx ...`) or a remote HTTP endpoint. Good for a handful of
+  well-known integrations.
+- **Use an MCP gateway.** A gateway like
+  [Arcade.dev](https://www.arcade.dev/) exposes hundreds of
+  authenticated tools (Gmail, Google Drive, Slack, GitHub, Notion,
+  Linear, …) behind one endpoint, handles OAuth for you, and is
+  maintained centrally. Configure it once and Botholomew sees the full
+  tool surface.
+
 ---
 
 ## Configuration
@@ -26,16 +38,20 @@ format:
       "args": ["-y", "@modelcontextprotocol/server-gmail"],
       "env": {}
     },
-    "firecrawl": {
+    "arcade": {
       "type": "http",
-      "url": "https://mcp.firecrawl.dev/search"
+      "url": "https://api.arcade.dev/v1/mcp",
+      "env": {
+        "ARCADE_API_KEY": "${ARCADE_API_KEY}"
+      }
     }
   }
 }
 ```
 
 `type: "stdio"` launches a subprocess and speaks MCP over pipes;
-`type: "http"` connects to a remote MCP server. MCPX handles both.
+`type: "http"` connects to a remote MCP server (like an Arcade gateway).
+MCPX handles both.
 
 ---
 

--- a/docs/mcpx.md
+++ b/docs/mcpx.md
@@ -39,19 +39,22 @@ format:
       "env": {}
     },
     "arcade": {
-      "type": "http",
-      "url": "https://api.arcade.dev/v1/mcp",
-      "env": {
-        "ARCADE_API_KEY": "${ARCADE_API_KEY}"
+      "url": "https://api.arcade.dev/mcp/engineering",
+      "headers": {
+        "Authorization": "Bearer arc_xxxxxxx",
+        "Arcade-User-ID": "you@example.com"
       }
     }
   }
 }
 ```
 
-`type: "stdio"` launches a subprocess and speaks MCP over pipes;
-`type: "http"` connects to a remote MCP server (like an Arcade gateway).
-MCPX handles both.
+Stdio entries launch a subprocess and speak MCP over pipes. Entries
+with a `url` connect to a remote MCP server — this is the shape Arcade
+(and most hosted MCP gateways) expect: a gateway endpoint plus
+`headers` for auth. See [Arcade's docs](https://docs.arcade.dev/mcp-servers)
+for the list of gateway URLs and how `Arcade-User-ID` scopes tool
+access per user. MCPX accepts both shapes.
 
 ---
 

--- a/docs/persistent-context.md
+++ b/docs/persistent-context.md
@@ -130,4 +130,9 @@ agent-modification: false
 
 Tasks mentioning "deploy", "release", or "version" will now include this
 file in the system prompt automatically. You didn't have to register it
-anywhere — the daemon scans `.botholomew/` on every tick.
+anywhere — on every tick the daemon reads every `.md` file in
+`.botholomew/`, extracts words longer than three characters from the
+task's name and description, and includes any `loading: contextual`
+file whose content contains at least one of those words. See
+`loadPersistentContext()` in `src/daemon/prompt.ts` for the exact
+logic.

--- a/docs/persistent-context.md
+++ b/docs/persistent-context.md
@@ -1,0 +1,133 @@
+# Persistent context & agent self-modification
+
+The `.botholomew/` directory contains a handful of markdown files that
+shape how the agent thinks. Some the agent can rewrite; some it can't.
+Every one is versioned by frontmatter.
+
+---
+
+## The three default files
+
+`botholomew init` creates:
+
+| File | Loading | Agent-editable? | Purpose |
+|---|---|---|---|
+| `soul.md` | `always` | **no** | Identity — who the agent is, how it behaves |
+| `beliefs.md` | `always` | yes | Priors the agent has learned about the world/project |
+| `goals.md` | `always` | yes | Current goals; updated as goals complete or change |
+
+Each uses YAML frontmatter to declare its behavior:
+
+```yaml
+---
+loading: always          # or "contextual"
+agent-modification: true # or false
+---
+
+# Beliefs
+
+- I should be concise and clear in my work products.
+- I should ask for help when I'm stuck rather than guessing.
+```
+
+---
+
+## Loading modes
+
+**`loading: always`** — the file is concatenated into every system
+prompt, verbatim. Use sparingly. `soul.md`, `beliefs.md`, and `goals.md`
+are always-loaded.
+
+**`loading: contextual`** — the file is included only if its content
+shares keywords with the current task's name/description. Use this for
+topic-specific notes ("Everything I know about our invoicing system")
+that shouldn't pollute the prompt on unrelated tasks.
+
+See `loadPersistentContext()` in `src/daemon/prompt.ts`.
+
+---
+
+## Agent self-modification
+
+When `agent-modification: true`, the agent can rewrite the file using
+the `update_beliefs` or `update_goals` tools (`src/tools/context/`).
+The flow:
+
+1. Agent calls `update_beliefs` with the new full file content.
+2. The tool reads the existing file, parses frontmatter with
+   `gray-matter`, preserves the frontmatter block, and writes back the
+   new body.
+3. A `context_update` interaction is logged to the current thread, so
+   you can see — and audit — every time the agent changed its own
+   priors.
+
+Files without `agent-modification: true` are read-only to the agent,
+even if the tool is called — the tool checks the frontmatter and
+refuses.
+
+---
+
+## What this actually looks like
+
+A typical `beliefs.md` after a few weeks of use:
+
+```yaml
+---
+loading: always
+agent-modification: true
+---
+
+# Beliefs
+
+- Evan prefers bullet-point summaries over paragraphs.
+- The "Q4 planning" doc in /notes is the canonical source for revenue targets.
+- The daemon should escalate to a "waiting" status if a task needs access
+  to a tool that isn't configured, instead of failing outright.
+- When summarizing email, strip quoted replies — they add tokens without
+  value.
+```
+
+None of those were in the seed template — they accumulated as the agent
+worked tasks and the chat user confirmed them. That's the whole point:
+the agent gets smarter about *your* workflow over time, and you can
+read (and edit) exactly what it believes.
+
+---
+
+## Why not put this all in a vector store?
+
+Beliefs and goals are high-priority, always-loaded text — they're what
+the agent uses to decide *what to do*, not raw reference material. Burying
+them in a vector index means the agent might not retrieve them when it
+matters. Keeping them as flat markdown with a hard `always` flag makes
+them impossible to miss.
+
+Long-form reference material (ingested PDFs, web pages, meeting notes)
+lives in the [context & embeddings system](context-and-search.md)
+instead. The two are complementary:
+
+- **Persistent context** = how the agent thinks.
+- **Context items / embeddings** = what the agent knows.
+
+---
+
+## Adding your own
+
+Drop any `.md` file into `.botholomew/` with frontmatter:
+
+```yaml
+---
+loading: contextual
+agent-modification: false
+---
+
+# Our deployment checklist
+
+1. Bump version in package.json
+2. Run bun test && bun run lint
+3. ...
+```
+
+Tasks mentioning "deploy", "release", or "version" will now include this
+file in the system prompt automatically. You didn't have to register it
+anywhere — the daemon scans `.botholomew/` on every tick.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,0 +1,135 @@
+# Skills (slash commands)
+
+Skills are user-defined slash commands for the chat TUI. A skill is a
+markdown file with frontmatter and a prompt template; when you type
+`/<name>` in chat, the template is rendered and sent as a user message.
+
+Think of them as reusable prompts — "summarize this conversation",
+"review this file", "give me a standup update" — parameterized and
+version-controlled alongside the project.
+
+---
+
+## File format
+
+Skills live in `.botholomew/skills/<name>.md`:
+
+```yaml
+---
+name: review
+description: "Review a file for quality and issues"
+arguments:
+  - name: file
+    description: "Path to the file to review"
+    required: true
+  - name: focus
+    description: "What to focus on (security, performance, etc.)"
+    required: false
+    default: "general quality"
+---
+
+Please review the file at `$1`. Read it with the available tools, then provide:
+1. A brief summary of what the file does
+2. Any issues or concerns (bugs, security, performance)
+3. Suggestions for improvement
+4. An overall assessment (focus: $2)
+```
+
+**Frontmatter fields:**
+
+| Field | Required? | Purpose |
+|---|---|---|
+| `name` | no | Defaults to filename. Determines the slash command name |
+| `description` | yes | Shown in `/skills` listing and `/help` |
+| `arguments` | no | Array of argument definitions (name, description, required, default) |
+
+**Body:** Markdown prompt template with variable substitution.
+
+---
+
+## Variable substitution
+
+| Placeholder | Meaning |
+|---|---|
+| `$ARGUMENTS` | The entire argument string as typed |
+| `$1`, `$2`, … | Positional arguments (split on whitespace, quoted strings respected) |
+
+Missing optional arguments fall back to their `default`. Missing required
+arguments cause a validation error before the skill is sent.
+
+Example:
+
+```
+> /review src/cli.ts security
+```
+
+becomes `$1 = "src/cli.ts"`, `$2 = "security"`, `$ARGUMENTS = "src/cli.ts
+security"`.
+
+---
+
+## Built-in defaults
+
+`botholomew init` ships two skills out of the box:
+
+**`summarize.md`** — summarize the current chat conversation.
+
+**`standup.md`** — generate a standup update from recent tasks (completed
+in the last 24h + in progress).
+
+More are easy to add; see the quickstart below.
+
+---
+
+## Invoking skills
+
+From inside `botholomew chat`:
+
+```
+> /skills              # list all available skills
+> /summarize           # run the summarize skill
+> /review src/cli.ts   # positional argument becomes $1
+> /rev<TAB>            # tab-completes to /review
+```
+
+A system message ("Running skill: review") is printed to the TUI when a
+skill is invoked, so it's visually distinct from a regular message.
+
+---
+
+## CLI management
+
+```bash
+botholomew skill list                 # table of all skills
+botholomew skill show review          # print the full skill file
+botholomew skill create daily-log     # scaffold a new skill
+```
+
+Skills are parsed by `src/skills/parser.ts` and loaded from disk by
+`src/skills/loader.ts` at chat-session start. They're cached on the
+`ChatSession` object, so changes require restarting the chat — but not
+the daemon.
+
+---
+
+## Writing a good skill
+
+- **Be explicit about what you want.** The model doesn't know the shape
+  of the output unless you describe it.
+- **Use positional args, not free-form.** `/review src/cli.ts` is easier
+  to tab-complete than `/review --file=src/cli.ts`.
+- **Reference tools by name.** "Read the file with `file_read`" nudges
+  the agent toward the right tool and keeps token counts down.
+- **Keep them short.** A skill is a prompt, not a program. If your skill
+  is 200 lines of conditional logic, it probably wants to be a real
+  tool.
+
+---
+
+## Why not just type the prompt?
+
+Because you'll type it a hundred times. Skills are pure convenience —
+but they're also version-controllable, shareable (copy a `skills/`
+directory between projects), and discoverable (`/skills` shows them all).
+They turn "the prompt I always use for standup updates" into a durable
+project asset.

--- a/docs/tasks-and-schedules.md
+++ b/docs/tasks-and-schedules.md
@@ -1,0 +1,167 @@
+# Tasks & schedules
+
+The task queue is Botholomew's execution substrate. Humans and agents
+both write to it; the daemon is the only reader.
+
+---
+
+## Tasks
+
+A task is a unit of work with a lifecycle:
+
+```
+ pending ──► in_progress ──► complete
+     │            │          │ failed
+     │            │          │ waiting
+     │            └── (reset by timeout)
+     ▼
+ blocked (via blocked_by)
+```
+
+**Columns** (`src/db/sql/1-core_tables.sql`):
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | TEXT | UUIDv7 |
+| `name` | TEXT | Short title |
+| `description` | TEXT | Full description for the LLM |
+| `priority` | ENUM | `low` / `medium` / `high` |
+| `status` | ENUM | `pending` / `in_progress` / `failed` / `complete` / `waiting` |
+| `waiting_reason` | TEXT | Set when the agent calls `wait_task` |
+| `claimed_by` | TEXT | PID of the daemon that claimed it |
+| `claimed_at` | TEXT | ISO timestamp |
+| `blocked_by` | JSON[] | Array of task IDs that must complete first |
+| `context_ids` | JSON[] | Context items referenced by this task |
+| `output` | TEXT | The `summary` from `complete_task` (added in migration 8) |
+
+---
+
+## The claim loop
+
+`claimNextTask()` in `src/db/tasks.ts`:
+
+1. Select `pending` tasks where every `blocked_by` ID is in status
+   `complete`.
+2. Order by priority, then `created_at`.
+3. Atomically update the first match to `in_progress`, stamp
+   `claimed_by` and `claimed_at`.
+
+Each daemon holds its claimed task for the duration of the tick. If a
+tick crashes, `resetStaleTasks()` (called at the top of every tick)
+reclaims rows whose `claimed_at` is older than
+`max_tick_duration_seconds * 3` and sets them back to `pending`.
+
+---
+
+## DAG validation
+
+`blocked_by` defines a dependency DAG. Cycles would deadlock the claim
+loop, so `validateBlockedBy()` rejects them at insert time:
+
+- DFS from each blocker, looking for a path back to the task being
+  created.
+- If any path exists, `createTask()` throws.
+
+This is cheap because the graph is almost always shallow — the common
+pattern is "produce N subtasks from a schedule" which is a flat
+one-level fan-out.
+
+---
+
+## Predecessor outputs
+
+When the agent works a task that was blocked by others, it doesn't start
+from zero. `runAgentLoop()` (`src/daemon/llm.ts`) fetches each blocker's
+`output` (the summary passed to `complete_task`) and injects it into the
+user message:
+
+```
+Task:
+Name: Produce weekly summary
+Description: ...
+Priority: medium
+
+Predecessor Task Outputs:
+### Read email (01JE...)
+- 3 urgent threads from customers about Q4 rollover...
+
+### Check calendar (01JE...)
+- 5 meetings this week, 2 with external stakeholders...
+```
+
+This is how multi-step workflows chain without a dedicated orchestrator.
+
+---
+
+## Schedules
+
+A schedule is a recurring task template described in natural language:
+
+```bash
+botholomew schedule add "Morning review" \
+  --frequency "every weekday at 7am" \
+  --description "Read my email, check my calendar, draft a morning summary"
+```
+
+**Columns:**
+
+| Field | Notes |
+|---|---|
+| `frequency` | Plain text — "every morning", "weekly on Mondays", "every 2 hours" |
+| `last_run_at` | ISO timestamp of last evaluation that created tasks |
+| `enabled` | Boolean |
+
+---
+
+## LLM-evaluated "is it due?"
+
+Instead of parsing cron expressions, `processSchedules()`
+(`src/daemon/schedules.ts`) asks the model:
+
+> Given the frequency `"every weekday at 7am"`, `last_run_at`
+> = 2025-04-16T07:03:12Z, and now = 2025-04-17T07:41:05Z — is this
+> schedule due? If yes, what task(s) should be created?
+
+The LLM returns structured output: `{ isDue: boolean, tasksToCreate:
+Array<{ name, description, priority }> }`. If the schedule describes a
+multi-step workflow ("read email and summarize"), the model can return
+multiple tasks with `blocked_by` linking them — so a schedule naturally
+expands into a chained DAG.
+
+Trade-offs:
+
+- **Flexibility.** "Every weekday at 7am, except US holidays, unless I'm
+  on vacation (check calendar)" is specifiable in English and evaluable
+  by the model.
+- **Cost.** One (cheap) model call per enabled schedule per tick. For
+  dozens of schedules this is negligible; for thousands, you'd want a
+  parser.
+- **Drift.** The model's idea of "morning" might not match yours.
+  Tighten the frequency text if you see misfires.
+
+---
+
+## Running the queue by hand
+
+```bash
+# Add work
+botholomew task add "Draft Q4 retro" --priority high
+
+# Inspect
+botholomew task list --status pending
+botholomew task view <id>
+
+# Force the daemon to pick up
+botholomew daemon start --foreground
+
+# Unstick a task
+botholomew task reset <id>
+botholomew task delete <id>
+
+# Manually fire a schedule
+botholomew schedule trigger <id>
+```
+
+All of the same operations are available to the chat agent (`create_task`,
+`list_tasks`, `view_task`, `update_task`, `create_schedule`,
+`list_schedules`) so you can drive the queue conversationally too.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,0 +1,155 @@
+# The Tool class
+
+Every tool the agent can call — and every matching CLI subcommand you
+can run yourself — is defined once as a `ToolDefinition`. A single
+definition drives three consumers:
+
+1. **The Anthropic SDK** (via `input_schema: JSONSchema`) so the model
+   can call it.
+2. **Commander.js** via an auto-generated subcommand.
+3. **Tests**, which import the tool directly and call `execute()`.
+
+This lives in `src/tools/tool.ts`.
+
+---
+
+## Shape of a tool
+
+```ts
+import { z } from "zod";
+import type { ToolDefinition } from "../tool.ts";
+
+const inputSchema = z.object({
+  summary: z.string().describe("Summary of work done"),
+});
+
+const outputSchema = z.object({
+  message: z.string(),
+  is_error: z.boolean(),
+});
+
+export const completeTaskTool = {
+  name: "complete_task",
+  description:
+    "Mark the current task as complete with a summary of what was accomplished.",
+  group: "task",
+  terminal: true,
+  inputSchema,
+  outputSchema,
+  execute: async (input, ctx) => ({
+    message: `Task completed: ${input.summary}`,
+    is_error: false,
+  }),
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;
+```
+
+**Fields:**
+
+| Field | Purpose |
+|---|---|
+| `name` | Snake-case identifier; also the CLI subcommand name |
+| `description` | Used for both the LLM tool definition and CLI help text |
+| `group` | Groups tools into CLI namespaces (`task`, `file`, `dir`, …) |
+| `terminal` | If `true`, the daemon ends the agent loop when this tool is called (e.g., `complete_task`, `fail_task`, `wait_task`) |
+| `inputSchema` | Zod schema with `.describe()` per field — becomes JSON Schema for the model and Commander flags for the CLI |
+| `outputSchema` | Zod schema guaranteeing the shape of the response |
+| `execute` | The actual implementation, receiving validated input and a `ToolContext` |
+
+---
+
+## ToolContext
+
+Every tool receives a `ToolContext`:
+
+```ts
+interface ToolContext {
+  conn: DbConnection;            // DuckDB connection
+  projectDir: string;             // absolute path to the project
+  config: Required<BotholomewConfig>;  // resolved config (API keys, model, …)
+  mcpxClient: McpxClient | null;  // external MCP tools (may be null)
+}
+```
+
+This is the only capability surface. A tool that isn't handed an
+`mcpxClient` can't reach the network; a tool that doesn't use `conn`
+can't touch the database. The context is constructed once per
+tick/session and passed to every `execute()` call.
+
+---
+
+## Anthropic adapter
+
+`toAnthropicTools()` walks the registry and converts each Zod input
+schema to the Anthropic SDK's `Tool` type using `z.toJSONSchema()`:
+
+```ts
+{
+  name: "file_write",
+  description: "Create or overwrite a file in the virtual filesystem.",
+  input_schema: {
+    type: "object",
+    properties: { /* derived from Zod */ },
+    required: ["path", "content"],
+  }
+}
+```
+
+`runAgentLoop()` feeds this array into `client.messages.create({ tools:
+... })`. When the model emits a `tool_use` block, the loop looks up the
+tool by name via `getTool(name)`, validates the input against
+`inputSchema`, calls `execute()`, and returns the result as a
+`tool_result` block.
+
+Terminal tools (the ones with `terminal: true`) tell the loop to stop.
+For the daemon, those are `complete_task`, `fail_task`, and `wait_task` —
+any of which transitions the task out of `in_progress`.
+
+---
+
+## CLI adapter
+
+`registerToolsAsCLI(program)` iterates the registry and generates a
+Commander subcommand per tool, grouped by `group`:
+
+```bash
+botholomew file read /notes/meeting.md --offset 10 --limit 20
+botholomew dir tree / --max-items 100
+botholomew search semantic "quarterly revenue"
+```
+
+Positional args and `--options` are derived from the Zod schema shape.
+The same validation that runs for the LLM runs here, so you get the same
+error messages.
+
+---
+
+## Registry
+
+Tools register themselves on import, so adding a tool is a one-file
+change:
+
+1. Create `src/tools/<group>/<name>.ts` exporting a
+   `ToolDefinition`.
+2. Add `registerTool(myTool);` to `src/tools/registry.ts`.
+3. Write a test in `test/tools/<group>/<name>.test.ts`.
+
+No central dispatch table to edit, no LLM tool list to update, no CLI
+command to wire. The Zod schema is the source of truth.
+
+---
+
+## Why Zod for the schema?
+
+Zod gives us three things at once:
+
+- **Runtime validation.** Untrusted inputs (from the model, from the
+  CLI) are validated before `execute()` runs. A malformed tool call
+  becomes a clear `tool_result` error the model can recover from, not a
+  crash.
+- **TypeScript inference.** `z.infer<typeof inputSchema>` gives
+  `execute()` a statically-typed `input` parameter.
+- **JSON Schema export.** `z.toJSONSchema()` produces the schema the
+  Anthropic API needs without a separate definition.
+
+The entire adapter layer is ~80 lines (`src/tools/tool.ts`) because Zod
+does the heavy lifting.

--- a/docs/virtual-filesystem.md
+++ b/docs/virtual-filesystem.md
@@ -5,9 +5,16 @@ Botholomew's agent has no access to your real filesystem. When it calls
 it's a row in the `context_items` table with `context_path =
 '/notes/meeting.md'`.
 
-This is deliberate:
+This is deliberate, and it's the single most important safety property
+of the system:
 
-- **Safety.** The agent can't touch anything outside the project.
+- **Safety.** The agent cannot read your home directory, cannot
+  overwrite your SSH keys, cannot `rm -rf` anything, cannot exfiltrate
+  files it wasn't handed. A prompt-injected instruction telling it to
+  "read `~/.ssh/id_rsa`" has nothing to act on — that path doesn't
+  exist in its world. The worst a rogue agent can do is corrupt rows
+  inside `.botholomew/data.duckdb`, which you can recover from a
+  backup of a single file.
 - **Portability.** The entire "filesystem" is a single DuckDB file you
   can copy, share, or back up.
 - **Searchability.** Every "file" is already indexed, chunked, embedded,
@@ -120,3 +127,10 @@ A DuckDB row is already all of those things at once — transactional,
 searchable, and backed by a single file you can `cp` or `sqlite3` (well,
 `duckdb`) into. The trade-off: you can't `cat` a note from the shell.
 That's what `botholomew file read` is for.
+
+And the biggest reason: **safety**. A filesystem abstraction that
+happens to be a database is a filesystem the agent cannot escape.
+There is no `..`, no symlink, no `/etc/passwd` — just a `context_path`
+column with a `UNIQUE` constraint. If you're comfortable letting a
+model make decisions on your behalf but not comfortable letting it
+touch your disk, that's exactly the trade Botholomew makes.

--- a/docs/virtual-filesystem.md
+++ b/docs/virtual-filesystem.md
@@ -1,0 +1,122 @@
+# The virtual filesystem
+
+Botholomew's agent has no access to your real filesystem. When it calls
+`file_read /notes/meeting.md`, there is no `/notes/meeting.md` on disk —
+it's a row in the `context_items` table with `context_path =
+'/notes/meeting.md'`.
+
+This is deliberate:
+
+- **Safety.** The agent can't touch anything outside the project.
+- **Portability.** The entire "filesystem" is a single DuckDB file you
+  can copy, share, or back up.
+- **Searchability.** Every "file" is already indexed, chunked, embedded,
+  and queryable.
+- **History.** Everything the agent writes is recorded in
+  `threads`/`interactions`, so you can audit every change.
+
+---
+
+## The mapping
+
+| Filesystem concept | DuckDB representation |
+|---|---|
+| File path        | `context_items.context_path` (TEXT, unique) |
+| File contents    | `context_items.content` (TEXT) or `content_blob` (BLOB) |
+| MIME type        | `context_items.mime_type` |
+| Directory        | A row with `mime_type = 'inode/directory'` |
+| Directory listing | `SELECT DISTINCT parent(context_path) ...` |
+| Binary file      | `is_textual = false`, content in `content_blob` |
+| Source URL/path  | `source_path` (where the content originally came from) |
+| Ingestion time   | `indexed_at`, `created_at`, `updated_at` |
+
+---
+
+## The agent's tools
+
+These are the tools the agent sees. All are implemented as `ToolDefinition`
+instances in `src/tools/dir/` and `src/tools/file/`.
+
+**Directory operations:**
+
+| Tool | What it does |
+|---|---|
+| `dir_create` | Create a directory placeholder row |
+| `dir_list`   | List entries under a path (files + subdirs, with sizes) |
+| `dir_tree`   | Render a markdown tree of everything under a prefix |
+| `dir_size`   | Sum `length(content)` for items under a prefix |
+
+**File operations:**
+
+| Tool | What it does |
+|---|---|
+| `file_read`        | `getContextItemByPath(path)` → slice lines (`offset`/`limit`) |
+| `file_write`       | Upsert a row, trigger re-chunk + re-embed |
+| `file_edit`        | Apply git-style line-range patches |
+| `file_delete`      | Remove by path (or recursively by prefix) |
+| `file_copy`        | Duplicate a row with a new `context_path` |
+| `file_move`        | Rename a row |
+| `file_info`        | Return metadata (size, lines, mime, indexed_at) |
+| `file_exists`      | Path existence check |
+| `file_count_lines` | Count `\n` in content |
+
+These are also exposed from the host CLI via Commander:
+
+```bash
+botholomew file write /notes/meeting.md "# Q4 Planning"
+botholomew file read /notes/meeting.md
+botholomew dir tree /
+```
+
+---
+
+## Patch format for `file_edit`
+
+```ts
+{ start_line: number, end_line: number, content: string }
+```
+
+- `start_line` / `end_line` are 1-based inclusive.
+- `end_line: 0` means **insert** without replacing.
+- `content: ""` means **delete** the line range.
+- Patches are applied bottom-up (descending `start_line`) so earlier
+  line numbers remain stable.
+
+Example — replace lines 5–7 and append at line 20:
+
+```json
+[
+  { "start_line": 20, "end_line": 0,  "content": "\n## Appendix\n..." },
+  { "start_line": 5,  "end_line": 7,  "content": "Updated text" }
+]
+```
+
+---
+
+## Embedding cascade
+
+Every mutation cascades into the embeddings table:
+
+- `file_write` → delete old chunks, re-chunk via LLM, re-embed, insert.
+- `file_edit` → same.
+- `file_move` → update `source_path` on embedding rows.
+- `file_delete` → cascade delete embedding rows.
+
+The HNSW index on `embeddings.embedding` stays in sync automatically (it
+is maintained by DuckDB VSS on INSERT/DELETE, and persisted with
+`SET hnsw_enable_experimental_persistence = true`).
+
+---
+
+## Why not just use files on disk?
+
+A real filesystem would require:
+
+- path escaping, sandboxing, symlink resolution;
+- a separate indexer that must stay consistent with the files;
+- backup/versioning/synchronization logic.
+
+A DuckDB row is already all of those things at once — transactional,
+searchable, and backed by a single file you can `cp` or `sqlite3` (well,
+`duckdb`) into. The trade-off: you can't `cat` a note from the shell.
+That's what `botholomew file read` is for.

--- a/docs/watchdog.md
+++ b/docs/watchdog.md
@@ -1,0 +1,100 @@
+# The watchdog
+
+Botholomew's daemon is a long-running `bun` process. Long-running Bun
+processes die — they get OOM-killed, the network hiccups during a model
+call, you accidentally close the terminal. Without supervision, the
+queue silently stops draining.
+
+The watchdog is a thin OS-level supervisor that keeps the daemon alive:
+
+- **macOS**: a `launchd` LaunchAgent (`~/Library/LaunchAgents/`).
+- **Linux**: a `systemd --user` service + timer
+  (`~/.config/systemd/user/`).
+
+Both fire every 60 seconds. They don't run the daemon directly — they
+run `healthcheck.ts`, which is idempotent and cheap.
+
+---
+
+## Installation
+
+```bash
+botholomew daemon install
+```
+
+This detects the platform, writes a `.plist` (macOS) or `.service` +
+`.timer` (Linux), loads/enables it, and registers the project in
+`~/.botholomew/projects.json` so `botholomew daemon list` can find it
+later.
+
+```bash
+botholomew daemon list         # all projects with watchdogs installed
+botholomew daemon uninstall    # remove the watchdog
+```
+
+---
+
+## The health check
+
+`src/daemon/healthcheck.ts` runs every 60 seconds:
+
+1. Read `.botholomew/daemon.pid`.
+2. If the PID is alive, exit 0 — nothing to do.
+3. If the PID is missing or stale, spawn a fresh detached daemon
+   (equivalent to `botholomew daemon start`).
+4. If `daemon.log` is larger than `LOG_MAX_BYTES` (10 MB), rotate it.
+
+A separate watchdog log (`.botholomew/watchdog.log`) records every
+invocation so you can see exactly when restarts happened.
+
+---
+
+## Why not `KeepAlive: true`?
+
+`launchd` supports `KeepAlive: true`, which would respawn the daemon
+instantly on exit. We don't use it because:
+
+- A crash loop from a bad config would burn API credits in seconds.
+- Rotating logs and running a health check requires real logic, not a
+  plist flag.
+- The same pattern needs to work on systemd, which doesn't have an
+  exact `KeepAlive` equivalent.
+
+Running `healthcheck.ts` on a 60-second timer gives us uniform, scriptable
+supervision across both platforms with a built-in cooldown.
+
+---
+
+## Multi-project machines
+
+Service names embed a sanitized version of the absolute project path, so
+multiple Botholomew projects on one machine don't collide:
+
+```
+/Users/evan/work       → com.botholomew.users-evan-work          (launchd)
+/Users/evan/personal   → com.botholomew.users-evan-personal       (launchd)
+/home/evan/side-quest  → botholomew-home-evan-side-quest.service (systemd)
+```
+
+See `sanitizePathForServiceName()` in `src/constants.ts`.
+
+`botholomew daemon list` scans `~/.botholomew/projects.json` and reports
+which projects have watchdogs installed and which are currently running.
+
+---
+
+## What about Windows?
+
+Not supported. The watchdog assumes POSIX PID semantics and either
+`launchd` or `systemd`. If you want to run Botholomew on Windows, use
+WSL.
+
+---
+
+## Binary compilation?
+
+It would be nice to ship a single statically-linked binary via `bun
+build --compile`. This was explored and dropped — DuckDB's native
+extensions (including VSS) can't currently be bundled by `bun build`.
+For now, Botholomew is distributed as a TypeScript package that runs on
+`bun`.


### PR DESCRIPTION
Replaces the placeholder README with an overview of what Botholomew is,
install + quickstart instructions, an ASCII architecture diagram, a CLI
reference table, and links into a set of new deep-dive docs.

New docs under docs/:
- architecture.md — daemon, chat, watchdog, DB sharing
- virtual-filesystem.md — DuckDB as the agent's filesystem
- context-and-search.md — LLM chunking + HNSW hybrid search
- tasks-and-schedules.md — claim loop, DAG validation, LLM schedules
- tools.md — the Tool class pattern (Zod → Anthropic + CLI)
- persistent-context.md — soul/beliefs/goals + self-modification
- skills.md — slash-command skills
- mcpx.md — external tools via MCP
- watchdog.md — launchd/systemd supervision
- configuration.md — every config.json key