### PR TITLE
Add slash-command autocomplete popup to chat TUI

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -89,8 +89,23 @@ From inside `botholomew chat`:
 > /skills              # list all available skills
 > /summarize           # run the summarize skill
 > /review src/cli.ts   # positional argument becomes $1
-> /rev<TAB>            # tab-completes to /review
 ```
+
+### Autocomplete popup
+
+Typing `/` at the start of the input pops up a menu of matching
+commands (built-ins `/help`, `/skills`, `/exit` plus every
+skill loaded from `.botholomew/skills/`). Each row shows the command
+name and its description.
+
+| Key | Action |
+|---|---|
+| `↑` / `↓` | Move the highlight |
+| `Tab` or `Return` | Accept the highlighted command (fills in `/<name> ` so you can type arguments) |
+| `Esc` | Close the popup without changing the input |
+
+The popup filters as you keep typing, and it disappears once you type
+a space — so a second `Return` submits the message as usual.
 
 A system message ("Running skill: review") is printed to the TUI when a
 skill is invoked, so it's visually distinct from a regular message.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "An AI agent for knowledge work",
   "type": "module",
   "bin": {

--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -12,7 +12,7 @@ export function registerChatCommand(program: Command) {
         "  Commands:\n" +
         "    /help           Show keyboard shortcuts\n" +
         "    /tools          Open tool call inspector\n" +
-        "    /quit, /exit    End the chat session",
+        "    /exit           End the chat session",
     )
     .option("--thread-id <id>", "Resume an existing chat thread")
     .option("-p, --prompt <text>", "Start chat with an initial prompt")

--- a/src/skills/commands.ts
+++ b/src/skills/commands.ts
@@ -1,6 +1,17 @@
 import type { SkillDefinition } from "./parser.ts";
 import { renderSkill } from "./parser.ts";
 
+export interface SlashCommand {
+  name: string;
+  description: string;
+}
+
+export const BUILTIN_SLASH_COMMANDS: SlashCommand[] = [
+  { name: "help", description: "Show command reference and shortcuts" },
+  { name: "skills", description: "List available skills" },
+  { name: "exit", description: "End the chat session" },
+];
+
 export interface SlashCommandContext {
   skills: Map<string, SkillDefinition>;
   addSystemMessage: (content: string) => void;
@@ -22,7 +33,7 @@ export function handleSlashCommand(
   const name = commandPart.slice(1).toLowerCase(); // remove leading /
 
   // Built-in commands
-  if (name === "quit" || name === "exit") {
+  if (name === "exit") {
     ctx.exit();
     return true;
   }

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -9,7 +9,11 @@ import {
 import { MAX_INLINE_CHARS, PAGE_SIZE_CHARS } from "../daemon/large-results.ts";
 import type { Interaction } from "../db/threads.ts";
 import { getThread } from "../db/threads.ts";
-import { handleSlashCommand } from "../skills/commands.ts";
+import {
+  BUILTIN_SLASH_COMMANDS,
+  handleSlashCommand,
+  type SlashCommand,
+} from "../skills/commands.ts";
 import { ContextPanel } from "./components/ContextPanel.tsx";
 import { HelpPanel } from "./components/HelpPanel.tsx";
 import { InputBar } from "./components/InputBar.tsx";
@@ -27,6 +31,7 @@ import { TaskPanel } from "./components/TaskPanel.tsx";
 import { ThreadPanel } from "./components/ThreadPanel.tsx";
 import type { ToolCallData } from "./components/ToolCall.tsx";
 import { ToolPanel } from "./components/ToolPanel.tsx";
+import { buildSlashCommands, getSlashMatches } from "./slashCompletion.ts";
 import { ansi } from "./theme.ts";
 
 interface AppProps {
@@ -210,10 +215,8 @@ export function App({
   queuedMessagesRef.current = queuedMessages;
   selectedQueueIndexRef.current = selectedQueueIndex;
 
-  const tabConsumedRef = useRef(false);
-  const handleTabConsumed = useCallback(() => {
-    tabConsumedRef.current = true;
-  }, []);
+  const slashCommandsRef = useRef<SlashCommand[]>([]);
+  const inputValueRef = useRef("");
 
   const stableAppHandler = useCallback(
     // biome-ignore lint/suspicious/noExplicitAny: Ink's Key type is not exported
@@ -224,11 +227,15 @@ export function App({
         return;
       }
 
-      // Tab key cycles tabs — unless InputBar consumed it for completion
+      // Tab key cycles tabs — but on the Chat tab, let InputBar consume it
+      // whenever the slash autocomplete popup would be open.
       if (key.tab && !key.shift) {
-        if (tabConsumedRef.current) {
-          tabConsumedRef.current = false;
-          return;
+        if (activeTabRef.current === 1) {
+          const popupOpen = getSlashMatches(
+            inputValueRef.current,
+            slashCommandsRef.current,
+          );
+          if (popupOpen) return;
         }
         setActiveTab((t) => ((t % 7) + 1) as TabId);
         return;
@@ -454,6 +461,10 @@ export function App({
             "  Enter          Send message",
             "  ⌥+Enter        Insert newline",
             "  ↑/↓            Browse input history",
+            "  /              Open slash-command autocomplete",
+            "  Tab/Enter      Accept highlighted command (popup open)",
+            "  ↑/↓            Move highlight (popup open)",
+            "  Esc            Close popup",
             "",
             "Tools (Tab 2):",
             "  ↑/↓            Select tool call",
@@ -495,7 +506,7 @@ export function App({
             "Commands:",
             "  /help           Show this help",
             "  /skills         List available skills",
-            "  /quit, /exit    End the chat session",
+            "  /exit           End the chat session",
             ...skillLines,
           ].join("\n"),
           timestamp: new Date(),
@@ -551,13 +562,18 @@ export function App({
   );
 
   const sessionSkills = ready ? sessionRef.current?.skills : undefined;
-  const skillCompletions = useMemo(() => {
-    const builtins = ["/help", "/quit", "/exit", "/skills"];
-    const skillNames = Array.from(sessionSkills?.keys() ?? []).map(
-      (name) => `/${name}`,
-    );
-    return [...builtins, ...skillNames];
+  const slashCommands = useMemo<SlashCommand[]>(() => {
+    const skillList = sessionSkills
+      ? Array.from(sessionSkills.values()).map((s) => ({
+          name: s.name,
+          description: s.description,
+        }))
+      : [];
+    return buildSlashCommands(BUILTIN_SLASH_COMMANDS, skillList);
   }, [sessionSkills]);
+
+  slashCommandsRef.current = slashCommands;
+  inputValueRef.current = inputValue;
 
   const allToolCalls = useMemo(
     () => messages.flatMap((m) => m.toolCalls ?? []),
@@ -681,8 +697,7 @@ export function App({
         disabled={activeTab !== 1}
         history={inputHistory}
         header={inputBarHeader}
-        completions={skillCompletions}
-        onTabConsumed={handleTabConsumed}
+        slashCommands={slashCommands}
       />
       <TabBar activeTab={activeTab} />
     </Box>

--- a/src/tui/components/HelpPanel.tsx
+++ b/src/tui/components/HelpPanel.tsx
@@ -136,7 +136,7 @@ export const HelpPanel = memo(function HelpPanel({
           {"  "}/help{"          "}Show help in chat
         </Text>
         <Text>
-          {"  "}/quit, /exit{"   "}End the chat session
+          {"  "}/exit{"          "}End the chat session
         </Text>
       </Box>
 

--- a/src/tui/components/InputBar.tsx
+++ b/src/tui/components/InputBar.tsx
@@ -4,9 +4,13 @@ import {
   type ReactNode,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
+import type { SlashCommand } from "../../skills/commands.ts";
+import { getSlashMatches } from "../slashCompletion.ts";
+import { SlashCommandPopup } from "./SlashCommandPopup.tsx";
 
 interface InputBarProps {
   value: string;
@@ -15,8 +19,7 @@ interface InputBarProps {
   disabled: boolean;
   history: string[];
   header?: ReactNode;
-  completions?: string[];
-  onTabConsumed?: () => void;
+  slashCommands?: SlashCommand[];
 }
 
 export const InputBar = memo(function InputBar({
@@ -26,12 +29,13 @@ export const InputBar = memo(function InputBar({
   disabled,
   history,
   header,
-  completions,
-  onTabConsumed,
+  slashCommands,
 }: InputBarProps) {
   const [historyIndex, setHistoryIndex] = useState(-1);
   const [cursorPos, setCursorPos] = useState(0);
   const [cursorVisible, setCursorVisible] = useState(true);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [popupDismissed, setPopupDismissed] = useState(false);
   const savedInput = useRef("");
   const lastActivity = useRef(Date.now());
 
@@ -43,9 +47,9 @@ export const InputBar = memo(function InputBar({
   const onChangeRef = useRef(onChange);
   const onSubmitRef = useRef(onSubmit);
   const historyRef = useRef(history);
-  const completionsRef = useRef(completions);
-  const onTabConsumedRef = useRef(onTabConsumed);
-  const tabCycleRef = useRef(-1);
+  const slashCommandsRef = useRef(slashCommands);
+  const selectedIndexRef = useRef(selectedIndex);
+  const popupDismissedRef = useRef(popupDismissed);
 
   valueRef.current = value;
   cursorPosRef.current = cursorPos;
@@ -53,8 +57,39 @@ export const InputBar = memo(function InputBar({
   onChangeRef.current = onChange;
   onSubmitRef.current = onSubmit;
   historyRef.current = history;
-  completionsRef.current = completions;
-  onTabConsumedRef.current = onTabConsumed;
+  slashCommandsRef.current = slashCommands;
+  selectedIndexRef.current = selectedIndex;
+  popupDismissedRef.current = popupDismissed;
+
+  // Matches visible in the autocomplete popup, or null when it should be
+  // hidden (non-slash input, space typed, no matches, or user escaped).
+  const popupMatches = useMemo(() => {
+    if (popupDismissed) return null;
+    return getSlashMatches(value, slashCommands ?? []);
+  }, [value, slashCommands, popupDismissed]);
+
+  // Reset highlight to top whenever the match list changes.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally reset on match-list change, not value change
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [popupMatches?.length]);
+
+  // Clamp highlight if the list shrank (defensive — the effect above usually handles it).
+  useEffect(() => {
+    if (popupMatches && selectedIndex >= popupMatches.length) {
+      setSelectedIndex(Math.max(0, popupMatches.length - 1));
+    }
+  }, [popupMatches, selectedIndex]);
+
+  // Clear the dismissed flag as soon as the user edits the value,
+  // so a fresh "/" reopens the popup.
+  const prevValueRef = useRef(value);
+  useEffect(() => {
+    if (prevValueRef.current !== value && popupDismissed) {
+      setPopupDismissed(false);
+    }
+    prevValueRef.current = value;
+  }, [value, popupDismissed]);
 
   // Blink cursor when input is active — skip ticks while typing so the
   // cursor stays solid and we avoid unnecessary renders during rapid input.
@@ -87,8 +122,43 @@ export const InputBar = memo(function InputBar({
       const hIdx = historyIndexRef.current;
       const hist = historyRef.current;
 
-      // Enter: submit (shift+enter or opt+enter inserts newline)
+      // Is the slash popup visible right now? Recompute from the authoritative
+      // ref-state so we don't depend on stale closure values.
+      const popupOpen = !popupDismissedRef.current
+        ? getSlashMatches(val, slashCommandsRef.current ?? [])
+        : null;
+
+      const acceptSelection = () => {
+        if (!popupOpen) return false;
+        const chosen =
+          popupOpen[Math.min(selectedIndexRef.current, popupOpen.length - 1)];
+        if (!chosen) return false;
+        const completed = `/${chosen.name} `;
+        valueRef.current = completed;
+        cursorPosRef.current = completed.length;
+        onChangeRef.current(completed);
+        setCursorPos(completed.length);
+        // A trailing space makes the popup disappear naturally via regex,
+        // but set dismissed too so stray state can't re-open it.
+        setPopupDismissed(true);
+        return true;
+      };
+
+      // Escape: close popup if open, keep value untouched
+      if (key.escape) {
+        if (popupOpen) {
+          setPopupDismissed(true);
+        }
+        return;
+      }
+
+      // Enter: if popup is open, accept selection (do not submit).
+      // Otherwise submit as before.
       if (key.return) {
+        if (popupOpen && !key.shift && !key.meta) {
+          acceptSelection();
+          return;
+        }
         if (key.shift || key.meta) {
           const before = val.slice(0, pos);
           const after = val.slice(pos);
@@ -105,6 +175,14 @@ export const InputBar = memo(function InputBar({
           cursorPosRef.current = 0;
           setCursorPos(0);
           onSubmitRef.current(val);
+        }
+        return;
+      }
+
+      // Tab: accept popup selection if open. No-op otherwise.
+      if (key.tab) {
+        if (popupOpen) {
+          acceptSelection();
         }
         return;
       }
@@ -138,81 +216,71 @@ export const InputBar = memo(function InputBar({
         return;
       }
 
-      // History navigation
-      if (key.upArrow && hist.length > 0) {
-        const nextIndex = hIdx + 1;
-        if (nextIndex < hist.length) {
-          if (hIdx === -1) {
-            savedInput.current = val;
-          }
-          historyIndexRef.current = nextIndex;
-          setHistoryIndex(nextIndex);
-          const entry = hist[hist.length - 1 - nextIndex];
-          if (entry !== undefined) {
-            valueRef.current = entry;
-            cursorPosRef.current = entry.length;
-            onChangeRef.current(entry);
-            setCursorPos(entry.length);
+      // Up/Down: popup navigation when open, history otherwise
+      if (key.upArrow) {
+        if (popupOpen) {
+          const next = Math.max(0, selectedIndexRef.current - 1);
+          selectedIndexRef.current = next;
+          setSelectedIndex(next);
+          return;
+        }
+        if (hist.length > 0) {
+          const nextIndex = hIdx + 1;
+          if (nextIndex < hist.length) {
+            if (hIdx === -1) {
+              savedInput.current = val;
+            }
+            historyIndexRef.current = nextIndex;
+            setHistoryIndex(nextIndex);
+            const entry = hist[hist.length - 1 - nextIndex];
+            if (entry !== undefined) {
+              valueRef.current = entry;
+              cursorPosRef.current = entry.length;
+              onChangeRef.current(entry);
+              setCursorPos(entry.length);
+            }
           }
         }
         return;
       }
 
-      if (key.downArrow && hist.length > 0) {
-        if (hIdx > 0) {
-          const nextIndex = hIdx - 1;
-          historyIndexRef.current = nextIndex;
-          setHistoryIndex(nextIndex);
-          const entry = hist[hist.length - 1 - nextIndex];
-          if (entry !== undefined) {
-            valueRef.current = entry;
-            cursorPosRef.current = entry.length;
-            onChangeRef.current(entry);
-            setCursorPos(entry.length);
+      if (key.downArrow) {
+        if (popupOpen) {
+          const next = Math.min(
+            popupOpen.length - 1,
+            selectedIndexRef.current + 1,
+          );
+          selectedIndexRef.current = next;
+          setSelectedIndex(next);
+          return;
+        }
+        if (hist.length > 0) {
+          if (hIdx > 0) {
+            const nextIndex = hIdx - 1;
+            historyIndexRef.current = nextIndex;
+            setHistoryIndex(nextIndex);
+            const entry = hist[hist.length - 1 - nextIndex];
+            if (entry !== undefined) {
+              valueRef.current = entry;
+              cursorPosRef.current = entry.length;
+              onChangeRef.current(entry);
+              setCursorPos(entry.length);
+            }
+          } else if (hIdx === 0) {
+            historyIndexRef.current = -1;
+            setHistoryIndex(-1);
+            const saved = savedInput.current;
+            valueRef.current = saved;
+            cursorPosRef.current = saved.length;
+            onChangeRef.current(saved);
+            setCursorPos(saved.length);
           }
-        } else if (hIdx === 0) {
-          historyIndexRef.current = -1;
-          setHistoryIndex(-1);
-          const saved = savedInput.current;
-          valueRef.current = saved;
-          cursorPosRef.current = saved.length;
-          onChangeRef.current(saved);
-          setCursorPos(saved.length);
         }
         return;
       }
-
-      // Tab-completion for slash commands
-      if (key.tab) {
-        const comps = completionsRef.current;
-        if (val.startsWith("/") && comps && comps.length > 0) {
-          const matches = comps.filter((c) => c.startsWith(val));
-          if (matches.length === 1) {
-            const completed = `${matches[0] ?? ""} `;
-            valueRef.current = completed;
-            cursorPosRef.current = completed.length;
-            onChangeRef.current(completed);
-            setCursorPos(completed.length);
-            tabCycleRef.current = -1;
-          } else if (matches.length > 1) {
-            const idx = (tabCycleRef.current + 1) % matches.length;
-            tabCycleRef.current = idx;
-            const completed = matches[idx] ?? "";
-            valueRef.current = completed;
-            cursorPosRef.current = completed.length;
-            onChangeRef.current(completed);
-            setCursorPos(completed.length);
-          }
-          onTabConsumedRef.current?.();
-        }
-        return;
-      }
-
-      // Reset tab cycle on any non-tab key
-      tabCycleRef.current = -1;
 
       // Ignore other control keys
-      if (key.ctrl || key.escape) {
+      if (key.ctrl) {
         return;
       }
 
@@ -239,36 +307,45 @@ export const InputBar = memo(function InputBar({
 
   const isMultiline = value.includes("\n");
   const placeholder = !value && !disabled;
+  const showPopup = !disabled && popupMatches !== null;
 
   return (
-    <Box
-      flexDirection="column"
-      borderStyle="single"
-      borderColor={disabled ? "gray" : "green"}
-      paddingX={1}
-    >
-      {header}
-      {!disabled && (
-        <Box flexDirection="column">
-          <Box>
-            <Text color="green">{"› "}</Text>
-            {placeholder ? (
-              <Text dimColor>Type a message...</Text>
-            ) : (
-              <Text>
-                {value.slice(0, cursorPos)}
-                <Text inverse={cursorVisible}>{value[cursorPos] ?? " "}</Text>
-                {value.slice(cursorPos + 1)}
-              </Text>
+    <Box flexDirection="column">
+      {showPopup && popupMatches && (
+        <SlashCommandPopup
+          matches={popupMatches}
+          selectedIndex={selectedIndex}
+        />
+      )}
+      <Box
+        flexDirection="column"
+        borderStyle="single"
+        borderColor={disabled ? "gray" : "green"}
+        paddingX={1}
+      >
+        {header}
+        {!disabled && (
+          <Box flexDirection="column">
+            <Box>
+              <Text color="green">{"› "}</Text>
+              {placeholder ? (
+                <Text dimColor>Type a message...</Text>
+              ) : (
+                <Text>
+                  {value.slice(0, cursorPos)}
+                  <Text inverse={cursorVisible}>{value[cursorPos] ?? " "}</Text>
+                  {value.slice(cursorPos + 1)}
+                </Text>
+              )}
+            </Box>
+            {isMultiline && (
+              <Box>
+                <Text dimColor> alt+return for newline, return to send</Text>
+              </Box>
             )}
           </Box>
-          {isMultiline && (
-            <Box>
-              <Text dimColor> alt+return for newline, return to send</Text>
-            </Box>
-          )}
-        </Box>
-      )}
+        )}
+      </Box>
     </Box>
   );
 });

--- a/src/tui/components/SlashCommandPopup.tsx
+++ b/src/tui/components/SlashCommandPopup.tsx
@@ -1,0 +1,50 @@
+import { Box, Text } from "ink";
+import { memo } from "react";
+import type { SlashCommand } from "../../skills/commands.ts";
+
+interface SlashCommandPopupProps {
+  matches: SlashCommand[];
+  selectedIndex: number;
+}
+
+export const SlashCommandPopup = memo(function SlashCommandPopup({
+  matches,
+  selectedIndex,
+}: SlashCommandPopupProps) {
+  if (matches.length === 0) return null;
+
+  const nameWidth = matches.reduce(
+    (max, c) => Math.max(max, c.name.length + 1),
+    0,
+  );
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor="gray"
+      paddingX={1}
+    >
+      {matches.map((cmd, i) => {
+        const active = i === selectedIndex;
+        const marker = active ? "›" : " ";
+        const padded = `/${cmd.name}`.padEnd(nameWidth + 1);
+        return (
+          <Box key={cmd.name}>
+            <Text color={active ? "green" : undefined} bold={active}>
+              {marker} {padded}
+            </Text>
+            <Text dimColor={!active}>
+              {cmd.description || "(no description)"}
+            </Text>
+          </Box>
+        );
+      })}
+      <Box marginTop={0}>
+        <Text dimColor>
+          ↑↓ to navigate · tab/return to accept · esc to close
+        </Text>
+      </Box>
+    </Box>
+  );
+});

--- a/src/tui/slashCompletion.ts
+++ b/src/tui/slashCompletion.ts
@@ -1,0 +1,38 @@
+import type { SlashCommand } from "../skills/commands.ts";
+
+export const MAX_VISIBLE_COMPLETIONS = 8;
+
+const SLASH_QUERY = /^\/([\w-]*)$/;
+
+/**
+ * Given the current input value, return the list of slash commands that
+ * should appear in the autocomplete popup. Returns `null` when the popup
+ * should not be shown at all (e.g. the input isn't a slash query, or the
+ * user has already typed a space to start writing arguments).
+ */
+export function getSlashMatches(
+  value: string,
+  commands: SlashCommand[],
+): SlashCommand[] | null {
+  const match = SLASH_QUERY.exec(value);
+  if (!match) return null;
+
+  const query = (match[1] ?? "").toLowerCase();
+  const filtered = commands.filter((c) =>
+    c.name.toLowerCase().startsWith(query),
+  );
+  if (filtered.length === 0) return null;
+
+  return filtered.slice(0, MAX_VISIBLE_COMPLETIONS);
+}
+
+export function buildSlashCommands(
+  builtins: SlashCommand[],
+  skills: Iterable<{ name: string; description: string }>,
+): SlashCommand[] {
+  const out: SlashCommand[] = [...builtins];
+  for (const s of skills) {
+    out.push({ name: s.name, description: s.description });
+  }
+  return out;
+}

--- a/test/skills/commands.test.ts
+++ b/test/skills/commands.test.ts
@@ -57,13 +57,6 @@ const summarizeSkill: SkillDefinition = {
 };
 
 describe("handleSlashCommand", () => {
-  test("/quit calls exit", () => {
-    const ctx = makeCtx();
-    const result = handleSlashCommand("/quit", ctx);
-    expect(result).toBe(true);
-    expect(ctx.exited).toBe(true);
-  });
-
   test("/exit calls exit", () => {
     const ctx = makeCtx();
     const result = handleSlashCommand("/exit", ctx);

--- a/test/tui/slash-completion.test.ts
+++ b/test/tui/slash-completion.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import type { SlashCommand } from "../../src/skills/commands.ts";
+import {
+  buildSlashCommands,
+  getSlashMatches,
+  MAX_VISIBLE_COMPLETIONS,
+} from "../../src/tui/slashCompletion.ts";
+
+const commands: SlashCommand[] = [
+  { name: "help", description: "Show help" },
+  { name: "skills", description: "List skills" },
+  { name: "quit", description: "Exit" },
+  { name: "exit", description: "Exit" },
+  { name: "review", description: "Review a file" },
+  { name: "summarize", description: "Summarize the chat" },
+];
+
+describe("getSlashMatches", () => {
+  test("returns null when value doesn't start with /", () => {
+    expect(getSlashMatches("hello", commands)).toBeNull();
+    expect(getSlashMatches("", commands)).toBeNull();
+  });
+
+  test("returns all commands for a bare slash", () => {
+    const result = getSlashMatches("/", commands);
+    expect(result).not.toBeNull();
+    expect(result?.map((c) => c.name)).toEqual([
+      "help",
+      "skills",
+      "quit",
+      "exit",
+      "review",
+      "summarize",
+    ]);
+  });
+
+  test("filters by prefix", () => {
+    const result = getSlashMatches("/s", commands);
+    expect(result?.map((c) => c.name)).toEqual(["skills", "summarize"]);
+  });
+
+  test("is case-insensitive", () => {
+    const result = getSlashMatches("/SK", commands);
+    expect(result?.map((c) => c.name)).toEqual(["skills"]);
+  });
+
+  test("returns null on no matches", () => {
+    expect(getSlashMatches("/zzzz", commands)).toBeNull();
+  });
+
+  test("returns null once a space is typed", () => {
+    expect(getSlashMatches("/review ", commands)).toBeNull();
+    expect(getSlashMatches("/review foo.ts", commands)).toBeNull();
+  });
+
+  test("returns null for multi-word values starting with /", () => {
+    expect(getSlashMatches("/help me", commands)).toBeNull();
+  });
+
+  test("caps results at MAX_VISIBLE_COMPLETIONS", () => {
+    const many: SlashCommand[] = Array.from(
+      { length: MAX_VISIBLE_COMPLETIONS + 5 },
+      (_, i) => ({ name: `cmd${i}`, description: "" }),
+    );
+    const result = getSlashMatches("/cmd", many);
+    expect(result).toHaveLength(MAX_VISIBLE_COMPLETIONS);
+  });
+
+  test("accepts hyphens in command names", () => {
+    const withHyphen: SlashCommand[] = [
+      { name: "daily-log", description: "" },
+      { name: "daily-standup", description: "" },
+    ];
+    const result = getSlashMatches("/daily-s", withHyphen);
+    expect(result?.map((c) => c.name)).toEqual(["daily-standup"]);
+  });
+});
+
+describe("buildSlashCommands", () => {
+  test("concatenates builtins then skills", () => {
+    const builtins: SlashCommand[] = [{ name: "help", description: "Help" }];
+    const skills = [
+      { name: "review", description: "Review a file" },
+      { name: "summarize", description: "Summarize" },
+    ];
+    const result = buildSlashCommands(builtins, skills);
+    expect(result.map((c) => c.name)).toEqual(["help", "review", "summarize"]);
+    expect(result[1]?.description).toBe("Review a file");
+  });
+
+  test("preserves builtin order and does not dedupe", () => {
+    const builtins: SlashCommand[] = [
+      { name: "quit", description: "Exit" },
+      { name: "exit", description: "Exit" },
+    ];
+    const result = buildSlashCommands(builtins, []);
+    expect(result.map((c) => c.name)).toEqual(["quit", "exit"]);
+  });
+});


### PR DESCRIPTION
## Summary

- Typing `/` in the chat input opens a popup listing matching built-in commands and skills with descriptions; `↑/↓` moves the highlight, `Tab`/`Return` accepts (fills in `/<name> ` so args flow normally), `Esc` dismisses.
- Pure matching logic lives in `src/tui/slashCompletion.ts` with 11 unit tests in `test/tui/slash-completion.test.ts`. The presentational `SlashCommandPopup` component is a small sibling Box rendered above the bordered input.
- Drops the redundant `/quit` alias in favor of a single `/exit` command, and updates `/help`, `HelpPanel`, `chat --help`, and `docs/skills.md` to match.

## Test plan

- [x] `bun test` — 616/616 pass
- [x] `bun run lint` — tsc + biome clean
- [ ] Manually in `bun run dev`: `/` opens popup, `/he` filters to `/help`, `Tab` fills `/help `, `Esc` closes, `↑/↓` outside a popup still browses history

🤖 Generated with [Claude Code](https://claude.com/claude-code)