### PR TITLE
Add `skill list` and `skill show` CLI subcommands (#107)

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -105,6 +105,9 @@ botholomew skill show review          # print the full skill file
 botholomew skill create daily-log     # scaffold a new skill
 ```
 
+`skill show` exits non-zero if the name doesn't match a loaded skill, and
+prints the available skill names to stderr.
+
 Skills are parsed by `src/skills/parser.ts` and loaded from disk by
 `src/skills/loader.ts` at chat-session start. They're cached on the
 `ChatSession` object, so changes require restarting the chat — but not

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "An AI agent for knowledge work",
   "type": "module",
   "bin": {

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -1,4 +1,4 @@
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import ansis from "ansis";
 import type { Command } from "commander";
 import { getSkillsDir } from "../constants.ts";
@@ -22,6 +22,67 @@ export function registerSkillCommand(program: Command) {
       } else {
         await validateAllSkills(dir);
       }
+    });
+
+  skill
+    .command("list")
+    .description("List all skills loaded from .botholomew/skills/")
+    .action(async () => {
+      const dir = program.opts().dir;
+      const skills = await loadSkills(dir);
+
+      if (skills.size === 0) {
+        logger.dim("No skill files found.");
+        return;
+      }
+
+      const sorted = [...skills.values()].sort((a, b) =>
+        a.name.localeCompare(b.name),
+      );
+
+      const header = `${ansis.bold("Name".padEnd(20))} ${ansis.bold("Description".padEnd(40))} ${ansis.bold("Args".padEnd(20))} ${ansis.bold("Path")}`;
+      console.log(header);
+      console.log("-".repeat(header.length));
+
+      for (const s of sorted) {
+        const name = s.name.padEnd(20);
+        const desc = s.description
+          ? s.description.slice(0, 39).padEnd(40)
+          : ansis.dim("(no description)".padEnd(40));
+        const args =
+          s.arguments.length > 0
+            ? s.arguments
+                .map((a) => a.name)
+                .join(",")
+                .slice(0, 19)
+                .padEnd(20)
+            : ansis.dim("none".padEnd(20));
+        const path = relative(dir, s.filePath);
+        console.log(`${name} ${desc} ${args} ${path}`);
+      }
+
+      console.log(`\n${ansis.dim(`${sorted.length} skill(s)`)}`);
+    });
+
+  skill
+    .command("show <name>")
+    .description("Print the raw contents of a skill file")
+    .action(async (name: string) => {
+      const dir = program.opts().dir;
+      const skills = await loadSkills(dir);
+      const s = skills.get(name.toLowerCase());
+
+      if (!s) {
+        logger.error(`Skill not found: ${name}`);
+        if (skills.size > 0) {
+          const available = [...skills.keys()].sort().join(", ");
+          console.error(ansis.dim(`Available: ${available}`));
+        }
+        process.exit(1);
+      }
+
+      const raw = await Bun.file(s.filePath).text();
+      process.stdout.write(raw);
     });
 
   skill

--- a/test/commands/skill.test.ts
+++ b/test/commands/skill.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { BOTHOLOMEW_DIR, SKILLS_DIR } from "../../src/constants.ts";
+import { initProject } from "../../src/init/index.ts";
+
+let tempDir: string;
+
+afterEach(async () => {
+  if (tempDir) {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+const CLI = join(import.meta.dir, "..", "..", "src", "cli.ts");
+
+async function run(
+  args: string[],
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  const proc = Bun.spawn(["bun", CLI, "--dir", tempDir, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, NO_COLOR: "1" },
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const code = await proc.exited;
+  return { code, stdout, stderr };
+}
+
+describe("skill list CLI", () => {
+  test("lists all seeded skills", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "botholomew-test-"));
+    await initProject(tempDir);
+
+    const result = await run(["skill", "list"]);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("summarize");
+    expect(result.stdout).toContain("standup");
+    expect(result.stdout).toMatch(/skill\(s\)/);
+  });
+
+  test("reports empty state when no skills are present", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "botholomew-test-"));
+    // Deliberately do not call initProject — loadSkills handles the
+    // missing directory gracefully.
+
+    const result = await run(["skill", "list"]);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("No skill files found.");
+  });
+});
+
+describe("skill show CLI", () => {
+  test("prints raw file contents including frontmatter", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "botholomew-test-"));
+    const skillsDir = join(tempDir, BOTHOLOMEW_DIR, SKILLS_DIR);
+    await mkdir(skillsDir, { recursive: true });
+    const raw = `---
+name: greet
+description: "Say hello"
+arguments: []
+---
+
+Hello, world!
+`;
+    await Bun.write(join(skillsDir, "greet.md"), raw);
+
+    const result = await run(["skill", "show", "greet"]);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe(raw);
+  });
+
+  test("exits non-zero and lists available skills on miss", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "botholomew-test-"));
+    await initProject(tempDir);
+
+    const result = await run(["skill", "show", "does-not-exist"]);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("Skill not found: does-not-exist");
+    expect(result.stderr).toContain("Available:");
+    expect(result.stderr).toContain("summarize");
+  });
+
+  test("exits non-zero without an available list when no skills exist", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "botholomew-test-"));
+    const skillsDir = join(tempDir, BOTHOLOMEW_DIR, SKILLS_DIR);
+    await mkdir(skillsDir, { recursive: true });
+
+    const result = await run(["skill", "show", "anything"]);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("Skill not found: anything");
+    expect(result.stderr).not.toContain("Available:");
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #107 (and the already-closed #108). `docs/skills.md` documented `botholomew skill list` and `botholomew skill show <name>`, but `src/commands/skill.ts` only had `validate` and `create`.
- `skill list` prints a sorted 4-column table (Name, Description, Args, Path) using `loadSkills()` so output matches what chat sessions actually load.
- `skill show <name>` writes the raw file contents (including frontmatter) to stdout so `skill show foo > foo.md` round-trips; on miss it prints the available skill names to stderr and exits 1.
- Adds `test/commands/skill.test.ts` (5 subprocess tests covering list empty/populated + show hit/miss/miss-when-empty), a short doc note, and a version bump to 0.7.1.

## Test plan

- [x] `bun run lint`
- [x] `bun test` (611/611 pass)
- [x] Manual smoke: `skill list`, `skill show summarize`, `skill show does-not-exist` (exit 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)