### PR TITLE
Load contextual persistent-context files in chat (fixes #106)

### DIFF
--- a/docs/persistent-context.md
+++ b/docs/persistent-context.md
@@ -39,11 +39,14 @@ prompt, verbatim. Use sparingly. `soul.md`, `beliefs.md`, and `goals.md`
 are always-loaded.
 
 **`loading: contextual`** — the file is included only if its content
-shares keywords with the current task's name/description. Use this for
+shares keywords with the caller's current intent. The daemon derives
+keywords from the running task's name and description; the chat agent
+derives them from your most recent message. Use this for
 topic-specific notes ("Everything I know about our invoicing system")
 that shouldn't pollute the prompt on unrelated tasks.
 
-See `loadPersistentContext()` in `src/daemon/prompt.ts`.
+See `loadPersistentContext()` and `extractKeywords()` in
+`src/daemon/prompt.ts`.
 
 ---
 
@@ -128,11 +131,13 @@ agent-modification: false
 3. ...
 ```
 
-Tasks mentioning "deploy", "release", or "version" will now include this
-file in the system prompt automatically. You didn't have to register it
-anywhere — on every tick the daemon reads every `.md` file in
-`.botholomew/`, extracts words longer than three characters from the
-task's name and description, and includes any `loading: contextual`
-file whose content contains at least one of those words. See
+Tasks mentioning "deploy", "release", or "version" — and chat messages
+mentioning the same — will now include this file in the system prompt
+automatically. You didn't have to register it anywhere. On every tick
+the daemon reads every `.md` file in `.botholomew/`, extracts words
+longer than three characters from the current task's name and
+description, and includes any `loading: contextual` file whose content
+contains at least one of those words. The chat agent does the same on
+every turn, using your most recent message as the keyword source. See
 `loadPersistentContext()` in `src/daemon/prompt.ts` for the exact
 logic.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "An AI agent for knowledge work",
   "type": "module",
   "bin": {

--- a/src/chat/agent.ts
+++ b/src/chat/agent.ts
@@ -5,10 +5,16 @@ import type {
   ToolUseBlock,
 } from "@anthropic-ai/sdk/resources/messages";
 import type { BotholomewConfig } from "../config/schemas.ts";
+import { embedSingle } from "../context/embedder.ts";
 import { fitToContextWindow, getMaxInputTokens } from "../daemon/context.ts";
 import { maybeStoreResult } from "../daemon/large-results.ts";
-import { buildMetaHeader, loadPersistentContext } from "../daemon/prompt.ts";
+import {
+  buildMetaHeader,
+  extractKeywords,
+  loadPersistentContext,
+} from "../daemon/prompt.ts";
 import type { DbConnection } from "../db/connection.ts";
+import { hybridSearch } from "../db/embeddings.ts";
 import { logInteraction } from "../db/threads.ts";
 import { registerAllTools } from "../tools/registry.ts";
 import {
@@ -17,6 +23,7 @@ import {
   type ToolContext,
   toAnthropicTool,
 } from "../tools/tool.ts";
+import { logger } from "../utils/logger.ts";
 
 registerAllTools();
 
@@ -49,11 +56,44 @@ export function getChatTools() {
 
 export async function buildChatSystemPrompt(
   projectDir: string,
+  options?: {
+    keywordSource?: string;
+    conn?: DbConnection;
+    config?: Required<BotholomewConfig>;
+  },
 ): Promise<string> {
   const parts: string[] = [];
 
   parts.push(...buildMetaHeader(projectDir));
-  parts.push(...(await loadPersistentContext(projectDir)));
+
+  const keywordSource = options?.keywordSource?.trim();
+  const taskKeywords = keywordSource ? extractKeywords(keywordSource) : null;
+
+  parts.push(...(await loadPersistentContext(projectDir, taskKeywords)));
+
+  // Relevant context from embeddings search
+  const conn = options?.conn;
+  const config = options?.config;
+  if (conn && config?.openai_api_key && keywordSource) {
+    try {
+      const queryVec = await embedSingle(keywordSource, config);
+      const results = await hybridSearch(conn, keywordSource, queryVec, 5);
+
+      if (results.length > 0) {
+        parts.push("## Relevant Context");
+        for (const r of results) {
+          const path = r.source_path || r.context_item_id;
+          parts.push(`### ${r.title} (${path})`);
+          if (r.chunk_content) {
+            parts.push(r.chunk_content.slice(0, 1000));
+          }
+          parts.push("");
+        }
+      }
+    } catch (err) {
+      logger.debug(`Failed to load contextual embeddings: ${err}`);
+    }
+  }
 
   parts.push("## Instructions");
   parts.push(
@@ -96,20 +136,34 @@ export interface ChatTurnCallbacks {
 }
 
 /**
+ * Walk messages backward to find the most recent human-authored user message.
+ * After tool turns, `messages[messages.length - 1]` is a user entry whose
+ * content is a `ToolResultBlockParam[]` — we want the string content from the
+ * actual user, not tool output, as the keyword source.
+ */
+function findLastUserText(messages: MessageParam[]): string {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (m?.role === "user" && typeof m.content === "string") return m.content;
+  }
+  return "";
+}
+
+/**
  * Run a single chat turn: stream the assistant response, execute any tool calls,
  * and loop until the model produces end_turn with no tool calls.
  * Mutates `messages` in-place by appending assistant/tool messages.
  */
 export async function runChatTurn(input: {
   messages: MessageParam[];
-  systemPrompt: string;
+  projectDir: string;
   config: Required<BotholomewConfig>;
   conn: DbConnection;
   threadId: string;
   toolCtx: ToolContext;
   callbacks: ChatTurnCallbacks;
 }): Promise<void> {
-  const { messages, systemPrompt, config, conn, threadId, toolCtx, callbacks } =
+  const { messages, projectDir, config, conn, threadId, toolCtx, callbacks } =
     input;
 
   const client = new Anthropic({
@@ -125,6 +179,18 @@ export async function runChatTurn(input: {
 
   for (let turn = 0; !maxTurns || turn < maxTurns; turn++) {
     const startTime = Date.now();
+
+    // Rebuild the system prompt every iteration so that:
+    //   (1) `loading: contextual` files get matched against the latest user
+    //       message, and
+    //   (2) any update_beliefs / update_goals tool call in the previous
+    //       iteration is reflected in the next LLM call.
+    const keywordSource = findLastUserText(messages);
+    const systemPrompt = await buildChatSystemPrompt(projectDir, {
+      keywordSource,
+      conn,
+      config,
+    });
 
     fitToContextWindow(messages, systemPrompt, maxInputTokens);
     const stream = client.messages.stream({

--- a/src/chat/session.ts
+++ b/src/chat/session.ts
@@ -17,11 +17,7 @@ import { loadSkills } from "../skills/loader.ts";
 import type { SkillDefinition } from "../skills/parser.ts";
 import type { ToolContext } from "../tools/tool.ts";
 import { generateThreadTitle } from "../utils/title.ts";
-import {
-  buildChatSystemPrompt,
-  type ChatTurnCallbacks,
-  runChatTurn,
-} from "./agent.ts";
+import { type ChatTurnCallbacks, runChatTurn } from "./agent.ts";
 
 export interface ChatSession {
   conn: DbConnection;
@@ -29,7 +25,6 @@ export interface ChatSession {
   projectDir: string;
   config: Required<BotholomewConfig>;
   messages: MessageParam[];
-  systemPrompt: string;
   toolCtx: ToolContext;
   skills: Map<string, SkillDefinition>;
   cleanup: () => Promise<void>;
@@ -83,8 +78,6 @@ export async function startChatSession(
     threadId = await createThread(conn, "chat_session", undefined, "New chat");
   }
 
-  const systemPrompt = await buildChatSystemPrompt(projectDir);
-
   const mcpxClient = await createMcpxClient(projectDir);
   const skills = await loadSkills(projectDir);
 
@@ -105,7 +98,6 @@ export async function startChatSession(
     projectDir,
     config,
     messages,
-    systemPrompt,
     toolCtx,
     skills,
     cleanup,
@@ -138,7 +130,7 @@ export async function sendMessage(
 
   await runChatTurn({
     messages: session.messages,
-    systemPrompt: session.systemPrompt,
+    projectDir: session.projectDir,
     config: session.config,
     conn: session.conn,
     threadId: session.threadId,

--- a/src/daemon/prompt.ts
+++ b/src/daemon/prompt.ts
@@ -14,6 +14,21 @@ const pkg = await Bun.file(
 ).json();
 
 /**
+ * Extract keyword set from free-form text: lowercase, split on whitespace,
+ * keep words longer than 3 chars. Used to match `loading: contextual` files
+ * against the agent's current intent (task text for the daemon, latest user
+ * message for the chat).
+ */
+export function extractKeywords(text: string): Set<string> {
+  return new Set(
+    text
+      .toLowerCase()
+      .split(/\s+/)
+      .filter((w) => w.length > 3),
+  );
+}
+
+/**
  * Load persistent context files from .botholomew/ directory.
  * Returns an array of formatted string sections for "always" loaded files.
  * If taskKeywords are provided, also includes "contextual" files that match.
@@ -85,12 +100,7 @@ export async function buildSystemPrompt(
 
   // Build keyword set from task for contextual loading
   const taskKeywords = task
-    ? new Set(
-        `${task.name} ${task.description}`
-          .toLowerCase()
-          .split(/\s+/)
-          .filter((w) => w.length > 3),
-      )
+    ? extractKeywords(`${task.name} ${task.description}`)
     : null;
 
   // Load context files from .botholomew/

--- a/test/chat/agent.test.ts
+++ b/test/chat/agent.test.ts
@@ -1,5 +1,33 @@
-import { describe, expect, test } from "bun:test";
-import { buildChatSystemPrompt, getChatTools } from "../../src/chat/agent.ts";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { serializeContextFile } from "../../src/utils/frontmatter.ts";
+import { mockEmbed, mockEmbedSingle, silentLogger } from "../helpers.ts";
+
+// Mock the embedder to avoid loading the real model
+mock.module("../../src/context/embedder.ts", () => ({
+  embed: mockEmbed,
+  embedSingle: mockEmbedSingle,
+}));
+
+// Mock the logger to suppress output
+mock.module("../../src/utils/logger.ts", () => silentLogger);
+
+const { buildChatSystemPrompt, getChatTools } = await import(
+  "../../src/chat/agent.ts"
+);
+
+let projectDir: string;
+
+beforeEach(async () => {
+  projectDir = await mkdtemp(join(tmpdir(), "botholomew-chat-test-"));
+  await mkdir(join(projectDir, ".botholomew"), { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(projectDir, { recursive: true, force: true });
+});
 
 describe("getChatTools", () => {
   test("returns only chat-allowed tools", () => {
@@ -42,7 +70,7 @@ describe("getChatTools", () => {
 
 describe("buildChatSystemPrompt", () => {
   test("includes chat-specific instructions", async () => {
-    const prompt = await buildChatSystemPrompt("/tmp/test-project");
+    const prompt = await buildChatSystemPrompt(projectDir);
     expect(prompt).toContain("Botholomew");
     expect(prompt).toContain("interactive chat interface");
     expect(prompt).toContain("create_task");
@@ -50,8 +78,73 @@ describe("buildChatSystemPrompt", () => {
   });
 
   test("includes meta header", async () => {
-    const prompt = await buildChatSystemPrompt("/tmp/test-project");
+    const prompt = await buildChatSystemPrompt(projectDir);
     expect(prompt).toContain("Current time:");
-    expect(prompt).toContain("/tmp/test-project");
+    expect(prompt).toContain(projectDir);
+  });
+
+  test("includes always-loaded context files", async () => {
+    const content = serializeContextFile(
+      { loading: "always", "agent-modification": false },
+      "I am the soul of the project.",
+    );
+    await Bun.write(join(projectDir, ".botholomew", "soul.md"), content);
+
+    const prompt = await buildChatSystemPrompt(projectDir);
+    expect(prompt).toContain("## soul.md");
+    expect(prompt).toContain("I am the soul of the project.");
+  });
+
+  test("includes contextual files when keywordSource matches", async () => {
+    const content = serializeContextFile(
+      { loading: "contextual", "agent-modification": false },
+      "Our invoicing system uses Stripe for billing.",
+    );
+    await Bun.write(join(projectDir, ".botholomew", "invoicing.md"), content);
+
+    const prompt = await buildChatSystemPrompt(projectDir, {
+      keywordSource: "what is our invoicing setup?",
+    });
+    expect(prompt).toContain("invoicing.md (contextual)");
+    expect(prompt).toContain("Our invoicing system uses Stripe for billing.");
+  });
+
+  test("excludes contextual files when keywordSource does not match", async () => {
+    const content = serializeContextFile(
+      { loading: "contextual", "agent-modification": false },
+      "Our invoicing system uses Stripe for billing.",
+    );
+    await Bun.write(join(projectDir, ".botholomew", "invoicing.md"), content);
+
+    const prompt = await buildChatSystemPrompt(projectDir, {
+      keywordSource: "deployment pipeline help",
+    });
+    expect(prompt).not.toContain("invoicing.md");
+    expect(prompt).not.toContain("Our invoicing system uses Stripe");
+  });
+
+  test("excludes contextual files when no keywordSource is given", async () => {
+    const content = serializeContextFile(
+      { loading: "contextual", "agent-modification": false },
+      "Our invoicing system uses Stripe for billing.",
+    );
+    await Bun.write(join(projectDir, ".botholomew", "invoicing.md"), content);
+
+    const prompt = await buildChatSystemPrompt(projectDir);
+    expect(prompt).not.toContain("invoicing.md");
+    expect(prompt).not.toContain("Our invoicing system uses Stripe");
+  });
+
+  test("always-loaded files appear even when keywordSource matches nothing", async () => {
+    const always = serializeContextFile(
+      { loading: "always", "agent-modification": true },
+      "Beliefs content here.",
+    );
+    await Bun.write(join(projectDir, ".botholomew", "beliefs.md"), always);
+
+    const prompt = await buildChatSystemPrompt(projectDir, {
+      keywordSource: "zzz nonmatching xyzzy",
+    });
+    expect(prompt).toContain("Beliefs content here.");
   });
 });

--- a/test/chat/session.test.ts
+++ b/test/chat/session.test.ts
@@ -37,7 +37,6 @@ describe("startChatSession", () => {
     expect(session.threadId).toBeTruthy();
     expect(session.conn).toBeTruthy();
     expect(session.messages).toEqual([]);
-    expect(session.systemPrompt).toContain("interactive chat interface");
   });
 
   test("creates a chat_session thread in the database", async () => {


### PR DESCRIPTION
## Summary

- Fix #106: the chat agent was calling `loadPersistentContext(projectDir)` with no keywords, so every `.botholomew/*.md` file with `loading: contextual` was silently dropped from its system prompt.
- The chat prompt is now rebuilt at the top of every `runChatTurn` iteration using the latest user message as the keyword source — which also closes a secondary bug where mid-session `update_beliefs` / `update_goals` edits didn't reach the LLM until a new chat started.
- Closes the related `hybridSearch` gap the issue flagged: chat now adds top-5 embeddings hits as "## Relevant Context" (gated on `openai_api_key`), matching the daemon.
- Extracts the shared keyword logic into `extractKeywords(text)`; updates `docs/persistent-context.md` to describe both agents; bumps version to `0.7.1`.

## Test plan
- [x] `bun test` — 611 pass, 0 fail (new chat-agent tests cover always-loaded, contextual-match, contextual-no-match, no-keywordSource, and keyword-mismatch-still-loads-always)
- [x] `bun run lint` — clean
- [ ] Manual smoke: `bun run dev chat` with a `.botholomew/invoicing.md` (`loading: contextual`) — verify the model references the file when asked about invoicing but not when asked about deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)