### PR TITLE
Improve context_tree tool description to encourage discovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "An AI agent for knowledge work",
   "type": "module",
   "bin": {

--- a/src/tools/dir/tree.ts
+++ b/src/tools/dir/tree.ts
@@ -66,7 +66,7 @@ type TreeEntry = DirNode | FileNode;
 export const contextTreeTool = {
   name: "context_tree",
   description:
-    "Render a directory as a markdown-style tree. Use max_depth and items_per_dir to bound output; drill in by passing a deeper path.",
+    "Explore your context filesystem with a bird's-eye view — shows many paths across nested directories in one call. Reach for this first when you need to discover what content exists before reading a specific file (context_read) or running a keyword search (context_search). Returns a markdown-style tree; tune max_depth and items_per_dir to bound output, or pass a deeper path to drill into a subtree.",
   group: "context",
   inputSchema,
   outputSchema,


### PR DESCRIPTION
## Summary

- Rewrite the `context_tree` tool description so the LLM treats it as the default orientation move — discovering what content exists before committing to a `context_read` or `context_search`.
- Bump version to `0.7.3`.

## Test plan

- [x] `bun run lint` passes
- [x] `bun test test/tools/dir.test.ts` passes (16/16)