### PR TITLE
Add date sort, timestamps, and --limit/--offset to all list commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ An AI agent for knowledge work. See `docs/plans/README.md` for the milestone roa
 - `bun run lint` runs both `tsc --noEmit` and `biome check`
 - All database access goes through `src/db/` modules
 - All agent interactions are logged to the threads/interactions tables
+- **List operations always support `-l, --limit <n>` and `-o, --offset <n>`** — applies to every CLI `list` subcommand and the corresponding `src/db/` list function. Use `sanitizeInt` on both when interpolating into SQL, and pick a stable `ORDER BY` (with an `id` tiebreaker) so pagination is deterministic.
 - No filesystem tools for the agent — FS access is abstracted through CRUD modules scoped to `.botholomew/`
 - When designing or modifying agent tools, follow PATs (Patterns for Agentic Tools): https://arcade.dev/patterns/llm.txt — key principles: error-guided recovery, next-action hints, token-efficient outputs, error classification
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Everything the agent can touch is here. No surprises.
 | `botholomew nuke context\|tasks\|schedules\|threads\|all` | Bulk-erase sections of the database |
 | `botholomew upgrade` | Self-update |
 
+All `list` subcommands support `-l, --limit <n>` and `-o, --offset <n>` for pagination.
+
 ---
 
 ## How it works

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -115,7 +115,7 @@ skill is invoked, so it's visually distinct from a regular message.
 ## CLI management
 
 ```bash
-botholomew skill list                 # table of all skills
+botholomew skill list                 # table of all skills (supports --limit / --offset)
 botholomew skill show review          # print the full skill file
 botholomew skill create daily-log     # scaffold a new skill
 botholomew skill validate             # parse every .botholomew/skills/*.md and report errors

--- a/docs/tasks-and-schedules.md
+++ b/docs/tasks-and-schedules.md
@@ -152,8 +152,9 @@ next tick.
 # Add work
 botholomew task add "Draft Q4 retro" --priority high
 
-# Inspect
+# Inspect (newest first; supports --status, --priority, --limit, --offset)
 botholomew task list --status pending
+botholomew task list --limit 20 --offset 20
 botholomew task view <id>
 
 # Force the daemon to pick up

--- a/docs/watchdog.md
+++ b/docs/watchdog.md
@@ -28,7 +28,7 @@ This detects the platform, writes a `.plist` (macOS) or `.service` +
 later.
 
 ```bash
-botholomew daemon list         # all projects with watchdogs installed
+botholomew daemon list         # all projects with watchdogs installed (supports --limit / --offset)
 botholomew daemon uninstall    # remove the watchdog
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "Local, autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/commands/daemon.ts
+++ b/src/commands/daemon.ts
@@ -109,7 +109,9 @@ export function registerDaemonCommand(program: Command) {
   daemon
     .command("list")
     .description("List all registered Botholomew projects on this machine")
-    .action(async () => {
+    .option("-l, --limit <n>", "max number of projects", Number.parseInt)
+    .option("-o, --offset <n>", "skip first N projects", Number.parseInt)
+    .action(async (opts: { limit?: number; offset?: number }) => {
       const { listAllWatchdogProjects } = await import("../daemon/watchdog.ts");
       try {
         const projects = await listAllWatchdogProjects();
@@ -117,9 +119,20 @@ export function registerDaemonCommand(program: Command) {
           logger.dim("No registered projects found.");
           return;
         }
-        for (const p of projects) {
+        const total = projects.length;
+        const start = opts.offset ?? 0;
+        const end = opts.limit ? start + opts.limit : undefined;
+        const page = projects.slice(start, end);
+        if (page.length === 0) {
+          logger.dim(`No projects on this page (total: ${total}).`);
+          return;
+        }
+        for (const p of page) {
           logger.info(p.projectDir);
           logger.dim(`  Config: ${p.configPath}`);
+        }
+        if (page.length !== total) {
+          logger.dim(`\nshowing ${page.length} of ${total} project(s)`);
         }
       } catch (err) {
         logger.error(

--- a/src/commands/schedule.ts
+++ b/src/commands/schedule.ts
@@ -19,9 +19,18 @@ export function registerScheduleCommand(program: Command) {
     .description("List all schedules")
     .option("--enabled", "show only enabled schedules")
     .option("--disabled", "show only disabled schedules")
+    .option("-l, --limit <n>", "max number of schedules", Number.parseInt)
+    .option("-o, --offset <n>", "skip first N schedules", Number.parseInt)
     .action((opts) =>
       withDb(program, async (conn) => {
-        const filters: { enabled?: boolean } = {};
+        const filters: {
+          enabled?: boolean;
+          limit?: number;
+          offset?: number;
+        } = {
+          limit: opts.limit,
+          offset: opts.offset,
+        };
         if (opts.enabled) filters.enabled = true;
         if (opts.disabled) filters.enabled = false;
 

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -27,7 +27,9 @@ export function registerSkillCommand(program: Command) {
   skill
     .command("list")
     .description("List all skills loaded from .botholomew/skills/")
-    .action(async () => {
+    .option("-l, --limit <n>", "max number of skills", Number.parseInt)
+    .option("-o, --offset <n>", "skip first N skills", Number.parseInt)
+    .action(async (opts: { limit?: number; offset?: number }) => {
       const dir = program.opts().dir;
       const skills = await loadSkills(dir);
 
@@ -39,12 +41,21 @@ export function registerSkillCommand(program: Command) {
       const sorted = [...skills.values()].sort((a, b) =>
         a.name.localeCompare(b.name),
       );
+      const total = sorted.length;
+      const start = opts.offset ?? 0;
+      const end = opts.limit ? start + opts.limit : undefined;
+      const page = sorted.slice(start, end);
+
+      if (page.length === 0) {
+        logger.dim(`No skills on this page (total: ${total}).`);
+        return;
+      }
 
       const header = `${ansis.bold("Name".padEnd(20))} ${ansis.bold("Description".padEnd(40))} ${ansis.bold("Args".padEnd(20))} ${ansis.bold("Path")}`;
       console.log(header);
       console.log("-".repeat(header.length));
 
-      for (const s of sorted) {
+      for (const s of page) {
         const name = s.name.padEnd(20);
         const desc = s.description
           ? s.description.slice(0, 39).padEnd(40)
@@ -61,7 +72,11 @@ export function registerSkillCommand(program: Command) {
         console.log(`${name} ${desc} ${args} ${path}`);
       }
 
-      console.log(`\n${ansis.dim(`${sorted.length} skill(s)`)}`);
+      const footer =
+        page.length === total
+          ? `${total} skill(s)`
+          : `showing ${page.length} of ${total} skill(s)`;
+      console.log(`\n${ansis.dim(footer)}`);
     });
 
   skill

--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -17,16 +17,18 @@ export function registerTaskCommand(program: Command) {
 
   task
     .command("list")
-    .description("List all tasks")
+    .description("List all tasks (newest first)")
     .option("-s, --status <status>", "filter by status")
     .option("-p, --priority <priority>", "filter by priority")
-    .option("-l, --limit <n>", "max number of tasks", parseInt)
+    .option("-l, --limit <n>", "max number of tasks", Number.parseInt)
+    .option("-o, --offset <n>", "skip first N tasks", Number.parseInt)
     .action((opts) =>
       withDb(program, async (conn) => {
         const tasks = await listTasks(conn, {
           status: opts.status,
           priority: opts.priority,
           limit: opts.limit,
+          offset: opts.offset,
         });
 
         if (tasks.length === 0) {
@@ -34,9 +36,15 @@ export function registerTaskCommand(program: Command) {
           return;
         }
 
+        const header = `${ansis.bold("ID".padEnd(36))}  ${ansis.bold("Status".padEnd(11))}  ${ansis.bold("Priority".padEnd(6))}  ${ansis.bold("Created".padEnd(19))}  ${ansis.bold("Updated".padEnd(19))}  ${ansis.bold("Name")}`;
+        console.log(header);
+        console.log("-".repeat(120));
+
         for (const t of tasks) {
           printTask(t);
         }
+
+        console.log(`\n${ansis.dim(`${tasks.length} task(s)`)}`);
       }),
     );
 
@@ -154,10 +162,26 @@ function priorityColor(priority: Task["priority"]): string {
   }
 }
 
+function formatTime(date: Date): string {
+  return date
+    .toISOString()
+    .replace("T", " ")
+    .replace(/\.\d{3}Z$/, "");
+}
+
+function padColored(colored: string, raw: string, width: number): string {
+  const padding = Math.max(0, width - raw.length);
+  return colored + " ".repeat(padding);
+}
+
 function printTask(t: Task) {
-  const id = ansis.dim(t.id);
+  const id = ansis.dim(t.id.padEnd(36));
+  const status = padColored(statusColor(t.status), t.status, 11);
+  const priority = padColored(priorityColor(t.priority), t.priority, 6);
+  const created = ansis.dim(formatTime(t.created_at).padEnd(19));
+  const updated = ansis.dim(formatTime(t.updated_at).padEnd(19));
   console.log(
-    `  ${id}  ${statusColor(t.status)}  ${priorityColor(t.priority)}  ${t.name}`,
+    `${id}  ${status}  ${priority}  ${created}  ${updated}  ${t.name}`,
   );
 }
 

--- a/src/commands/thread.ts
+++ b/src/commands/thread.ts
@@ -19,12 +19,14 @@ export function registerThreadCommand(program: Command) {
     .command("list")
     .description("List threads")
     .option("-t, --type <type>", "filter by type (daemon_tick, chat_session)")
-    .option("-l, --limit <n>", "max number of threads", parseInt)
+    .option("-l, --limit <n>", "max number of threads", Number.parseInt)
+    .option("-o, --offset <n>", "skip first N threads", Number.parseInt)
     .action((opts) =>
       withDb(program, async (conn) => {
         const threads = await listThreads(conn, {
           type: opts.type,
           limit: opts.limit,
+          offset: opts.offset,
         });
 
         if (threads.length === 0) {

--- a/src/db/schedules.ts
+++ b/src/db/schedules.ts
@@ -1,5 +1,5 @@
 import type { DbConnection } from "./connection.ts";
-import { buildSetClauses, buildWhereClause } from "./query.ts";
+import { buildSetClauses, buildWhereClause, sanitizeInt } from "./query.ts";
 import { uuidv7 } from "./uuid.ts";
 
 export interface Schedule {
@@ -72,7 +72,7 @@ export async function getSchedule(
 
 export async function listSchedules(
   db: DbConnection,
-  filters?: { enabled?: boolean },
+  filters?: { enabled?: boolean; limit?: number; offset?: number },
 ): Promise<Schedule[]> {
   const { where, params } = buildWhereClause([
     [
@@ -80,9 +80,13 @@ export async function listSchedules(
       filters?.enabled !== undefined ? (filters.enabled ? 1 : 0) : undefined,
     ],
   ]);
+  const limit = filters?.limit ? `LIMIT ${sanitizeInt(filters.limit)}` : "";
+  const offset = filters?.offset ? `OFFSET ${sanitizeInt(filters.offset)}` : "";
 
   const rows = await db.queryAll<ScheduleRow>(
-    `SELECT * FROM schedules ${where} ORDER BY created_at ASC`,
+    `SELECT * FROM schedules ${where}
+     ORDER BY created_at ASC, id ASC
+     ${limit} ${offset}`,
     ...params,
   );
   return rows.map(rowToSchedule);

--- a/src/db/tasks.ts
+++ b/src/db/tasks.ts
@@ -109,6 +109,7 @@ export async function listTasks(
     status?: Task["status"];
     priority?: Task["priority"];
     limit?: number;
+    offset?: number;
   },
 ): Promise<Task[]> {
   const { where, params } = buildWhereClause([
@@ -116,13 +117,12 @@ export async function listTasks(
     ["priority", filters?.priority],
   ]);
   const limit = filters?.limit ? `LIMIT ${sanitizeInt(filters.limit)}` : "";
+  const offset = filters?.offset ? `OFFSET ${sanitizeInt(filters.offset)}` : "";
 
   const rows = await db.queryAll<TaskRow>(
     `SELECT * FROM tasks ${where}
-     ORDER BY
-       CASE priority WHEN 'high' THEN 0 WHEN 'medium' THEN 1 WHEN 'low' THEN 2 END,
-       created_at ASC
-     ${limit}`,
+     ORDER BY created_at DESC, id DESC
+     ${limit} ${offset}`,
     ...params,
   );
   return rows.map(rowToTask);

--- a/src/db/threads.ts
+++ b/src/db/threads.ts
@@ -1,5 +1,5 @@
 import type { DbConnection } from "./connection.ts";
-import { buildWhereClause } from "./query.ts";
+import { buildWhereClause, sanitizeInt } from "./query.ts";
 import { uuidv7 } from "./uuid.ts";
 
 export interface Thread {
@@ -256,18 +256,20 @@ export async function listThreads(
     type?: Thread["type"];
     taskId?: string;
     limit?: number;
+    offset?: number;
   },
 ): Promise<Thread[]> {
   const { where, params } = buildWhereClause([
     ["type", filters?.type],
     ["task_id", filters?.taskId],
   ]);
-  const limit = filters?.limit ? `LIMIT ${filters.limit}` : "";
+  const limit = filters?.limit ? `LIMIT ${sanitizeInt(filters.limit)}` : "";
+  const offset = filters?.offset ? `OFFSET ${sanitizeInt(filters.offset)}` : "";
 
   const rows = await db.queryAll<ThreadRow>(
     `SELECT * FROM threads ${where}
-     ORDER BY started_at DESC
-     ${limit}`,
+     ORDER BY started_at DESC, id DESC
+     ${limit} ${offset}`,
     ...params,
   );
   return rows.map(rowToThread);

--- a/test/db/schedules.test.ts
+++ b/test/db/schedules.test.ts
@@ -59,6 +59,18 @@ describe("schedule CRUD", () => {
     expect(schedules[1]?.name).toBe("B");
   });
 
+  test("list schedules with limit and offset", async () => {
+    await createSchedule(conn, { name: "A", frequency: "daily" });
+    await createSchedule(conn, { name: "B", frequency: "daily" });
+    await createSchedule(conn, { name: "C", frequency: "daily" });
+    await createSchedule(conn, { name: "D", frequency: "daily" });
+
+    const page = await listSchedules(conn, { limit: 2, offset: 1 });
+    expect(page.length).toBe(2);
+    expect(page[0]?.name).toBe("B");
+    expect(page[1]?.name).toBe("C");
+  });
+
   test("list schedules filtered by enabled", async () => {
     const s = await createSchedule(conn, {
       name: "Active",

--- a/test/db/tasks.test.ts
+++ b/test/db/tasks.test.ts
@@ -35,16 +35,28 @@ describe("task CRUD", () => {
     expect(fetched?.name).toBe("Test task");
   });
 
-  test("list tasks ordered by priority", async () => {
-    await createTask(conn, { name: "Low", priority: "low" });
-    await createTask(conn, { name: "High", priority: "high" });
-    await createTask(conn, { name: "Medium", priority: "medium" });
+  test("list tasks ordered by created_at desc", async () => {
+    await createTask(conn, { name: "First", priority: "low" });
+    await createTask(conn, { name: "Second", priority: "high" });
+    await createTask(conn, { name: "Third", priority: "medium" });
 
     const tasks = await listTasks(conn);
     expect(tasks.length).toBe(3);
-    expect(tasks[0]?.name).toBe("High");
-    expect(tasks[1]?.name).toBe("Medium");
-    expect(tasks[2]?.name).toBe("Low");
+    expect(tasks[0]?.name).toBe("Third");
+    expect(tasks[1]?.name).toBe("Second");
+    expect(tasks[2]?.name).toBe("First");
+  });
+
+  test("list tasks supports limit and offset", async () => {
+    await createTask(conn, { name: "First" });
+    await createTask(conn, { name: "Second" });
+    await createTask(conn, { name: "Third" });
+    await createTask(conn, { name: "Fourth" });
+
+    const page = await listTasks(conn, { limit: 2, offset: 1 });
+    expect(page.length).toBe(2);
+    expect(page[0]?.name).toBe("Third");
+    expect(page[1]?.name).toBe("Second");
   });
 
   test("list tasks with status filter", async () => {

--- a/test/db/threads.test.ts
+++ b/test/db/threads.test.ts
@@ -217,6 +217,18 @@ describe("listThreads", () => {
     const threads = await listThreads(conn, { limit: 2 });
     expect(threads).toHaveLength(2);
   });
+
+  test("list threads with limit and offset", async () => {
+    await createThread(conn, "daemon_tick", undefined, "Tick 1");
+    await createThread(conn, "daemon_tick", undefined, "Tick 2");
+    await createThread(conn, "daemon_tick", undefined, "Tick 3");
+    await createThread(conn, "daemon_tick", undefined, "Tick 4");
+
+    const page = await listThreads(conn, { limit: 2, offset: 1 });
+    expect(page).toHaveLength(2);
+    expect(page[0]?.title).toBe("Tick 3");
+    expect(page[1]?.title).toBe("Tick 2");
+  });
 });
 
 describe("follow queries", () => {

--- a/test/tools/task-list-view.test.ts
+++ b/test/tools/task-list-view.test.ts
@@ -20,12 +20,12 @@ describe("list_tasks", () => {
     expect(result.count).toBe(0);
   });
 
-  test("returns all tasks", async () => {
+  test("returns all tasks newest first", async () => {
     await createTask(ctx.conn, { name: "Task A" });
     await createTask(ctx.conn, { name: "Task B" });
     const result = await listTasksTool.execute({}, ctx);
     expect(result.count).toBe(2);
-    expect(result.tasks.map((t) => t.name)).toEqual(["Task A", "Task B"]);
+    expect(result.tasks.map((t) => t.name)).toEqual(["Task B", "Task A"]);
   });
 
   test("filters by status", async () => {


### PR DESCRIPTION
## Summary
- `task list` now sorts newest-first (`created_at DESC`), shows `Created`/`Updated` columns in a tabular layout, and accepts `-o, --offset` alongside the existing `-l, --limit`.
- Added `-l, --limit` and/or `-o, --offset` to the remaining list commands so pagination is consistent: `thread list` (added offset), `schedule list` (added both), `skill list` (added both, in-memory slice), `daemon list` (added both, in-memory slice).
- Hardened `listThreads` / `listSchedules` with `sanitizeInt` on limit/offset and added deterministic `id` tiebreakers for stable ordering.

## Test plan
- [x] `bun run lint` clean (tsc + biome)
- [x] `bun test` — 654/654 pass (includes new pagination tests for `listTasks`, `listThreads`, `listSchedules`)
- [x] Smoke-tested `task list`, `schedule list --limit/--offset`, and `skill list --limit/--offset` end-to-end in a scratch project