### PR TITLE
Add LLM-suggested paths and fail-loud collision handling for context add

### DIFF
--- a/docs/context-and-search.md
+++ b/docs/context-and-search.md
@@ -134,8 +134,11 @@ LLM-driven loading agent that handles URLs.
 ### Local files and folders
 
 ```bash
+# LLM picks a folder for each file based on content + existing structure
 botholomew context add ./notes
 botholomew context add ./report.pdf
+
+# Explicit placement under a prefix (no LLM call)
 botholomew context add ~/Documents/strategy --prefix /strategy
 ```
 
@@ -143,10 +146,50 @@ botholomew context add ~/Documents/strategy --prefix /strategy
 feeds every file through the ingestion pipeline (item → chunks →
 embeddings). Binary files (PDFs, images) are stored in `content_blob`
 with `is_textual = false`; textual files are indexed for hybrid search.
-Re-running `context add` on the same path upserts — it replaces the
-stored content and re-embeds, so running it on a cron keeps a folder
-mirrored. Items are stored with `source_type = 'file'` and their
-original absolute path in `source_path`.
+Items are stored with `source_type = 'file'` and their original
+absolute path in `source_path`.
+
+### Path placement
+
+There are two ways `context add` decides where a file lives in the
+virtual filesystem:
+
+- **Explicit** — pass `--prefix <prefix>` (or `--name <path>` for a
+  single URL) and the path is derived mechanically (`{prefix}/{basename}`
+  for single files, `{prefix}/{relative-path}` for directory walks).
+  Same behavior as before.
+- **LLM-suggested** (default when `--prefix`/`--name` aren't passed) —
+  a single `return_description_and_path` tool-use call produces both a
+  description and an absolute folder path per file. The LLM is primed
+  with the file's basename, a content excerpt, its source filesystem
+  path (for disambiguation when basenames collide — e.g. two projects
+  each with a `README.md`), and a summary of existing folders so it
+  classifies into the current structure instead of inventing new ones.
+
+  In a TTY, the suggestions are printed and you confirm with `Y`/`n`
+  (default accepts — just hit Enter). Pass `--auto-place` to skip the
+  prompt; non-TTY invocations (pipes, scripts) accept automatically.
+
+### Collision handling
+
+Every context item is keyed by a unique `context_path`. When a write
+targets an existing path, the policy is controlled by `--on-conflict`:
+
+| Policy      | Behavior                                                                 |
+| ----------- | ------------------------------------------------------------------------ |
+| `error` *(default)* | Skip the colliding item, keep going through the batch, and exit with a non-zero status listing every collision. |
+| `overwrite` | Replace the existing item and re-embed (the original pre-0.7.7 default). |
+| `skip`      | Log and move on — no write, no error.                                    |
+
+Re-running `context add` on the same path with the default policy is
+now a loud error rather than a silent overwrite. Use
+`--on-conflict=overwrite` when you genuinely want to refresh stored
+content (or `botholomew context refresh` for the idiomatic flow).
+
+The agent-side `context_write` tool follows the same convention:
+defaults to `on_conflict='error'` and returns a PATs-style
+`error_type: "path_conflict"` with a `next_action_hint` that guides the
+agent to `context_read` first or pass `on_conflict='overwrite'`.
 
 ### Remote content via a loading agent
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -85,7 +85,8 @@ schema to the Anthropic SDK's `Tool` type using `z.toJSONSchema()`:
 ```ts
 {
   name: "context_write",
-  description: "Create or overwrite a file in the virtual filesystem.",
+  description:
+    "Write content to a context item. By default, fails if the path already exists — pass on_conflict='overwrite' to replace.",
   input_schema: {
     type: "object",
     properties: { /* derived from Zod */ },
@@ -93,6 +94,11 @@ schema to the Anthropic SDK's `Tool` type using `z.toJSONSchema()`:
   }
 }
 ```
+
+`context_write` accepts an optional `on_conflict: "error" | "overwrite"`
+input (default `"error"`). A collision returns `is_error: true`,
+`error_type: "path_conflict"`, and a `next_action_hint` that steers the
+model back to `context_read` or a retry with `on_conflict='overwrite'`.
 
 `runAgentLoop()` feeds this array into `client.messages.create({ tools:
 ... })`. When the model emits a `tool_use` block, the loop looks up the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Local, autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -6,7 +6,10 @@ import { isText } from "istextorbinary";
 import { createSpinner } from "nanospinner";
 import { loadConfig } from "../config/loader.ts";
 import type { BotholomewConfig } from "../config/schemas.ts";
-import { generateDescription } from "../context/describer.ts";
+import {
+  generateDescription,
+  generateDescriptionAndPath,
+} from "../context/describer.ts";
 import { embedSingle } from "../context/embedder.ts";
 import { FetchFailureError, fetchUrl } from "../context/fetcher.ts";
 import {
@@ -19,9 +22,12 @@ import { isUrl, urlToContextPath } from "../context/url-utils.ts";
 import type { DbConnection } from "../db/connection.ts";
 import {
   type ContextItem,
+  createContextItemStrict,
   deleteContextItemByPath,
+  getContextItemByPath,
   listContextItems,
   listContextItemsByPrefix,
+  PathConflictError,
   resolveContextItem,
   upsertContextItem,
 } from "../db/context.ts";
@@ -95,16 +101,41 @@ export function registerContextCommand(program: Command) {
   ctx
     .command("add <paths...>")
     .description("Add files, directories, or URLs to context")
-    .option("--prefix <prefix>", "virtual path prefix", "/")
+    .option(
+      "--prefix <prefix>",
+      "virtual path prefix (if omitted, an LLM suggests a folder for each file)",
+    )
     .option("--name <path>", "custom context path (single URL only)")
+    .option(
+      "--on-conflict <policy>",
+      "collision policy: error | overwrite | skip",
+      "error",
+    )
+    .option(
+      "--auto-place",
+      "accept all LLM-suggested paths without confirmation",
+    )
     .option(
       "--prompt-addition <text>",
       "extra guidance for the URL fetcher agent (e.g., auth notes, tool hints)",
     )
     .action((paths: string[], opts) =>
       withDb(program, async (conn, dir) => {
+        type ConflictPolicy = "error" | "overwrite" | "skip";
+        const policy = opts.onConflict as ConflictPolicy;
+        if (!["error", "overwrite", "skip"].includes(policy)) {
+          logger.error(
+            `Invalid --on-conflict value: ${policy} (must be error, overwrite, or skip)`,
+          );
+          process.exit(1);
+        }
+
         // Phase 1: Scan all paths — separate URLs from local files
-        const filesToAdd: { filePath: string; contextPath: string }[] = [];
+        type FileToAdd = {
+          filePath: string;
+          contextPath: string | null; // null = defer to LLM placement
+        };
+        const filesToAdd: FileToAdd[] = [];
         const urlsToAdd: { url: string; contextPath: string }[] = [];
         const spinner = createSpinner("Scanning paths...").start();
 
@@ -116,10 +147,14 @@ export function registerContextCommand(program: Command) {
           process.exit(1);
         }
 
+        // Explicit placement: user passed --prefix (or --name for URLs).
+        // Implicit placement: LLM decides per-file.
+        const explicitPlacement = typeof opts.prefix === "string";
+        const urlPrefix = opts.prefix ?? "/";
+
         for (const path of paths) {
           if (isUrl(path)) {
-            const contextPath =
-              opts.name || urlToContextPath(path, opts.prefix);
+            const contextPath = opts.name || urlToContextPath(path, urlPrefix);
             urlsToAdd.push({ url: path, contextPath });
           } else {
             const resolvedPath = resolve(path);
@@ -137,13 +172,17 @@ export function registerContextCommand(program: Command) {
                 const relativePath = filePath.slice(resolvedPath.length);
                 filesToAdd.push({
                   filePath,
-                  contextPath: join(opts.prefix, relativePath),
+                  contextPath: explicitPlacement
+                    ? join(opts.prefix, relativePath)
+                    : null,
                 });
               }
             } else {
               filesToAdd.push({
                 filePath: resolvedPath,
-                contextPath: join(opts.prefix, basename(resolvedPath)),
+                contextPath: explicitPlacement
+                  ? join(opts.prefix, basename(resolvedPath))
+                  : null,
               });
             }
           }
@@ -154,11 +193,78 @@ export function registerContextCommand(program: Command) {
           text: `Found ${totalCount} item(s) to add (${filesToAdd.length} file(s), ${urlsToAdd.length} URL(s)).`,
         });
 
-        // Phase 2: Load config and upsert DB records (batched, parallel LLM descriptions)
+        // Phase 1.5: LLM placement for files without an explicit path
         const config = await loadConfig(dir);
         const CONCURRENCY = 10;
+        const needsPlacement = filesToAdd.filter((f) => f.contextPath === null);
+        // description cache keyed by filePath — populated when LLM placement runs,
+        // reused in addFile to avoid a second describe call.
+        const descriptionCache = new Map<string, string>();
+
+        if (needsPlacement.length > 0) {
+          if (!config.anthropic_api_key) {
+            logger.error(
+              "No anthropic_api_key configured — cannot auto-place files. Pass --prefix to specify a folder.",
+            );
+            process.exit(1);
+          }
+
+          const existingTree = await renderExistingTree(conn);
+          const placeSpinner = createSpinner(
+            `Choosing paths for 0/${needsPlacement.length} file(s)...`,
+          ).start();
+          let placed = 0;
+
+          for (let i = 0; i < needsPlacement.length; i += CONCURRENCY) {
+            const batch = needsPlacement.slice(i, i + CONCURRENCY);
+            await Promise.all(
+              batch.map(async (entry) => {
+                const suggestion = await suggestPathForFile(
+                  entry.filePath,
+                  config,
+                  existingTree,
+                );
+                entry.contextPath =
+                  suggestion?.suggested_path ?? `/${basename(entry.filePath)}`;
+                if (suggestion?.description) {
+                  descriptionCache.set(entry.filePath, suggestion.description);
+                }
+                placed++;
+                placeSpinner.update({
+                  text: `Choosing paths for ${placed}/${needsPlacement.length} file(s)...`,
+                });
+              }),
+            );
+          }
+          placeSpinner.success({
+            text: `Chose paths for ${placed} file(s).`,
+          });
+
+          // Confirm in TTY unless --auto-place
+          const isTTY = Boolean(process.stdin.isTTY && process.stdout.isTTY);
+          if (isTTY && !opts.autoPlace) {
+            console.log("");
+            console.log(ansis.bold("Suggested paths:"));
+            for (const entry of needsPlacement) {
+              console.log(
+                `  ${ansis.dim(entry.filePath)} → ${ansis.cyan(entry.contextPath ?? "")}`,
+              );
+            }
+            const accepted = await confirmYesNo("Accept these paths? (Y/n): ");
+            if (!accepted) {
+              logger.warn(
+                "Aborted. Re-run with --prefix to place files manually, or --auto-place to skip this prompt.",
+              );
+              process.exit(1);
+            }
+          }
+        }
+
+        // Phase 2: Upsert DB records (batched, parallel LLM descriptions)
         let addCompleted = 0;
         const itemIds: { id: string; contextPath: string }[] = [];
+        const conflicts: { contextPath: string; existingId: string }[] = [];
+        const skipped: string[] = [];
 
         // Process local files (with spinner — these are quick, no chatty logs)
         if (filesToAdd.length > 0) {
@@ -170,21 +276,34 @@ export function registerContextCommand(program: Command) {
             const batch = filesToAdd.slice(i, i + CONCURRENCY);
             const results = await Promise.all(
               batch.map(async ({ filePath, contextPath }) => {
+                if (contextPath === null) return null; // unreachable — placement filled it
                 const result = await addFile(
                   conn,
                   filePath,
                   contextPath,
                   config,
+                  policy,
+                  descriptionCache.get(filePath),
                 );
                 addCompleted++;
                 fileSpinner.update({
                   text: `Adding and describing ${addCompleted}/${filesToAdd.length} file(s)...`,
                 });
-                return result ? { id: result, contextPath } : null;
+                return result;
               }),
             );
             for (const r of results) {
-              if (r) itemIds.push(r);
+              if (!r) continue;
+              if (r.kind === "added") {
+                itemIds.push({ id: r.id, contextPath: r.contextPath });
+              } else if (r.kind === "conflict") {
+                conflicts.push({
+                  contextPath: r.contextPath,
+                  existingId: r.existingId,
+                });
+              } else if (r.kind === "skipped") {
+                skipped.push(r.contextPath);
+              }
             }
           }
 
@@ -216,11 +335,25 @@ export function registerContextCommand(program: Command) {
               contextPath,
               mcpxClient,
               opts.promptAddition,
+              policy,
             );
             if (result.ok) {
               urlAdded++;
               itemIds.push({ id: result.id, contextPath });
               console.log(`  ${ansis.green("✔")} stored at ${contextPath}`);
+            } else if (result.kind === "conflict") {
+              conflicts.push({
+                contextPath,
+                existingId: result.existingId,
+              });
+              console.log(
+                `  ${ansis.red("✗")} path already exists: ${contextPath}`,
+              );
+            } else if (result.kind === "skipped") {
+              skipped.push(contextPath);
+              console.log(
+                `  ${ansis.yellow("⊘")} skipped (path exists): ${contextPath}`,
+              );
             } else if (result.actionable) {
               console.log(
                 `  ${ansis.red("✗")} ${ansis.bold("action required:")}`,
@@ -245,13 +378,32 @@ export function registerContextCommand(program: Command) {
           }
         }
 
+        // Report conflicts before embeddings so the user sees them prominently
+        if (conflicts.length > 0) {
+          logger.error(
+            `${conflicts.length} path collision(s) — nothing written for these items:`,
+          );
+          for (const c of conflicts) {
+            console.log(
+              `  ${ansis.red("✗")} ${c.contextPath} (existing id: ${c.existingId})`,
+            );
+          }
+          logger.dim(
+            "Re-run with --on-conflict=overwrite to replace, --on-conflict=skip to ignore, or --name / --prefix to place elsewhere.",
+          );
+        }
+
         // Phase 3: Chunk + embed in parallel (network I/O)
         if (itemIds.length === 0 || !config.openai_api_key) {
           if (!config.openai_api_key) {
             logger.dim("Skipping embeddings (no OpenAI API key configured).");
           }
           const msg = `Added ${itemIds.length}/${totalCount} item(s), 0 chunks indexed.`;
-          if (itemIds.length === totalCount) {
+          if (conflicts.length > 0) {
+            logger.error(msg);
+            process.exit(1);
+          }
+          if (itemIds.length === totalCount - skipped.length) {
             logger.success(msg);
             process.exit(0);
           } else if (itemIds.length === 0) {
@@ -304,7 +456,11 @@ export function registerContextCommand(program: Command) {
         if (filesAdded > 0) parts.push(`${filesAdded} added`);
         if (filesUpdated > 0) parts.push(`${filesUpdated} updated`);
         const summary = `${parts.join(", ")} — ${chunks} chunk(s) indexed (${itemIds.length}/${totalCount} item(s)).`;
-        if (itemIds.length === totalCount) {
+        if (conflicts.length > 0) {
+          logger.error(summary);
+          process.exit(1);
+        }
+        if (itemIds.length === totalCount - skipped.length) {
           logger.success(summary);
           process.exit(0);
         } else {
@@ -517,28 +673,56 @@ async function resolveItems(
   return listContextItemsByPrefix(conn, p, { recursive: true });
 }
 
-/** Upsert a file into context. Returns the item ID if textual, null otherwise. */
+type ConflictPolicy = "error" | "overwrite" | "skip";
+
+type AddFileResult =
+  | { kind: "added"; id: string; contextPath: string }
+  | { kind: "skipped"; contextPath: string }
+  | { kind: "conflict"; contextPath: string; existingId: string }
+  | { kind: "failed"; contextPath: string; error: string };
+
+/** Upsert a file into context honoring the collision policy. */
 async function addFile(
   conn: DbConnection,
   filePath: string,
   contextPath: string,
   config: Required<BotholomewConfig>,
-): Promise<string | null> {
+  policy: ConflictPolicy,
+  cachedDescription?: string,
+): Promise<AddFileResult | null> {
   try {
+    // Pre-flight conflict check so we don't waste a describe call.
+    if (policy !== "overwrite") {
+      const existing = await getContextItemByPath(conn, contextPath);
+      if (existing) {
+        if (policy === "skip") {
+          logger.dim(`  ⊘ skipped (path exists): ${contextPath}`);
+          return { kind: "skipped", contextPath };
+        }
+        return {
+          kind: "conflict",
+          contextPath,
+          existingId: existing.id,
+        };
+      }
+    }
+
     const bunFile = Bun.file(filePath);
     const mimeType = bunFile.type.split(";")[0] || "application/octet-stream";
     const filename = basename(filePath);
     const textual = isText(filename) !== false;
     const content = textual ? await bunFile.text() : null;
 
-    const description = await generateDescription(config, {
-      filename,
-      mimeType,
-      content,
-      filePath,
-    });
+    const description =
+      cachedDescription ??
+      (await generateDescription(config, {
+        filename,
+        mimeType,
+        content,
+        filePath,
+      }));
 
-    const item = await upsertContextItem(conn, {
+    const itemParams = {
       title: filename,
       description,
       content: content ?? undefined,
@@ -546,19 +730,36 @@ async function addFile(
       sourcePath: filePath,
       contextPath,
       isTextual: textual,
-    });
+    } as const;
 
-    return textual && content ? item.id : null;
+    const item =
+      policy === "overwrite"
+        ? await upsertContextItem(conn, itemParams)
+        : await createContextItemStrict(conn, itemParams);
+
+    return textual && content
+      ? { kind: "added", id: item.id, contextPath: item.context_path }
+      : null;
   } catch (err) {
+    if (err instanceof PathConflictError) {
+      // Race between pre-flight check and insert — still a conflict.
+      return {
+        kind: "conflict",
+        contextPath,
+        existingId: err.existingId,
+      };
+    }
     logger.warn(`  ! ${contextPath}: ${err}`);
-    return null;
+    return { kind: "failed", contextPath, error: String(err) };
   }
 }
 
-/** Fetch a URL and upsert into context. Returns the item ID, or null on failure. */
+/** Fetch a URL and upsert into context. */
 type AddUrlResult =
   | { ok: true; id: string }
-  | { ok: false; error: string; actionable: boolean };
+  | { ok: false; kind: "conflict"; existingId: string }
+  | { ok: false; kind: "skipped" }
+  | { ok: false; kind: "fetch-failed"; error: string; actionable: boolean };
 
 async function addUrl(
   conn: DbConnection,
@@ -566,8 +767,18 @@ async function addUrl(
   url: string,
   contextPath: string,
   mcpxClient: Awaited<ReturnType<typeof createMcpxClient>>,
-  promptAddition?: string,
+  promptAddition: string | undefined,
+  policy: ConflictPolicy,
 ): Promise<AddUrlResult> {
+  // Pre-flight conflict check — skip the expensive fetch if we'd collide.
+  if (policy !== "overwrite") {
+    const existing = await getContextItemByPath(conn, contextPath);
+    if (existing) {
+      if (policy === "skip") return { ok: false, kind: "skipped" };
+      return { ok: false, kind: "conflict", existingId: existing.id };
+    }
+  }
+
   try {
     const fetched = await fetchUrl(url, config, mcpxClient, promptAddition);
 
@@ -577,24 +788,115 @@ async function addUrl(
       content: fetched.content,
     });
 
-    const item = await upsertContextItem(conn, {
+    const itemParams = {
       title: fetched.title,
       description,
       content: fetched.content,
       mimeType: fetched.mimeType,
-      sourceType: "url",
+      sourceType: "url" as const,
       sourcePath: url,
       contextPath,
       isTextual: true,
-    });
+    };
+
+    const item =
+      policy === "overwrite"
+        ? await upsertContextItem(conn, itemParams)
+        : await createContextItemStrict(conn, itemParams);
 
     return { ok: true, id: item.id };
   } catch (err) {
-    if (err instanceof FetchFailureError) {
-      return { ok: false, error: err.userMessage, actionable: true };
+    if (err instanceof PathConflictError) {
+      return { ok: false, kind: "conflict", existingId: err.existingId };
     }
-    return { ok: false, error: String(err), actionable: false };
+    if (err instanceof FetchFailureError) {
+      return {
+        ok: false,
+        kind: "fetch-failed",
+        error: err.userMessage,
+        actionable: true,
+      };
+    }
+    return {
+      ok: false,
+      kind: "fetch-failed",
+      error: String(err),
+      actionable: false,
+    };
   }
+}
+
+/**
+ * Build a listing of every existing path (folders + files) to feed the LLM
+ * placer. Seeing actual files in each folder helps the LLM place new content
+ * alongside similar documents instead of inventing parallel folder names.
+ */
+async function renderExistingTree(conn: DbConnection): Promise<string> {
+  const items = await listContextItems(conn);
+  if (items.length === 0) return "";
+
+  // Every implicit ancestor folder of every item.
+  const folders = new Set<string>();
+  for (const item of items) {
+    const parts = item.context_path.split("/").filter(Boolean);
+    const isExplicitDir = item.mime_type === "inode/directory";
+    const folderDepth = isExplicitDir ? parts.length : parts.length - 1;
+    for (let i = 1; i <= folderDepth; i++) {
+      folders.add(`/${parts.slice(0, i).join("/")}/`);
+    }
+  }
+
+  const files = items
+    .filter((i) => i.mime_type !== "inode/directory")
+    .map((i) => i.context_path);
+
+  const all = [...folders, ...files].sort();
+  const cap = 500;
+  const truncated = all.slice(0, cap);
+  const suffix =
+    all.length > cap ? `\n  (+${all.length - cap} more entries)` : "";
+  return truncated.map((p) => `  ${p}`).join("\n") + suffix;
+}
+
+/** Call the describer LLM to suggest a path + description for a file. */
+async function suggestPathForFile(
+  filePath: string,
+  config: Required<BotholomewConfig>,
+  existingTree: string,
+): Promise<{ description: string; suggested_path: string } | null> {
+  try {
+    const bunFile = Bun.file(filePath);
+    const mimeType = bunFile.type.split(";")[0] || "application/octet-stream";
+    const filename = basename(filePath);
+    const textual = isText(filename) !== false;
+    const content = textual ? await bunFile.text() : null;
+    return await generateDescriptionAndPath(config, {
+      filename,
+      mimeType,
+      content,
+      filePath,
+      sourcePath: filePath,
+      existingTree,
+    });
+  } catch {
+    return null;
+  }
+}
+
+/** Minimal stdin-based yes/no prompt, defaults to yes (empty input accepts). */
+async function confirmYesNo(prompt: string): Promise<boolean> {
+  process.stdout.write(prompt);
+  return new Promise((resolvePromise) => {
+    const onData = (chunk: Buffer) => {
+      const line = chunk.toString().trim().toLowerCase();
+      process.stdin.off("data", onData);
+      process.stdin.pause();
+      // Empty input (just Enter) or y/yes → accept; only n/no rejects.
+      resolvePromise(line !== "n" && line !== "no");
+    };
+    process.stdin.resume();
+    process.stdin.once("data", onData);
+  });
 }
 
 async function walkDirectory(dirPath: string): Promise<string[]> {

--- a/src/context/describer.ts
+++ b/src/context/describer.ts
@@ -3,6 +3,8 @@ import type { BotholomewConfig } from "../config/schemas.ts";
 import { logger } from "../utils/logger.ts";
 
 const DESCRIBE_TOOL_NAME = "return_description";
+const DESCRIBE_AND_PLACE_TOOL_NAME = "return_description_and_path";
+
 const DESCRIBE_TOOL = {
   name: DESCRIBE_TOOL_NAME,
   description: "Return a one-sentence description of this content.",
@@ -16,6 +18,28 @@ const DESCRIBE_TOOL = {
       },
     },
     required: ["description"],
+  },
+};
+
+const DESCRIBE_AND_PLACE_TOOL = {
+  name: DESCRIBE_AND_PLACE_TOOL_NAME,
+  description:
+    "Return a one-sentence description AND a suggested absolute folder path for this file.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      description: {
+        type: "string",
+        description:
+          "A concise one-sentence summary of what this content is about.",
+      },
+      suggested_path: {
+        type: "string",
+        description:
+          "Absolute virtual-filesystem path (starts with /) where this file should live, including the filename. Prefer existing folders. Include a project/source disambiguator (e.g. /projects/<source-dir>/README.md) when the basename is likely to collide.",
+      },
+    },
+    required: ["description", "suggested_path"],
   },
 };
 
@@ -38,8 +62,27 @@ type ImageMediaType = "image/jpeg" | "image/png" | "image/gif" | "image/webp";
  */
 async function buildMessageContent(
   opts: DescriberOpts,
+  includePlacement: boolean,
 ): Promise<Anthropic.Messages.ContentBlockParam[]> {
-  const textPrompt = `Describe this file in one sentence. Be specific about what it contains, not generic.\n\nFilename: ${opts.filename}\nMIME type: ${opts.mimeType}`;
+  const placementBlock = includePlacement
+    ? [
+        "",
+        "Also suggest an absolute folder path where this file should live in the virtual filesystem. Rules:",
+        "- Start with /",
+        "- Keep the basename close to the source filename",
+        "- STRONGLY prefer folders that already exist below — reuse them unless the new file is clearly unrelated to everything there. Do NOT invent a new folder that is a near-synonym of an existing one.",
+        "- Use at most 3 nested folders unless an existing folder already goes deeper",
+        "- If the basename is common (README.md, index.md, notes.md), include a project/source disambiguator from the source path",
+        opts.existingTree
+          ? `\nExisting filesystem (folders end with /, files are listed under the folders they live in so you can see what kinds of documents are already there):\n${opts.existingTree}`
+          : "\nExisting filesystem: (empty — you are placing the first file)",
+        opts.sourcePath ? `\nSource filesystem path: ${opts.sourcePath}` : "",
+      ]
+        .filter((s) => s.length > 0)
+        .join("\n")
+    : "";
+
+  const textPrompt = `Describe this file in one sentence. Be specific about what it contains, not generic.\n\nFilename: ${opts.filename}\nMIME type: ${opts.mimeType}${placementBlock ? `\n${placementBlock}` : ""}`;
 
   // Text file — include content inline
   if (opts.content) {
@@ -98,6 +141,20 @@ interface DescriberOpts {
   mimeType: string;
   content: string | null;
   filePath?: string;
+  sourcePath?: string;
+  existingTree?: string;
+}
+
+/** Normalize and validate an LLM-suggested path. Returns null if invalid. */
+export function sanitizeSuggestedPath(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  if (!trimmed.startsWith("/")) return null;
+  if (trimmed.includes("..")) return null;
+  // Collapse repeated slashes, strip trailing slash (unless root).
+  const collapsed = trimmed.replace(/\/+/g, "/");
+  if (collapsed === "/") return null; // needs a filename
+  return collapsed.endsWith("/") ? collapsed.slice(0, -1) : collapsed;
 }
 
 /**
@@ -116,7 +173,7 @@ export async function generateDescription(
   const client = new Anthropic({ apiKey: config.anthropic_api_key });
 
   try {
-    const content = await buildMessageContent(opts);
+    const content = await buildMessageContent(opts, false);
 
     const response = await Promise.race([
       client.messages.create({
@@ -142,5 +199,57 @@ export async function generateDescription(
   } catch (err) {
     logger.debug(`Description generation failed: ${err}`);
     return "";
+  }
+}
+
+/**
+ * Generate description + suggested_path in a single LLM call.
+ * Returns { description, suggested_path } on success, or null on failure.
+ */
+export async function generateDescriptionAndPath(
+  config: Required<BotholomewConfig>,
+  opts: DescriberOpts,
+): Promise<{ description: string; suggested_path: string } | null> {
+  if (!config.anthropic_api_key) return null;
+
+  const client = new Anthropic({ apiKey: config.anthropic_api_key });
+
+  try {
+    const content = await buildMessageContent(opts, true);
+
+    const response = await Promise.race([
+      client.messages.create({
+        model: config.chunker_model,
+        max_tokens: 512,
+        tools: [DESCRIBE_AND_PLACE_TOOL],
+        tool_choice: { type: "tool", name: DESCRIBE_AND_PLACE_TOOL_NAME },
+        messages: [{ role: "user", content }],
+      }),
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () => reject(new Error("Description+path generation timeout")),
+          TIMEOUT_MS,
+        ),
+      ),
+    ]);
+
+    const toolBlock = response.content.find((b) => b.type === "tool_use");
+    if (!toolBlock || toolBlock.type !== "tool_use") return null;
+
+    const input = toolBlock.input as {
+      description?: string;
+      suggested_path?: string;
+    };
+    const suggested = input.suggested_path
+      ? sanitizeSuggestedPath(input.suggested_path)
+      : null;
+    if (!suggested) return null;
+    return {
+      description: input.description || "",
+      suggested_path: suggested,
+    };
+  } catch (err) {
+    logger.debug(`Description+path generation failed: ${err}`);
+    return null;
   }
 }

--- a/src/db/context.ts
+++ b/src/db/context.ts
@@ -56,6 +56,17 @@ function rowToContextItem(row: ContextItemRow): ContextItem {
   };
 }
 
+export class PathConflictError extends Error {
+  existingId: string;
+  contextPath: string;
+  constructor(existingId: string, contextPath: string) {
+    super(`context_path already exists: ${contextPath}`);
+    this.name = "PathConflictError";
+    this.existingId = existingId;
+    this.contextPath = contextPath;
+  }
+}
+
 // --- Basic CRUD ---
 
 export async function createContextItem(
@@ -121,6 +132,28 @@ export async function upsertContextItem(
     if (!updated) throw new Error(`Failed to update: ${params.contextPath}`);
     return updated;
   }
+  return createContextItem(db, params);
+}
+
+/**
+ * Strict creator: throws PathConflictError if context_path already exists.
+ * Use when callers want to surface collisions instead of silently overwriting.
+ */
+export async function createContextItemStrict(
+  db: DbConnection,
+  params: {
+    title: string;
+    content?: string;
+    mimeType?: string;
+    sourceType?: "file" | "url";
+    sourcePath?: string;
+    contextPath: string;
+    description?: string;
+    isTextual?: boolean;
+  },
+): Promise<ContextItem> {
+  const existing = await getContextItemByPath(db, params.contextPath);
+  if (existing) throw new PathConflictError(existing.id, params.contextPath);
   return createContextItem(db, params);
 }
 

--- a/src/tools/file/write.ts
+++ b/src/tools/file/write.ts
@@ -1,7 +1,11 @@
 import { isText } from "istextorbinary";
 import { z } from "zod";
 import { ingestByPath } from "../../context/ingest.ts";
-import { upsertContextItem } from "../../db/context.ts";
+import {
+  createContextItemStrict,
+  PathConflictError,
+  upsertContextItem,
+} from "../../db/context.ts";
 import type { ToolDefinition } from "../tool.ts";
 
 function mimeFromPath(path: string): string {
@@ -30,18 +34,27 @@ const inputSchema = z.object({
     .optional()
     .describe("Title for the file (defaults to filename)"),
   description: z.string().optional().describe("Description of the file"),
+  on_conflict: z
+    .enum(["error", "overwrite"])
+    .optional()
+    .describe(
+      "What to do if a file already exists at this path. Defaults to 'error'. Pass 'overwrite' to replace.",
+    ),
 });
 
 const outputSchema = z.object({
-  id: z.string(),
+  id: z.string().nullable(),
   path: z.string(),
   is_error: z.boolean(),
+  error_type: z.string().optional(),
+  message: z.string().optional(),
+  next_action_hint: z.string().optional(),
 });
 
 export const contextWriteTool = {
   name: "context_write",
   description:
-    "Write content to a context item. Creates the item if it doesn't exist, or overwrites if it does.",
+    "Write content to a context item. By default, fails if the path already exists — pass on_conflict='overwrite' to replace.",
   group: "context",
   inputSchema,
   outputSchema,
@@ -50,17 +63,43 @@ export const contextWriteTool = {
     const isTextual = isTextualPath(input.path);
     const title =
       input.title ?? input.path.split("/").filter(Boolean).pop() ?? input.path;
+    const onConflict = input.on_conflict ?? "error";
 
-    const item = await upsertContextItem(ctx.conn, {
-      title,
-      description: input.description,
-      content: input.content_base64 ?? input.content,
-      contextPath: input.path,
-      mimeType,
-      isTextual,
-    });
+    try {
+      const item =
+        onConflict === "overwrite"
+          ? await upsertContextItem(ctx.conn, {
+              title,
+              description: input.description,
+              content: input.content_base64 ?? input.content,
+              contextPath: input.path,
+              mimeType,
+              isTextual,
+            })
+          : await createContextItemStrict(ctx.conn, {
+              title,
+              description: input.description,
+              content: input.content_base64 ?? input.content,
+              contextPath: input.path,
+              mimeType,
+              isTextual,
+            });
 
-    await ingestByPath(ctx.conn, input.path, ctx.config);
-    return { id: item.id, path: item.context_path, is_error: false };
+      await ingestByPath(ctx.conn, input.path, ctx.config);
+      return { id: item.id, path: item.context_path, is_error: false };
+    } catch (err) {
+      if (err instanceof PathConflictError) {
+        return {
+          id: null,
+          path: input.path,
+          is_error: true,
+          error_type: "path_conflict",
+          message: `A file already exists at ${input.path} (id: ${err.existingId}).`,
+          next_action_hint:
+            "Call context_read to inspect the existing file, or retry with on_conflict='overwrite' to replace it.",
+        };
+      }
+      throw err;
+    }
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/test/context/describer.test.ts
+++ b/test/context/describer.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { DEFAULT_CONFIG } from "../../src/config/schemas.ts";
-import { generateDescription } from "../../src/context/describer.ts";
+import {
+  generateDescription,
+  generateDescriptionAndPath,
+  sanitizeSuggestedPath,
+} from "../../src/context/describer.ts";
 
 describe("generateDescription", () => {
   test("returns empty string when no API key is configured", async () => {
@@ -32,5 +36,56 @@ describe("generateDescription", () => {
       filePath: "/tmp/photo.png",
     });
     expect(result).toBe("");
+  });
+});
+
+describe("generateDescriptionAndPath", () => {
+  test("returns null when no API key is configured", async () => {
+    const config = { ...DEFAULT_CONFIG, anthropic_api_key: "" };
+    const result = await generateDescriptionAndPath(config, {
+      filename: "report.md",
+      mimeType: "text/markdown",
+      content: "# Quarterly Report",
+      existingTree: "",
+    });
+    expect(result).toBeNull();
+  });
+});
+
+describe("sanitizeSuggestedPath", () => {
+  test("accepts a simple absolute path", () => {
+    expect(sanitizeSuggestedPath("/docs/readme.md")).toBe("/docs/readme.md");
+  });
+
+  test("collapses repeated slashes", () => {
+    expect(sanitizeSuggestedPath("//docs///sub/file.md")).toBe(
+      "/docs/sub/file.md",
+    );
+  });
+
+  test("strips trailing slashes", () => {
+    expect(sanitizeSuggestedPath("/docs/readme.md/")).toBe("/docs/readme.md");
+  });
+
+  test("trims whitespace", () => {
+    expect(sanitizeSuggestedPath("  /docs/x.md  ")).toBe("/docs/x.md");
+  });
+
+  test("rejects relative paths", () => {
+    expect(sanitizeSuggestedPath("docs/readme.md")).toBeNull();
+  });
+
+  test("rejects parent-traversal", () => {
+    expect(sanitizeSuggestedPath("/docs/../etc/passwd")).toBeNull();
+  });
+
+  test("rejects empty strings", () => {
+    expect(sanitizeSuggestedPath("")).toBeNull();
+    expect(sanitizeSuggestedPath("   ")).toBeNull();
+  });
+
+  test("rejects root by itself (no filename)", () => {
+    expect(sanitizeSuggestedPath("/")).toBeNull();
+    expect(sanitizeSuggestedPath("//")).toBeNull();
   });
 });

--- a/test/db/context.test.ts
+++ b/test/db/context.test.ts
@@ -5,6 +5,7 @@ import {
   contextPathExists,
   copyContextItem,
   createContextItem,
+  createContextItemStrict,
   deleteContextItem,
   deleteContextItemByPath,
   deleteContextItemsByPrefix,
@@ -14,6 +15,7 @@ import {
   listContextItems,
   listContextItemsByPrefix,
   moveContextItem,
+  PathConflictError,
   searchContextByKeyword,
   updateContextItem,
   updateContextItemContent,
@@ -93,6 +95,47 @@ describe("context CRUD", () => {
 
     const items = await listContextItems(conn);
     expect(items.length).toBe(1);
+  });
+
+  test("createContextItemStrict: inserts when new", async () => {
+    const item = await createContextItemStrict(conn, {
+      title: "Strict",
+      content: "hello",
+      contextPath: "/strict/new.md",
+    });
+    expect(item.title).toBe("Strict");
+    expect(item.content).toBe("hello");
+    expect(item.context_path).toBe("/strict/new.md");
+  });
+
+  test("createContextItemStrict: throws PathConflictError on collision", async () => {
+    const first = await createContextItemStrict(conn, {
+      title: "Original",
+      content: "v1",
+      contextPath: "/strict/conflict.md",
+    });
+
+    let caught: unknown;
+    try {
+      await createContextItemStrict(conn, {
+        title: "Second",
+        content: "v2",
+        contextPath: "/strict/conflict.md",
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(PathConflictError);
+    if (caught instanceof PathConflictError) {
+      expect(caught.existingId).toBe(first.id);
+      expect(caught.contextPath).toBe("/strict/conflict.md");
+    }
+
+    // Original content preserved; no new row
+    const items = await listContextItems(conn);
+    expect(items.length).toBe(1);
+    expect(items[0]?.content).toBe("v1");
   });
 
   test("upsertContextItem: insert when new", async () => {

--- a/test/tools/file.test.ts
+++ b/test/tools/file.test.ts
@@ -34,16 +34,37 @@ describe("context_write", () => {
     expect(read.content).toBe("hello world");
   });
 
-  test("overwrites existing file", async () => {
+  test("overwrites existing file when on_conflict='overwrite'", async () => {
     await seedFile(conn, "/overwrite.txt", "original");
     const result = await contextWriteTool.execute(
-      { path: "/overwrite.txt", content: "updated" },
+      {
+        path: "/overwrite.txt",
+        content: "updated",
+        on_conflict: "overwrite",
+      },
       ctx,
     );
     expect(result.path).toBe("/overwrite.txt");
+    expect(result.is_error).toBe(false);
 
     const read = await contextReadTool.execute({ path: "/overwrite.txt" }, ctx);
     expect(read.content).toBe("updated");
+  });
+
+  test("returns path_conflict error by default when file exists", async () => {
+    await seedFile(conn, "/collision.txt", "original");
+    const result = await contextWriteTool.execute(
+      { path: "/collision.txt", content: "second" },
+      ctx,
+    );
+    expect(result.is_error).toBe(true);
+    expect(result.error_type).toBe("path_conflict");
+    expect(result.id).toBeNull();
+    expect(result.next_action_hint).toContain("on_conflict='overwrite'");
+
+    // Original content preserved
+    const read = await contextReadTool.execute({ path: "/collision.txt" }, ctx);
+    expect(read.content).toBe("original");
   });
 
   test("sets title and description", async () => {


### PR DESCRIPTION
## Summary

- `context add` now asks the LLM to place each file into the existing folder tree when `--prefix` is omitted — the describer is primed with the full list of existing folders *and files* (up to 500 entries) plus the source filesystem path, so basenames like `README.md` get disambiguated under `/projects/<source-dir>/`.
- Collisions stop being silent: new `--on-conflict` flag (`error` | `overwrite` | `skip`, default `error`) in the CLI, and matching `on_conflict` input on the `context_write` agent tool that returns a PATs-style `path_conflict` error with a `next_action_hint`.
- TTY confirmation for LLM suggestions defaults to accept (Enter / `Y` accepts, `n` rejects); `--auto-place` skips the prompt entirely.
- New `PathConflictError` + `createContextItemStrict` in the DB layer; `upsertContextItem` kept intact so explicit overwrite flows are unchanged.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun test` — 663/663 passing (13 new expectations across db/context, context/describer, tools/file)
- [ ] Manual: `bun run dev context add ~/some/README.md ~/other/README.md` without flags → LLM places each under a distinct folder, TTY prompt defaults to accept
- [ ] Manual: re-run the same command → second run exits non-zero listing collisions; `--on-conflict=overwrite` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)