### PR TITLE
Add daemon/chat context_refresh tool, fix DuckDB corruption crashes

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,6 +62,8 @@ set — it does **not** execute long-running work itself. Instead, it:
 - answers questions about tasks, threads, and context,
 - creates tasks (via the `create_task` tool) that the daemon will pick up,
 - reads daemon activity (`list_threads`, `view_thread`),
+- looks up context items by path or UUID (`context_info`, `context_search`)
+  and can refresh them in place (`context_refresh`),
 - invokes **skills** (`/review`, `/standup`, …) defined in
   `.botholomew/skills/`,
 - edits `beliefs.md` and `goals.md` via `update_beliefs` / `update_goals`.

--- a/docs/context-and-search.md
+++ b/docs/context-and-search.md
@@ -202,22 +202,19 @@ cases it compares the new content against what's stored, updates only
 when they differ, and re-embeds only the changed items. Missing files
 are reported, not silently dropped.
 
-Today `refresh` lives on the CLI only — the daemon has no registered
-tool for it, so a schedule that says "run `context refresh`" will
-enqueue a task the agent can't actually work. Until
-[#105](https://github.com/evantahler/botholomew/issues/105) lands, the
-right way to run it on a schedule is an external timer:
+The same logic is exposed to the daemon as the `context_refresh`
+tool, so schedules like "every morning at 7, refresh remote context"
+work end-to-end without an external scheduler. The tool takes the
+same arguments as the CLI (`path` for a single item or subtree,
+`all: true` for every sourced item) and returns a structured summary
+(`checked`, `updated`, `unchanged`, `missing`, `reembedded`,
+`chunks`, per-item statuses) so the agent can report back or feed a
+downstream task via `complete_task`.
 
-```bash
-# cron — every morning at 7
-0 7 * * * cd ~/my-project && botholomew context refresh --all
-
-# launchd / systemd — point the user-level service at the same command
-```
-
-Once the daemon-accessible tool from #105 exists, you'll be able to
-drive it entirely from Botholomew schedules without an external
-scheduler.
+Under the hood, URL fetches from the daemon open a nested fetcher
+loop with the project's MCPX client — the same path the CLI uses.
+`all: true` across many URLs is serial (each URL runs its own
+Anthropic agent loop), so prefer narrowing with `path` when you can.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "An AI agent for knowledge work",
   "type": "module",
   "bin": {

--- a/src/chat/agent.ts
+++ b/src/chat/agent.ts
@@ -33,6 +33,8 @@ const CHAT_TOOL_NAMES = new Set([
   "list_tasks",
   "view_task",
   "context_search",
+  "context_info",
+  "context_refresh",
   "search_grep",
   "search_semantic",
   "list_threads",
@@ -103,7 +105,7 @@ export async function buildChatSystemPrompt(
     "You do NOT execute long-running work directly — enqueue tasks for the daemon instead using create_task.",
   );
   parts.push(
-    "Use the available tools to look up tasks, threads, schedules, and context when the user asks about them.",
+    "Use the available tools to look up tasks, threads, schedules, and context when the user asks about them. Context items can be looked up by virtual path or by UUID via `context_info` and refreshed via `context_refresh`.",
   );
   parts.push(
     "When multiple tool calls are independent of each other (i.e., one does not depend on the result of another), call them all in a single response. They will be executed in parallel, which is faster than calling them one at a time.",

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -14,6 +14,7 @@ import {
   prepareIngestion,
   storeIngestion,
 } from "../context/ingest.ts";
+import { refreshContextItems } from "../context/refresh.ts";
 import { isUrl, urlToContextPath } from "../context/url-utils.ts";
 import type { DbConnection } from "../db/connection.ts";
 import {
@@ -22,7 +23,6 @@ import {
   listContextItems,
   listContextItemsByPrefix,
   resolveContextItem,
-  updateContextItem,
   upsertContextItem,
 } from "../db/context.ts";
 import { getEmbeddingsForItem, hybridSearch } from "../db/embeddings.ts";
@@ -444,95 +444,55 @@ export function registerContextCommand(program: Command) {
         const hasUrls = sourced.some((i) => i.source_type === "url");
         const mcpxClient = hasUrls ? await createMcpxClient(dir) : null;
 
-        // Phase 1: Read files / fetch URLs, compare, and update DB
-        const spinner = createSpinner(
+        const refreshSpinner = createSpinner(
           `Refreshing 0/${sourced.length} items...`,
         ).start();
-        let updated = 0;
-        let unchanged = 0;
-        let missing = 0;
-        const toReembed: string[] = [];
+        const embedSpinner = createSpinner("Embedding 0 item(s)...");
 
-        for (const [idx, item] of sourced.entries()) {
-          spinner.update({
-            text: `Refreshing ${idx + 1}/${sourced.length} items...`,
-          });
-          try {
-            const sourcePath = item.source_path as string;
-            let content: string;
-
-            if (item.source_type === "url") {
-              const fetched = await fetchUrl(sourcePath, config, mcpxClient);
-              content = fetched.content;
-            } else {
-              const bunFile = Bun.file(sourcePath);
-              if (!(await bunFile.exists())) {
-                missing++;
-                logger.warn(`  Missing: ${item.source_path}`);
-                continue;
-              }
-              content = await bunFile.text();
-            }
-
-            if (content === item.content) {
-              unchanged++;
-              continue;
-            }
-            await updateContextItem(conn, item.id, { content });
-            updated++;
-            toReembed.push(item.id);
-          } catch (err) {
-            logger.warn(`  Error refreshing ${item.source_path}: ${err}`);
-          }
-        }
-        spinner.success({
-          text: `Checked ${sourced.length} item(s): ${updated} updated, ${unchanged} unchanged, ${missing} missing.`,
-        });
-
-        // Phase 2: Re-embed changed items
-        if (toReembed.length === 0 || !config.openai_api_key) {
-          if (toReembed.length > 0 && !config.openai_api_key) {
-            logger.dim("Skipping embeddings (no OpenAI API key configured).");
-          }
-          return;
-        }
-
-        const CONCURRENCY = 10;
-        let completed = 0;
-        const embedSpinner = createSpinner(
-          `Embedding 0/${toReembed.length} item(s)...`,
-        ).start();
-
-        const prepared: PreparedIngestion[] = [];
-        for (let i = 0; i < toReembed.length; i += CONCURRENCY) {
-          const batch = toReembed.slice(i, i + CONCURRENCY);
-          const results = await Promise.all(
-            batch.map(async (id) => {
-              const result = await prepareIngestion(conn, id, config);
-              completed++;
-              embedSpinner.update({
-                text: `Embedding ${completed}/${toReembed.length} item(s)...`,
+        const result = await refreshContextItems(
+          conn,
+          sourced,
+          config,
+          mcpxClient,
+          {
+            onItemProgress: (done, total) => {
+              refreshSpinner.update({
+                text: `Refreshing ${done}/${total} items...`,
               });
-              return result;
-            }),
-          );
-          for (const r of results) {
-            if (r) prepared.push(r);
-          }
-        }
-        embedSpinner.success({
-          text: `Embedded ${prepared.length} item(s).`,
+            },
+            onEmbedProgress: (done, total) => {
+              if (done === 1) embedSpinner.start();
+              embedSpinner.update({
+                text: `Embedding ${done}/${total} item(s)...`,
+              });
+            },
+          },
+        );
+
+        refreshSpinner.success({
+          text: `Checked ${result.checked} item(s): ${result.updated} updated, ${result.unchanged} unchanged, ${result.missing} missing.`,
         });
 
-        let chunks = 0;
-        for (const p of prepared) {
-          const result = await storeIngestion(conn, p);
-          chunks += result.chunks;
+        for (const item of result.items) {
+          if (item.status === "missing") {
+            logger.warn(`  Missing: ${item.source_path}`);
+          } else if (item.status === "error") {
+            logger.warn(
+              `  Error refreshing ${item.source_path}: ${item.error}`,
+            );
+          }
         }
 
-        logger.success(
-          `Refreshed ${updated} item(s), ${chunks} chunk(s) re-indexed.`,
-        );
+        if (result.reembedded > 0) {
+          embedSpinner.success({
+            text: `Embedded ${result.reembedded} item(s).`,
+          });
+          logger.success(
+            `Refreshed ${result.updated} item(s), ${result.chunks} chunk(s) re-indexed.`,
+          );
+        } else if (result.embeddings_skipped) {
+          logger.dim("Skipping embeddings (no OpenAI API key configured).");
+        }
       }),
     );
 

--- a/src/context/refresh.ts
+++ b/src/context/refresh.ts
@@ -1,0 +1,159 @@
+import type { McpxClient } from "@evantahler/mcpx";
+import type { BotholomewConfig } from "../config/schemas.ts";
+import type { DbConnection } from "../db/connection.ts";
+import { type ContextItem, updateContextItem } from "../db/context.ts";
+import { fetchUrl } from "./fetcher.ts";
+import {
+  type PreparedIngestion,
+  prepareIngestion,
+  storeIngestion,
+} from "./ingest.ts";
+
+export type RefreshItemStatus = "updated" | "unchanged" | "missing" | "error";
+
+export interface RefreshItemResult {
+  id: string;
+  context_path: string;
+  source_path: string;
+  source_type: "file" | "url";
+  status: RefreshItemStatus;
+  error?: string;
+}
+
+export interface RefreshResult {
+  checked: number;
+  updated: number;
+  unchanged: number;
+  missing: number;
+  reembedded: number;
+  chunks: number;
+  embeddings_skipped: boolean;
+  items: RefreshItemResult[];
+}
+
+export interface RefreshOptions {
+  concurrency?: number;
+  onItemProgress?: (done: number, total: number) => void;
+  onEmbedProgress?: (done: number, total: number) => void;
+}
+
+type IngestEmbedFn = (texts: string[]) => Promise<number[][]>;
+
+/**
+ * Refresh a batch of context items: re-read source (file or URL), diff, update
+ * content, and re-embed only the items that changed. Side-effect free on the
+ * outside world — the caller owns logging and spinners.
+ */
+export async function refreshContextItems(
+  conn: DbConnection,
+  items: ContextItem[],
+  config: Required<BotholomewConfig>,
+  mcpxClient: McpxClient | null,
+  opts: RefreshOptions = {},
+  embedFn?: IngestEmbedFn,
+): Promise<RefreshResult> {
+  const sourced = items.filter(
+    (i): i is ContextItem & { source_path: string } => !!i.source_path,
+  );
+
+  const results: RefreshItemResult[] = [];
+  const toReembed: string[] = [];
+
+  // Phase 1: read each source, diff against stored content, update when changed.
+  for (const [idx, item] of sourced.entries()) {
+    opts.onItemProgress?.(idx, sourced.length);
+    const base = {
+      id: item.id,
+      context_path: item.context_path,
+      source_path: item.source_path,
+      source_type: item.source_type,
+    };
+
+    try {
+      let content: string;
+
+      if (item.source_type === "url") {
+        const fetched = await fetchUrl(item.source_path, config, mcpxClient);
+        content = fetched.content;
+      } else {
+        const bunFile = Bun.file(item.source_path);
+        if (!(await bunFile.exists())) {
+          results.push({ ...base, status: "missing" });
+          continue;
+        }
+        content = await bunFile.text();
+      }
+
+      if (content === item.content) {
+        results.push({ ...base, status: "unchanged" });
+        continue;
+      }
+
+      await updateContextItem(conn, item.id, { content });
+      results.push({ ...base, status: "updated" });
+      toReembed.push(item.id);
+    } catch (err) {
+      results.push({
+        ...base,
+        status: "error",
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  opts.onItemProgress?.(sourced.length, sourced.length);
+
+  const updated = results.filter((r) => r.status === "updated").length;
+  const unchanged = results.filter((r) => r.status === "unchanged").length;
+  const missing = results.filter((r) => r.status === "missing").length;
+
+  // Phase 2: re-embed changed items. Skip cleanly if no OpenAI key.
+  const hasEmbedder = !!embedFn || !!config.openai_api_key;
+  if (toReembed.length === 0 || !hasEmbedder) {
+    return {
+      checked: sourced.length,
+      updated,
+      unchanged,
+      missing,
+      reembedded: 0,
+      chunks: 0,
+      embeddings_skipped: toReembed.length > 0 && !hasEmbedder,
+      items: results,
+    };
+  }
+
+  const concurrency = opts.concurrency ?? 10;
+  const prepared: PreparedIngestion[] = [];
+  let completed = 0;
+
+  for (let i = 0; i < toReembed.length; i += concurrency) {
+    const batch = toReembed.slice(i, i + concurrency);
+    const batchResults = await Promise.all(
+      batch.map(async (id) => {
+        const r = await prepareIngestion(conn, id, config, embedFn);
+        completed++;
+        opts.onEmbedProgress?.(completed, toReembed.length);
+        return r;
+      }),
+    );
+    for (const r of batchResults) {
+      if (r) prepared.push(r);
+    }
+  }
+
+  let chunks = 0;
+  for (const p of prepared) {
+    const result = await storeIngestion(conn, p);
+    chunks += result.chunks;
+  }
+
+  return {
+    checked: sourced.length,
+    updated,
+    unchanged,
+    missing,
+    reembedded: prepared.length,
+    chunks,
+    embeddings_skipped: false,
+    items: results,
+  };
+}

--- a/src/db/context.ts
+++ b/src/db/context.ts
@@ -290,6 +290,10 @@ export async function getDistinctDirectories(
 
 // --- Mutations ---
 
+// `UPDATE context_items ... RETURNING *` can crash @duckdb/node-api via a C++
+// exception when the table's unique index is in a violated state. Update +
+// separate SELECT is equivalent here (single-connection, no concurrent writers)
+// and avoids the crash entirely.
 export async function updateContextItem(
   db: DbConnection,
   id: string,
@@ -307,14 +311,13 @@ export async function updateContextItem(
   setClauses.push("updated_at = current_timestamp::VARCHAR");
   params.push(id);
 
-  const row = await db.queryGet<ContextItemRow>(
+  await db.queryRun(
     `UPDATE context_items
      SET ${setClauses.join(", ")}
-     WHERE id = ?${params.length}
-     RETURNING *`,
+     WHERE id = ?${params.length}`,
     ...params,
   );
-  return row ? rowToContextItem(row) : null;
+  return getContextItem(db, id);
 }
 
 export async function updateContextItemContent(
@@ -322,15 +325,14 @@ export async function updateContextItemContent(
   contextPath: string,
   content: string,
 ): Promise<ContextItem | null> {
-  const row = await db.queryGet<ContextItemRow>(
+  await db.queryRun(
     `UPDATE context_items
      SET content = ?1, updated_at = current_timestamp::VARCHAR
-     WHERE context_path = ?2
-     RETURNING *`,
+     WHERE context_path = ?2`,
     content,
     contextPath,
   );
-  return row ? rowToContextItem(row) : null;
+  return getContextItemByPath(db, contextPath);
 }
 
 export async function applyPatchesToContextItem(

--- a/src/db/sql/10-dedupe_context_items.sql
+++ b/src/db/sql/10-dedupe_context_items.sql
@@ -1,0 +1,26 @@
+-- Older DBs could accumulate duplicate rows in context_items with the same
+-- context_path: migration 4's CREATE UNIQUE INDEX IF NOT EXISTS silently left
+-- the index metadata in place without enforcing it when duplicates predated
+-- the migration. The resulting "corrupt" unique index triggers a native
+-- crash in @duckdb/node-api on UPDATE ... RETURNING. Rebuild cleanly.
+DROP INDEX IF EXISTS idx_context_items_context_path;
+
+DELETE FROM embeddings WHERE context_item_id IN (
+  SELECT id FROM (
+    SELECT id, ROW_NUMBER() OVER (
+      PARTITION BY context_path
+      ORDER BY updated_at DESC, id DESC
+    ) AS rn FROM context_items
+  ) WHERE rn > 1
+);
+
+DELETE FROM context_items WHERE id IN (
+  SELECT id FROM (
+    SELECT id, ROW_NUMBER() OVER (
+      PARTITION BY context_path
+      ORDER BY updated_at DESC, id DESC
+    ) AS rn FROM context_items
+  ) WHERE rn > 1
+);
+
+CREATE UNIQUE INDEX idx_context_items_context_path ON context_items(context_path);

--- a/src/db/sql/11-rebuild_hnsw.sql
+++ b/src/db/sql/11-rebuild_hnsw.sql
@@ -1,0 +1,9 @@
+-- The HNSW index from migration 6 can end up in an internally-inconsistent
+-- state after a native-side crash during embedding writes: the buffered WAL
+-- replay tries to re-insert a node that HNSW's high-level wrapper already has,
+-- and search_semantic then fails with "Duplicate keys not allowed in
+-- high-level wrappers". Dropping and recreating the index rebuilds it cleanly
+-- from the current contents of the embeddings table.
+DROP INDEX IF EXISTS idx_embeddings_cosine;
+
+CREATE INDEX idx_embeddings_cosine ON embeddings USING HNSW (embedding) WITH (metric = 'cosine');

--- a/src/tools/context/refresh.ts
+++ b/src/tools/context/refresh.ts
@@ -1,0 +1,136 @@
+import { z } from "zod";
+import { refreshContextItems } from "../../context/refresh.ts";
+import {
+  type ContextItem,
+  listContextItems,
+  listContextItemsByPrefix,
+  resolveContextItem,
+} from "../../db/context.ts";
+import type { ToolDefinition } from "../tool.ts";
+
+const inputSchema = z.object({
+  path: z
+    .string()
+    .optional()
+    .describe(
+      "Context path or ID of a single item, or a path prefix to refresh a subtree. Mutually exclusive with `all`.",
+    ),
+  all: z
+    .boolean()
+    .optional()
+    .describe(
+      "Refresh every item that has a source_path (file or URL). Mutually exclusive with `path`.",
+    ),
+});
+
+const outputSchema = z.object({
+  checked: z.number(),
+  updated: z.number(),
+  unchanged: z.number(),
+  missing: z.number(),
+  reembedded: z.number(),
+  chunks: z.number(),
+  embeddings_skipped: z.boolean(),
+  items: z.array(
+    z.object({
+      id: z.string(),
+      context_path: z.string(),
+      source_path: z.string(),
+      source_type: z.enum(["file", "url"]),
+      status: z.enum(["updated", "unchanged", "missing", "error"]),
+      error: z.string().optional(),
+    }),
+  ),
+  message: z.string(),
+  is_error: z.boolean(),
+});
+
+const empty = {
+  checked: 0,
+  updated: 0,
+  unchanged: 0,
+  missing: 0,
+  reembedded: 0,
+  chunks: 0,
+  embeddings_skipped: false,
+  items: [],
+};
+
+export const contextRefreshTool = {
+  name: "context_refresh",
+  description:
+    "Re-read source files from disk / re-fetch source URLs, update stored content if it changed, and re-embed only changed items. Use `path` for a single item or subtree, or `all: true` for every sourced item. Items without a source_path are skipped. URL fetches use the project's MCPX client when available and fall back to plain HTTP.",
+  group: "context",
+  inputSchema,
+  outputSchema,
+  execute: async (input, ctx) => {
+    if (!input.path && !input.all) {
+      return {
+        ...empty,
+        message: "Provide a `path` or set `all: true`.",
+        is_error: true,
+      };
+    }
+    if (input.path && input.all) {
+      return {
+        ...empty,
+        message: "`path` and `all` are mutually exclusive.",
+        is_error: true,
+      };
+    }
+
+    let items: ContextItem[];
+    if (input.all) {
+      items = await listContextItems(ctx.conn);
+    } else {
+      const exact = await resolveContextItem(ctx.conn, input.path as string);
+      items = exact
+        ? [exact]
+        : await listContextItemsByPrefix(ctx.conn, input.path as string, {
+            recursive: true,
+          });
+    }
+
+    if (items.length === 0) {
+      return {
+        ...empty,
+        message: `No context items match \`${input.path ?? "all"}\`.`,
+        is_error: true,
+      };
+    }
+
+    const sourced = items.filter((i) => i.source_path);
+    if (sourced.length === 0) {
+      return {
+        ...empty,
+        message:
+          "No matching items have a source_path — nothing to refresh. (Items created via `context write` are not sourced.)",
+        is_error: false,
+      };
+    }
+
+    const result = await refreshContextItems(
+      ctx.conn,
+      sourced,
+      ctx.config,
+      ctx.mcpxClient,
+    );
+
+    const parts = [
+      `Checked ${result.checked}`,
+      `${result.updated} updated`,
+      `${result.unchanged} unchanged`,
+      `${result.missing} missing`,
+      `${result.reembedded} re-embedded (${result.chunks} chunks)`,
+    ];
+    if (result.embeddings_skipped) {
+      parts.push("embeddings skipped (no OpenAI API key configured)");
+    }
+
+    return {
+      ...result,
+      message: parts.join(", "),
+      is_error: false,
+    };
+  },
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -1,6 +1,7 @@
 // Context tools
 
 import { readLargeResultTool } from "./context/read-large-result.ts";
+import { contextRefreshTool } from "./context/refresh.ts";
 import { contextSearchTool } from "./context/search.ts";
 import { updateBeliefsTool } from "./context/update-beliefs.ts";
 import { updateGoalsTool } from "./context/update-goals.ts";
@@ -68,6 +69,7 @@ export function registerAllTools(): void {
   registerTool(contextExistsTool);
   registerTool(contextCountLinesTool);
   registerTool(contextSearchTool);
+  registerTool(contextRefreshTool);
   registerTool(updateBeliefsTool);
   registerTool(updateGoalsTool);
   registerTool(readLargeResultTool);

--- a/test/chat/agent.test.ts
+++ b/test/chat/agent.test.ts
@@ -41,6 +41,8 @@ describe("getChatTools", () => {
     expect(names).toContain("list_threads");
     expect(names).toContain("view_thread");
     expect(names).toContain("context_search");
+    expect(names).toContain("context_info");
+    expect(names).toContain("context_refresh");
     expect(names).toContain("update_beliefs");
     expect(names).toContain("update_goals");
     expect(names).toContain("list_schedules");

--- a/test/context/refresh.test.ts
+++ b/test/context/refresh.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DEFAULT_CONFIG } from "../../src/config/schemas.ts";
+import type { DbConnection } from "../../src/db/connection.ts";
+import { createContextItem, getContextItem } from "../../src/db/context.ts";
+import { mockEmbed, setupTestDb } from "../helpers.ts";
+
+const config = { ...DEFAULT_CONFIG, openai_api_key: "test-key" };
+const configNoEmbed = { ...DEFAULT_CONFIG };
+
+let conn: DbConnection;
+let tmpBase: string;
+
+beforeEach(async () => {
+  conn = await setupTestDb();
+  tmpBase = join(
+    tmpdir(),
+    `botholomew-refresh-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  await Bun.write(join(tmpBase, ".keep"), "");
+});
+
+afterEach(async () => {
+  await rm(tmpBase, { recursive: true, force: true });
+});
+
+async function seedFileBackedItem(params: {
+  filePath: string;
+  initialDiskContent: string;
+  storedContent: string;
+  contextPath: string;
+}) {
+  await Bun.write(params.filePath, params.initialDiskContent);
+  return createContextItem(conn, {
+    title: params.contextPath.split("/").pop() ?? "item",
+    content: params.storedContent,
+    contextPath: params.contextPath,
+    mimeType: "text/plain",
+    isTextual: true,
+    sourceType: "file",
+    sourcePath: params.filePath,
+  });
+}
+
+describe("refreshContextItems — file source", () => {
+  test("updates content and re-embeds when disk changed", async () => {
+    const { refreshContextItems } = await import(
+      "../../src/context/refresh.ts"
+    );
+    const filePath = join(tmpBase, "doc.md");
+    const item = await seedFileBackedItem({
+      filePath,
+      initialDiskContent: "new content",
+      storedContent: "old content",
+      contextPath: "/docs/doc.md",
+    });
+
+    const result = await refreshContextItems(
+      conn,
+      [item],
+      config,
+      null,
+      {},
+      mockEmbed,
+    );
+
+    expect(result.checked).toBe(1);
+    expect(result.updated).toBe(1);
+    expect(result.unchanged).toBe(0);
+    expect(result.missing).toBe(0);
+    expect(result.reembedded).toBe(1);
+    expect(result.chunks).toBeGreaterThan(0);
+
+    const fresh = await getContextItem(conn, item.id);
+    expect(fresh?.content).toBe("new content");
+    expect(fresh?.indexed_at).not.toBeNull();
+  });
+
+  test("reports unchanged when disk matches stored content", async () => {
+    const { refreshContextItems } = await import(
+      "../../src/context/refresh.ts"
+    );
+    const filePath = join(tmpBase, "same.md");
+    const item = await seedFileBackedItem({
+      filePath,
+      initialDiskContent: "identical",
+      storedContent: "identical",
+      contextPath: "/docs/same.md",
+    });
+
+    const result = await refreshContextItems(
+      conn,
+      [item],
+      config,
+      null,
+      {},
+      mockEmbed,
+    );
+
+    expect(result.unchanged).toBe(1);
+    expect(result.updated).toBe(0);
+    expect(result.reembedded).toBe(0);
+  });
+
+  test("reports missing when source file no longer exists", async () => {
+    const { refreshContextItems } = await import(
+      "../../src/context/refresh.ts"
+    );
+    const filePath = join(tmpBase, "gone.md");
+    const item = await seedFileBackedItem({
+      filePath,
+      initialDiskContent: "will be deleted",
+      storedContent: "will be deleted",
+      contextPath: "/docs/gone.md",
+    });
+    await rm(filePath);
+
+    const result = await refreshContextItems(
+      conn,
+      [item],
+      config,
+      null,
+      {},
+      mockEmbed,
+    );
+
+    expect(result.missing).toBe(1);
+    expect(result.items[0]?.status).toBe("missing");
+  });
+
+  test("skips embeddings and flags embeddings_skipped when no OpenAI key", async () => {
+    const { refreshContextItems } = await import(
+      "../../src/context/refresh.ts"
+    );
+    const filePath = join(tmpBase, "noembed.md");
+    const item = await seedFileBackedItem({
+      filePath,
+      initialDiskContent: "drifted",
+      storedContent: "original",
+      contextPath: "/docs/noembed.md",
+    });
+
+    const result = await refreshContextItems(conn, [item], configNoEmbed, null);
+
+    expect(result.updated).toBe(1);
+    expect(result.reembedded).toBe(0);
+    expect(result.embeddings_skipped).toBe(true);
+
+    const fresh = await getContextItem(conn, item.id);
+    expect(fresh?.content).toBe("drifted");
+  });
+
+  test("filters out items without a source_path", async () => {
+    const { refreshContextItems } = await import(
+      "../../src/context/refresh.ts"
+    );
+    const sourceless = await createContextItem(conn, {
+      title: "untethered",
+      content: "no source",
+      contextPath: "/docs/untethered.md",
+      mimeType: "text/plain",
+      isTextual: true,
+    });
+
+    const result = await refreshContextItems(
+      conn,
+      [sourceless],
+      config,
+      null,
+      {},
+      mockEmbed,
+    );
+
+    expect(result.checked).toBe(0);
+    expect(result.items).toHaveLength(0);
+  });
+
+  test("calls progress callbacks", async () => {
+    const { refreshContextItems } = await import(
+      "../../src/context/refresh.ts"
+    );
+    const filePath = join(tmpBase, "progress.md");
+    const item = await seedFileBackedItem({
+      filePath,
+      initialDiskContent: "changed",
+      storedContent: "original",
+      contextPath: "/docs/progress.md",
+    });
+
+    const itemProgress: Array<[number, number]> = [];
+    const embedProgress: Array<[number, number]> = [];
+
+    await refreshContextItems(
+      conn,
+      [item],
+      config,
+      null,
+      {
+        onItemProgress: (d, t) => itemProgress.push([d, t]),
+        onEmbedProgress: (d, t) => embedProgress.push([d, t]),
+      },
+      mockEmbed,
+    );
+
+    expect(itemProgress.at(-1)).toEqual([1, 1]);
+    expect(embedProgress.at(-1)).toEqual([1, 1]);
+  });
+});
+
+describe("refreshContextItems — error handling", () => {
+  test("records per-item error when source read throws", async () => {
+    const { refreshContextItems } = await import(
+      "../../src/context/refresh.ts"
+    );
+    // Point source_path at a directory; Bun.file().text() will throw when reading.
+    const item = await createContextItem(conn, {
+      title: "bad source",
+      content: "stored",
+      contextPath: "/docs/bad.md",
+      mimeType: "text/plain",
+      isTextual: true,
+      sourceType: "file",
+      sourcePath: tmpBase,
+    });
+
+    const result = await refreshContextItems(
+      conn,
+      [item],
+      config,
+      null,
+      {},
+      mockEmbed,
+    );
+
+    expect(result.updated).toBe(0);
+    const statuses = result.items.map((i) => i.status);
+    expect(statuses).toSatisfy(
+      (s) => s.includes("error") || s.includes("missing"),
+    );
+  });
+});

--- a/test/db/schema.test.ts
+++ b/test/db/schema.test.ts
@@ -35,7 +35,65 @@ describe("schema migrations", () => {
     )) as {
       count: number;
     };
-    expect(row.count).toBe(9);
+    expect(row.count).toBe(11);
+
+    db.close();
+  });
+
+  test("migration 10 rebuilds unique index on context_path", async () => {
+    const db = await getConnection();
+    await migrate(db);
+
+    // Inserting two rows with the same context_path must be blocked
+    await db.queryRun(
+      "INSERT INTO context_items (id, title, context_path) VALUES (?1, ?2, ?3)",
+      "a",
+      "first",
+      "/dup/path",
+    );
+
+    await expect(
+      db.queryRun(
+        "INSERT INTO context_items (id, title, context_path) VALUES (?1, ?2, ?3)",
+        "b",
+        "second",
+        "/dup/path",
+      ),
+    ).rejects.toThrow(/[Uu]nique/);
+
+    db.close();
+  });
+
+  test("migration 10 dedupes existing rows when re-applied", async () => {
+    const db = await getConnection();
+    await migrate(db);
+
+    // Force the broken state: drop the unique index, insert duplicates,
+    // remove the migration record so migrate() re-runs migration 10.
+    await db.exec("DROP INDEX IF EXISTS idx_context_items_context_path");
+    await db.queryRun(
+      "INSERT INTO context_items (id, title, context_path, updated_at) VALUES (?1, ?2, ?3, ?4)",
+      "older",
+      "old",
+      "/dup/x",
+      "2026-01-01 00:00:00",
+    );
+    await db.queryRun(
+      "INSERT INTO context_items (id, title, context_path, updated_at) VALUES (?1, ?2, ?3, ?4)",
+      "newer",
+      "new",
+      "/dup/x",
+      "2026-01-02 00:00:00",
+    );
+    await db.queryRun("DELETE FROM _migrations WHERE id = 10");
+
+    await migrate(db);
+
+    const rows = await db.queryAll<{ id: string }>(
+      "SELECT id FROM context_items WHERE context_path = ?1",
+      "/dup/x",
+    );
+    expect(rows.map((r) => r.id)).toEqual(["newer"]);
 
     db.close();
   });

--- a/test/tools/context-refresh.test.ts
+++ b/test/tools/context-refresh.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { contextRefreshTool } from "../../src/tools/context/refresh.ts";
+import type { ToolContext } from "../../src/tools/tool.ts";
+import { seedFile, setupToolContext } from "../helpers.ts";
+
+let ctx: ToolContext;
+let tmpBase: string;
+
+beforeEach(async () => {
+  ({ ctx } = await setupToolContext());
+  tmpBase = join(
+    tmpdir(),
+    `botholomew-refresh-tool-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  await Bun.write(join(tmpBase, ".keep"), "");
+});
+
+afterEach(async () => {
+  await rm(tmpBase, { recursive: true, force: true });
+});
+
+async function seedFileBackedItem(
+  filename: string,
+  diskContent: string,
+  storedContent: string,
+) {
+  const filePath = join(tmpBase, filename);
+  await Bun.write(filePath, diskContent);
+  const { createContextItem } = await import("../../src/db/context.ts");
+  return createContextItem(ctx.conn, {
+    title: filename,
+    content: storedContent,
+    contextPath: `/docs/${filename}`,
+    mimeType: "text/plain",
+    isTextual: true,
+    sourceType: "file",
+    sourcePath: filePath,
+  });
+}
+
+describe("context_refresh tool", () => {
+  test("errors when neither path nor all is provided", async () => {
+    const result = await contextRefreshTool.execute({}, ctx);
+    expect(result.is_error).toBe(true);
+    expect(result.message).toContain("path");
+    expect(result.message).toContain("all");
+  });
+
+  test("errors when both path and all are provided", async () => {
+    const result = await contextRefreshTool.execute(
+      { path: "/x", all: true },
+      ctx,
+    );
+    expect(result.is_error).toBe(true);
+    expect(result.message).toContain("mutually exclusive");
+  });
+
+  test("errors when path matches nothing", async () => {
+    const result = await contextRefreshTool.execute(
+      { path: "/no/such/thing" },
+      ctx,
+    );
+    expect(result.is_error).toBe(true);
+    expect(result.message).toContain("No context items");
+  });
+
+  test("returns informational success when matches have no source_path", async () => {
+    await seedFile(ctx.conn, "/hand-written.md", "written in virtual fs");
+    const result = await contextRefreshTool.execute(
+      { path: "/hand-written.md" },
+      ctx,
+    );
+    expect(result.is_error).toBe(false);
+    expect(result.checked).toBe(0);
+    expect(result.message).toContain("No matching items have a source_path");
+  });
+
+  test("updates a drifted file-backed item by path", async () => {
+    const item = await seedFileBackedItem(
+      "drift.md",
+      "new disk content",
+      "old stored content",
+    );
+    const result = await contextRefreshTool.execute({ path: item.id }, ctx);
+
+    expect(result.is_error).toBe(false);
+    expect(result.checked).toBe(1);
+    expect(result.updated).toBe(1);
+    expect(result.items[0]?.status).toBe("updated");
+  });
+
+  test("reports unchanged when disk matches stored content", async () => {
+    const item = await seedFileBackedItem("same.md", "identical", "identical");
+    const result = await contextRefreshTool.execute({ path: item.id }, ctx);
+
+    expect(result.is_error).toBe(false);
+    expect(result.unchanged).toBe(1);
+    expect(result.updated).toBe(0);
+  });
+
+  test("all: true refreshes every sourced item", async () => {
+    await seedFileBackedItem("a.md", "new a", "old a");
+    await seedFileBackedItem("b.md", "same b", "same b");
+    await seedFile(ctx.conn, "/no-source.md", "virtual fs only");
+
+    const result = await contextRefreshTool.execute({ all: true }, ctx);
+    expect(result.is_error).toBe(false);
+    expect(result.checked).toBe(2);
+    expect(result.updated).toBe(1);
+    expect(result.unchanged).toBe(1);
+  });
+
+  test("path prefix matches a subtree of sourced items", async () => {
+    await seedFileBackedItem("a.md", "new a", "old a");
+    await seedFileBackedItem("b.md", "new b", "old b");
+
+    const result = await contextRefreshTool.execute({ path: "/docs" }, ctx);
+    expect(result.is_error).toBe(false);
+    expect(result.checked).toBe(2);
+    expect(result.updated).toBe(2);
+  });
+
+  test("message surfaces embeddings_skipped when no OpenAI key", async () => {
+    await seedFileBackedItem("drift2.md", "new", "old");
+
+    const result = await contextRefreshTool.execute({ all: true }, ctx);
+    expect(result.is_error).toBe(false);
+    expect(result.updated).toBe(1);
+    expect(result.reembedded).toBe(0);
+    expect(result.embeddings_skipped).toBe(true);
+    expect(result.message).toContain("embeddings skipped");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `context_refresh` for daemon + chat (file/URL items, by path or UUID) backed by a shared `src/context/refresh.ts` helper; chat also gets `context_info` so it can look up items by ID. Closes #105.
- Migration 10 dedupes `context_items` rows and rebuilds the unique index on `context_path` (it was historically left non-enforcing by `CREATE UNIQUE INDEX IF NOT EXISTS`, letting duplicates accumulate and later crashing `@duckdb/node-api` during `UPDATE ... RETURNING *`).
- Migration 11 rebuilds the VSS HNSW vector index, which was corrupted by the same native crash and surfaced as `search_semantic` failing with "Duplicate keys not allowed in high-level wrappers".
- Defense in depth: `updateContextItem` / `updateContextItemContent` now do `UPDATE` + separate `SELECT` instead of `UPDATE ... RETURNING *`, avoiding the same class of native crash on any future corrupted-index states.

## Test plan

- [x] `bun run lint`
- [x] `bun test` (624 pass; added helper, tool, and migration tests)
- [x] Reproduced the original crash end-to-end, confirmed fix with `bun run src/cli.ts context refresh /plans` on the user's actual DB (9 items, 1 updated, 0 crashes)
- [ ] After merge, users with older DBs should verify `botholomew chat` → `search_semantic` works post-migration