### PR TITLE
Add timestamps and lifecycle phase markers to daemon logs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,6 +52,19 @@ immediately — so a backlog drains as fast as the LLM can process it.
 
 See `src/daemon/tick.ts`.
 
+### Log format
+
+Daemon logs (both foreground stdout and `.botholomew/daemon.log`) prefix
+every line with a local `HH:MM:SS` timestamp. Lifecycle phases render as
+`[[phase-name]]` in bold magenta so they're easy to scan and grep
+(`grep '\[\[' daemon.log`). Phases emitted each tick:
+
+- `[[tick-start]] #N`
+- `[[evaluating-schedules]]` (only when any are enabled)
+- `[[claiming-task]]`
+- `[[tick-end]] #N Xs didWork=true|false`
+- `[[sleeping]] Ns` (only when there was no work)
+
 ---
 
 ## The chat TUI

--- a/docs/watchdog.md
+++ b/docs/watchdog.md
@@ -47,6 +47,14 @@ botholomew daemon uninstall    # remove the watchdog
 A separate watchdog log (`.botholomew/watchdog.log`) records every
 invocation so you can see exactly when restarts happened.
 
+Every `daemon.log` line is prefixed with a local `HH:MM:SS` timestamp, and
+lifecycle phases are rendered as `[[phase-name]]` (e.g. `[[tick-start]]`,
+`[[claiming-task]]`, `[[sleeping]]`). To jump straight to phase boundaries:
+
+```
+grep '\[\[' .botholomew/daemon.log
+```
+
 ---
 
 ## Why not `KeepAlive: true`?

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Local, autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -75,18 +75,30 @@ export async function startDaemon(
     ? buildForegroundCallbacks()
     : undefined;
 
-  logger.info(`Daemon started for ${projectDir} (PID ${process.pid})`);
+  logger.info(
+    `Daemon started ${new Date().toISOString()} for ${projectDir} (PID ${process.pid})`,
+  );
   logger.info(`Tick interval: ${config.tick_interval_seconds}s`);
 
+  let tickNum = 0;
   while (true) {
+    tickNum++;
     let didWork = false;
     try {
-      didWork = await tick(projectDir, conn, config, mcpxClient, callbacks);
+      didWork = await tick(
+        projectDir,
+        conn,
+        config,
+        mcpxClient,
+        callbacks,
+        tickNum,
+      );
     } catch (err) {
       logger.error(`Tick failed: ${err}`);
     }
 
     if (!didWork) {
+      logger.phase("sleeping", `${config.tick_interval_seconds}s`);
       await Bun.sleep(config.tick_interval_seconds * 1000);
     }
   }

--- a/src/daemon/tick.ts
+++ b/src/daemon/tick.ts
@@ -1,6 +1,7 @@
 import type { McpxClient } from "@evantahler/mcpx";
 import type { BotholomewConfig } from "../config/schemas.ts";
 import type { DbConnection } from "../db/connection.ts";
+import { listSchedules } from "../db/schedules.ts";
 import {
   claimNextTask,
   resetStaleTasks,
@@ -20,8 +21,10 @@ export async function tick(
   config: Required<BotholomewConfig>,
   mcpxClient?: McpxClient | null,
   callbacks?: DaemonStreamCallbacks,
+  tickNum = 1,
 ): Promise<boolean> {
-  logger.debug("Tick starting...");
+  const tickStart = Date.now();
+  logger.phase("tick-start", `#${tickNum}`);
 
   // Reset stale tasks stuck in in_progress
   const resetIds = await resetStaleTasks(
@@ -35,20 +38,27 @@ export async function tick(
   }
 
   // Process schedules (may create new tasks)
-  try {
-    await processSchedules(conn, config);
-  } catch (err) {
-    logger.error(`Schedule processing failed: ${err}`);
+  const enabledSchedules = await listSchedules(conn, { enabled: true });
+  if (enabledSchedules.length > 0) {
+    logger.phase("evaluating-schedules", `${enabledSchedules.length} enabled`);
+    try {
+      await processSchedules(conn, config);
+    } catch (err) {
+      logger.error(`Schedule processing failed: ${err}`);
+    }
   }
 
   // Claim a task
+  logger.phase("claiming-task");
   const task = await claimNextTask(conn);
   if (!task) {
-    logger.debug("No tasks to work on. Sleeping.");
+    logger.info("No task claimed (queue empty or all blocked)");
+    const elapsed = ((Date.now() - tickStart) / 1000).toFixed(1);
+    logger.phase("tick-end", `#${tickNum} ${elapsed}s didWork=false`);
     return false;
   }
 
-  logger.info(`Working on task: ${task.name} (${task.id})`);
+  logger.info(`Claimed task: ${task.name} (${task.id})`);
   callbacks?.onTaskStart(task);
 
   // Create a thread for this tick
@@ -114,6 +124,9 @@ export async function tick(
   } finally {
     await endThread(conn, threadId);
   }
+
+  const elapsed = ((Date.now() - tickStart) / 1000).toFixed(1);
+  logger.phase("tick-end", `#${tickNum} ${elapsed}s didWork=true`);
 
   return true;
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,29 +1,42 @@
 import ansis from "ansis";
 
+function ts(): string {
+  return ansis.gray(new Date().toTimeString().slice(0, 8));
+}
+
 export const logger = {
   info(msg: string) {
-    console.log(ansis.blue("ℹ"), msg);
+    console.log(ts(), ansis.blue("ℹ"), msg);
   },
 
   success(msg: string) {
-    console.log(ansis.green("✓"), msg);
+    console.log(ts(), ansis.green("✓"), msg);
   },
 
   warn(msg: string) {
-    console.log(ansis.yellow("⚠"), msg);
+    console.log(ts(), ansis.yellow("⚠"), msg);
   },
 
   error(msg: string) {
-    console.error(ansis.red("✗"), msg);
+    console.error(ts(), ansis.red("✗"), msg);
   },
 
   debug(msg: string) {
     if (process.env.BOTHOLOMEW_DEBUG) {
-      console.log(ansis.gray("·"), ansis.gray(msg));
+      console.log(ts(), ansis.gray("·"), ansis.gray(msg));
     }
   },
 
   dim(msg: string) {
-    console.log(ansis.dim(msg));
+    console.log(ts(), ansis.dim(msg));
+  },
+
+  phase(name: string, detail?: string) {
+    const tag = ansis.magenta.bold(`[[${name}]]`);
+    if (detail) {
+      console.log(ts(), tag, ansis.dim(detail));
+    } else {
+      console.log(ts(), tag);
+    }
   },
 };

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -65,6 +65,7 @@ export const silentLogger = {
     error: () => {},
     debug: () => {},
     dim: () => {},
+    phase: () => {},
   },
 };
 


### PR DESCRIPTION
## Summary

- Every `logger` line now prefixes a gray local `HH:MM:SS` (for both `.botholomew/daemon.log` and foreground stdout); the startup banner still carries the full ISO date.
- New `logger.phase(name, detail?)` renders lifecycle markers as bold-magenta `[[phase-name]]`, wired into the tick loop at `tick-start`, `evaluating-schedules`, `claiming-task`, `tick-end`, and `sleeping`. After claiming we explicitly log whether a task was picked up or the queue was empty, so stalls are obvious.
- Docs (`architecture.md`, `watchdog.md`) updated with the format and the `grep '\[\[' daemon.log` trick; `silentLogger` in tests gets a `phase` no-op; version bumped to 0.7.7.

## Test plan

- [x] `bun run lint`
- [x] `bun test` (651/651 pass)
- [x] Smoke-tested logger output end-to-end