### PR TITLE
Fix task view showing same text in Waiting and Output fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "Local, autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/daemon/tick.ts
+++ b/src/daemon/tick.ts
@@ -86,13 +86,13 @@ export async function tick(
       callbacks,
     });
 
-    // Update task status and store output
+    const isComplete = result.status === "complete";
     await updateTaskStatus(
       conn,
       task.id,
       result.status,
-      result.reason,
-      result.reason,
+      isComplete ? null : result.reason,
+      isComplete ? result.reason : null,
     );
 
     // Log the status change
@@ -112,7 +112,7 @@ export async function tick(
       `Task: ${task.name}\nDescription: ${task.description}\nOutcome: ${result.status}${result.reason ? ` — ${result.reason}` : ""}`,
     );
   } catch (err) {
-    await updateTaskStatus(conn, task.id, "failed", String(err), String(err));
+    await updateTaskStatus(conn, task.id, "failed", String(err), null);
 
     await logInteraction(conn, threadId, {
       role: "system",

--- a/src/db/tasks.ts
+++ b/src/db/tasks.ts
@@ -132,8 +132,8 @@ export async function updateTaskStatus(
   db: DbConnection,
   id: string,
   status: Task["status"],
-  reason?: string,
-  output?: string,
+  reason?: string | null,
+  output?: string | null,
 ): Promise<void> {
   await db.queryRun(
     `UPDATE tasks

--- a/test/daemon/tick.test.ts
+++ b/test/daemon/tick.test.ts
@@ -36,6 +36,9 @@ describe("daemon tick", () => {
     // Task should be completed
     const updated = await getTask(conn, task.id);
     expect(updated?.status).toBe("complete");
+    // Completion summary belongs in `output`, not `waiting_reason`
+    expect(updated?.output).toBe("Task done successfully");
+    expect(updated?.waiting_reason).toBeNull();
 
     // tick should signal that work was done
     expect(didWork).toBe(true);
@@ -102,6 +105,10 @@ describe("daemon tick", () => {
 
     const updated = await getTask(conn, task.id);
     expect(updated?.status).toBe("failed");
+    // Failure explanation lives in `waiting_reason`; `output` is only for
+    // the deliverable of a completed task.
+    expect(updated?.waiting_reason).toContain("API rate limit exceeded");
+    expect(updated?.output).toBeNull();
 
     // Thread should still be created and ended
     const threads = await listThreads(conn, { type: "daemon_tick" });
@@ -110,6 +117,51 @@ describe("daemon tick", () => {
     expect(thread?.ended_at).not.toBeNull();
 
     // Restore original mock
+    mock.module("@anthropic-ai/sdk", () => ({
+      default: class MockAnthropic {
+        messages = {
+          create: async () => completionResponse(),
+        };
+      },
+    }));
+  });
+
+  test("marks task as waiting when agent calls wait_task", async () => {
+    mock.module("@anthropic-ai/sdk", () => ({
+      default: class MockAnthropic {
+        messages = {
+          create: async () => ({
+            content: [
+              { type: "text", text: "Need more info." },
+              {
+                type: "tool_use",
+                id: "tool_1",
+                name: "wait_task",
+                input: { reason: "Need user approval" },
+              },
+            ],
+            stop_reason: "tool_use",
+            usage: { input_tokens: 10, output_tokens: 10 },
+          }),
+        };
+      },
+    }));
+
+    const { tick: tickFresh } = await import("../../src/daemon/tick.ts");
+
+    const task = await createTask(conn, {
+      name: "Will wait",
+      description: "Agent will call wait_task",
+    });
+
+    await tickFresh("/tmp/test-project", conn, TEST_CONFIG);
+
+    const updated = await getTask(conn, task.id);
+    expect(updated?.status).toBe("waiting");
+    expect(updated?.waiting_reason).toBe("Need user approval");
+    expect(updated?.output).toBeNull();
+
+    // Restore default mock
     mock.module("@anthropic-ai/sdk", () => ({
       default: class MockAnthropic {
         messages = {


### PR DESCRIPTION
## Summary

- `src/daemon/tick.ts` was passing the agent's terminal `reason` to both the `waiting_reason` and `output` columns, so completed tasks showed a bogus `Waiting:` line in `task view` and waiting tasks carried a stale `output` that would have leaked into downstream tasks' predecessor context.
- Route the completion `summary` to `output` (null `waiting_reason`); route wait/fail reasons to `waiting_reason` (null `output`). Widens `updateTaskStatus` params to accept `null`.
- Adds a new regression test for `wait_task` and extends the existing complete/failed tests to assert the column split.

## Test plan

- [x] `bun run lint`
- [x] `bun test` (652 pass / 0 fail)