### PR TITLE
Release DuckDB file lock between operations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,8 +44,14 @@ An AI agent for knowledge work. See `docs/plans/README.md` for the milestone roa
 
 ## Database Patterns
 
-- **Connection**: use `DbConnection` type from `src/db/connection.ts` (wrapper around `@duckdb/node-api`)
-- **Migrations**: always call `migrate(db)` after opening a connection — it's idempotent
+- **Connection lifecycle**: DuckDB holds the file lock at the *instance* level, so **no process holds a connection longer than one logical operation**. Always use `withDb(dbPath, async (conn) => { ... })` from `src/db/connection.ts` — it opens a conn, runs your callback, closes, and releases the OS lock. Never stash a `DbConnection` on a long-lived object (daemon tick, chat session, TUI component state).
+- **`dbPath` is the currency**: long-lived callers (daemon, chat session, TUI panels) hold `dbPath: string`, not `conn`. They open a fresh `withDb` per operation.
+- **CRUD modules in `src/db/*`**: still take `conn: DbConnection` as their first argument. Callers supply one via `withDb`. Don't change these signatures to `dbPath` — tests pass an in-memory conn directly, which wouldn't survive a `withDb` (separate `:memory:` instances don't share state).
+- **Tools (`src/tools/*`)**: `ToolContext` has both `conn` (short-lived, scoped to this tool call) and `dbPath` (for long-running tools). Default to `ctx.conn`. For tools that take more than a couple seconds (e.g., `context_refresh` re-fetching many URLs), wrap DB touches in `await withDb(ctx.dbPath, ...)` so the lock releases between items.
+- **Transactions**: `BEGIN / COMMIT / ROLLBACK` must all run on the **same** `conn`. Keep the whole transaction inside one `withDb` block.
+- **Retry**: `withRetry` (inside `withDb`) catches DuckDB "Conflicting lock" errors and backs off exponentially (100, 200, 400 … up to 8 tries ≈ 25 s). Non-lock errors propagate immediately.
+- **Parallel tool calls**: safe. Overlapping `withDb` calls in one process share a refcounted instance; DuckDB's "don't open the same DB twice in a process" rule stays satisfied, and the OS lock releases once every overlapping caller has closed.
+- **Migrations**: always call `migrate(conn)` after opening — it's idempotent. In entrypoints, do it once in a short `withDb` at startup (daemon, chat, CLI via `src/commands/with-db.ts`).
 - **IDs**: UUIDv7 generated in application code via `uuidv7()` from `src/db/uuid.ts` (re-exports `uuid` package)
 - **Queries**: use parameterized queries (`?1, ?2, ...`) — never string interpolation (auto-translated to `$N` for DuckDB)
 - **Timestamps**: stored as ISO 8601 TEXT (`datetime('now')`), converted to `Date` objects in TypeScript interfaces
@@ -57,8 +63,8 @@ An AI agent for knowledge work. See `docs/plans/README.md` for the milestone roa
 ## Testing
 
 - **Tests are required**: all new features and bug fixes must include tests. `bun test` and `bun run lint` must pass before merging.
-- Use `getConnection(":memory:")` for in-memory test databases
-- Call `migrate(conn)` in `beforeEach` to get a fresh schema each test
+- Default to `setupTestDb()` from `test/helpers.ts` for in-memory tests — it calls `getConnection()` + `migrate(conn)`.
+- Use `setupTestDbFile()` when a test needs to pass a `dbPath` to production code that opens/closes its own connections (daemon `tick`, `processSchedules`, `runAgentLoop`, chat session). `:memory:` databases don't share state across `getConnection` calls, so a shared-file DB is required. Remember to call the returned `cleanup()` in `afterEach`.
 
 ## Documentation
 
@@ -77,6 +83,7 @@ An AI agent for knowledge work. See `docs/plans/README.md` for the milestone roa
   - `docs/tui.md` — the `botholomew chat` TUI: tabs, shortcuts, slash-command popup, message queue, streaming
 - **When to update which doc:**
   - Touching `src/db/sql/*.sql` or `src/db/schema.ts` → update `docs/virtual-filesystem.md` and/or `docs/context-and-search.md` with any new columns, tables, or indexes.
+  - Changing connection lifecycle or `withDb` semantics in `src/db/connection.ts` → update the "Connection model" section in `docs/architecture.md` and the "Database Patterns" section in this file.
   - Adding/renaming/removing a tool in `src/tools/` → update the relevant doc (`virtual-filesystem.md` for file/dir tools, `context-and-search.md` for search tools, `tools.md` if the registry pattern changed) and the CLI reference table in `README.md`.
   - Adding a CLI subcommand in `src/commands/` → update the CLI table in `README.md` and the doc for that area.
   - Changing config defaults in `src/config/schemas.ts` → update `docs/configuration.md`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,9 +11,14 @@ Botholomew is four cooperating processes that share a single DuckDB database:
 4. **The CLI** — everything else (`task add`, `schedule list`, `context
    search`, …). Each invocation opens its own DuckDB connection.
 
-All four share `.botholomew/data.duckdb`. Writes are serialized via
-`withRetry()` in `src/db/connection.ts`, which retries on busy with
-exponential backoff.
+All four share `.botholomew/data.duckdb`. DuckDB holds the file lock at
+the instance level (not the connection), so **no process holds a DB
+connection longer than a single logical operation**. Each CRUD call runs
+inside a short-lived `withDb(dbPath, fn)` from `src/db/connection.ts`,
+which acquires a connection, executes, and releases the instance when the
+last overlapping caller in the process is done. `withRetry` wraps the
+acquire path and retries with exponential backoff if another process is
+holding the lock.
 
 **Safety note.** None of these processes give the agent direct access
 to your machine. The daemon is the only thing executing LLM tool
@@ -109,10 +114,29 @@ Schema lives in `src/db/sql/2-logging_tables.sql`.
 
 ## Connection model
 
-- **Daemon**: opens one `DbConnection` at startup, holds it for the
-  process lifetime.
-- **Chat**: opens one connection per session.
-- **CLI invocations**: open a connection, do their work, close it.
+Every process uses the same policy: **open a DuckDB connection for one
+logical operation, then close it.**
+
+- **Daemon**: `tick()` takes a `dbPath`, not a held connection. Each call
+  into `src/db/*` is wrapped in `withDb` — stale-task reset, task claim,
+  thread create, every `logInteraction`, the status update. The LLM
+  network round-trip holds no connection.
+- **Chat**: `ChatSession` carries `dbPath`. Each write (user message
+  log, tool-use log, tool-result log, title update, thread end) is its
+  own `withDb`. Tool execution wraps each call in `withDb` so `ctx.conn`
+  is scoped to that tool call only.
+- **CLI invocations**: `withDb` in `src/commands/with-db.ts` opens a
+  connection for the command, applies migrations, and closes when the
+  callback returns.
+- **TUI panels**: take `dbPath`, not `conn`, and wrap each refresh poll
+  in `withDb`.
+
+DuckDB's file lock is process-wide and held by the *instance*, not
+individual connections. Within one process we refcount a shared
+instance so overlapping `withDb` calls (e.g., parallel tool execution
+via `Promise.all`) don't trip DuckDB's "don't open the same DB twice"
+rule; when the last caller in the process releases, we close the
+instance and free the OS-level lock so another process can claim it.
 
 The DuckDB VSS extension is loaded at connect time (`INSTALL vss; LOAD
 vss;`) and HNSW persistence is enabled so vector indexes survive

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -63,7 +63,8 @@ Every tool receives a `ToolContext`:
 
 ```ts
 interface ToolContext {
-  conn: DbConnection;            // DuckDB connection
+  conn: DbConnection;             // short-lived connection, scoped to this tool call
+  dbPath: string;                 // for long-running tools that manage their own withDb
   projectDir: string;             // absolute path to the project
   config: Required<BotholomewConfig>;  // resolved config (API keys, model, …)
   mcpxClient: McpxClient | null;  // external MCP tools (may be null)
@@ -71,9 +72,27 @@ interface ToolContext {
 ```
 
 This is the only capability surface. A tool that isn't handed an
-`mcpxClient` can't reach the network; a tool that doesn't use `conn`
-can't touch the database. The context is constructed once per
-tick/session and passed to every `execute()` call.
+`mcpxClient` can't reach the network; a tool that doesn't use `conn` or
+`dbPath` can't touch the database.
+
+### `conn` vs `dbPath`
+
+The executor (`runAgentLoop` / `runChatTurn`) wraps each tool call in
+`withDb(dbPath, async (conn) => tool.execute(input, { ...ctx, conn }))`.
+That means:
+
+- `ctx.conn` is **already open** for the duration of one `execute()` call
+  and will be closed immediately after. Use it for ordinary tools that
+  do one or two quick queries.
+- `ctx.dbPath` is for tools that run long enough that holding the file
+  lock would block the daemon or CLI (e.g., `context_refresh` re-fetching
+  many URLs). Wrap each DB touch in
+  `await withDb(ctx.dbPath, async (conn) => { … })` so the lock is
+  released between items.
+
+DuckDB holds the file lock at the instance level. A tool that hangs on
+`ctx.conn` through a long network round-trip keeps that lock held. When
+in doubt, prefer granular `ctx.dbPath` wrapping.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Local, autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/chat/agent.ts
+++ b/src/chat/agent.ts
@@ -4,6 +4,7 @@ import type {
   ToolResultBlockParam,
   ToolUseBlock,
 } from "@anthropic-ai/sdk/resources/messages";
+import type { McpxClient } from "@evantahler/mcpx";
 import type { BotholomewConfig } from "../config/schemas.ts";
 import { embedSingle } from "../context/embedder.ts";
 import { fitToContextWindow, getMaxInputTokens } from "../daemon/context.ts";
@@ -13,7 +14,7 @@ import {
   extractKeywords,
   loadPersistentContext,
 } from "../daemon/prompt.ts";
-import type { DbConnection } from "../db/connection.ts";
+import { withDb } from "../db/connection.ts";
 import { hybridSearch } from "../db/embeddings.ts";
 import { logInteraction } from "../db/threads.ts";
 import { registerAllTools } from "../tools/registry.ts";
@@ -60,7 +61,7 @@ export async function buildChatSystemPrompt(
   projectDir: string,
   options?: {
     keywordSource?: string;
-    conn?: DbConnection;
+    dbPath?: string;
     config?: Required<BotholomewConfig>;
   },
 ): Promise<string> {
@@ -74,12 +75,14 @@ export async function buildChatSystemPrompt(
   parts.push(...(await loadPersistentContext(projectDir, taskKeywords)));
 
   // Relevant context from embeddings search
-  const conn = options?.conn;
+  const dbPath = options?.dbPath;
   const config = options?.config;
-  if (conn && config?.openai_api_key && keywordSource) {
+  if (dbPath && config?.openai_api_key && keywordSource) {
     try {
       const queryVec = await embedSingle(keywordSource, config);
-      const results = await hybridSearch(conn, keywordSource, queryVec, 5);
+      const results = await withDb(dbPath, (conn) =>
+        hybridSearch(conn, keywordSource, queryVec, 5),
+      );
 
       if (results.length > 0) {
         parts.push("## Relevant Context");
@@ -160,13 +163,20 @@ export async function runChatTurn(input: {
   messages: MessageParam[];
   projectDir: string;
   config: Required<BotholomewConfig>;
-  conn: DbConnection;
+  dbPath: string;
   threadId: string;
-  toolCtx: ToolContext;
+  mcpxClient: McpxClient | null;
   callbacks: ChatTurnCallbacks;
 }): Promise<void> {
-  const { messages, projectDir, config, conn, threadId, toolCtx, callbacks } =
-    input;
+  const {
+    messages,
+    projectDir,
+    config,
+    dbPath,
+    threadId,
+    mcpxClient,
+    callbacks,
+  } = input;
 
   const client = new Anthropic({
     apiKey: config.anthropic_api_key || undefined,
@@ -190,7 +200,7 @@ export async function runChatTurn(input: {
     const keywordSource = findLastUserText(messages);
     const systemPrompt = await buildChatSystemPrompt(projectDir, {
       keywordSource,
-      conn,
+      dbPath,
       config,
     });
 
@@ -230,13 +240,15 @@ export async function runChatTurn(input: {
 
     // Log assistant text
     if (assistantText) {
-      await logInteraction(conn, threadId, {
-        role: "assistant",
-        kind: "message",
-        content: assistantText,
-        durationMs,
-        tokenCount,
-      });
+      await withDb(dbPath, (conn) =>
+        logInteraction(conn, threadId, {
+          role: "assistant",
+          kind: "message",
+          content: assistantText,
+          durationMs,
+          tokenCount,
+        }),
+      );
     }
 
     // Check for tool calls
@@ -260,20 +272,29 @@ export async function runChatTurn(input: {
         callbacks.onToolStart(toolUse.id, toolUse.name, toolInput);
       }
 
-      await logInteraction(conn, threadId, {
-        role: "assistant",
-        kind: "tool_use",
-        content: `Calling ${toolUse.name}`,
-        toolName: toolUse.name,
-        toolInput,
-      });
+      await withDb(dbPath, (conn) =>
+        logInteraction(conn, threadId, {
+          role: "assistant",
+          kind: "tool_use",
+          content: `Calling ${toolUse.name}`,
+          toolName: toolUse.name,
+          toolInput,
+        }),
+      );
     }
 
-    // Execute all tools in parallel
+    // Execute all tools in parallel. Each tool call opens its own short-lived
+    // connection; parallel calls share the process-local DuckDB instance and
+    // release the file lock as soon as the last one finishes.
     const execResults = await Promise.all(
       toolUseBlocks.map(async (toolUse) => {
         const start = Date.now();
-        const result = await executeChatToolCall(toolUse, toolCtx);
+        const result = await executeChatToolCall(toolUse, {
+          dbPath,
+          projectDir,
+          config,
+          mcpxClient,
+        });
         const durationMs = Date.now() - start;
         const stored = maybeStoreResult(toolUse.name, result.output);
         const meta: ToolEndMeta | undefined = stored.stored
@@ -293,13 +314,15 @@ export async function runChatTurn(input: {
     // Log results and collect tool_result messages
     const toolResults: ToolResultBlockParam[] = [];
     for (const { toolUse, result, durationMs, stored } of execResults) {
-      await logInteraction(conn, threadId, {
-        role: "tool",
-        kind: "tool_result",
-        content: result.output,
-        toolName: toolUse.name,
-        durationMs,
-      });
+      await withDb(dbPath, (conn) =>
+        logInteraction(conn, threadId, {
+          role: "tool",
+          kind: "tool_result",
+          content: result.output,
+          toolName: toolUse.name,
+          durationMs,
+        }),
+      );
 
       toolResults.push({
         type: "tool_result",
@@ -314,9 +337,16 @@ export async function runChatTurn(input: {
   }
 }
 
+interface ChatToolCallCtx {
+  dbPath: string;
+  projectDir: string;
+  config: Required<BotholomewConfig>;
+  mcpxClient: McpxClient | null;
+}
+
 async function executeChatToolCall(
   toolUse: ToolUseBlock,
-  ctx: ToolContext,
+  baseCtx: ChatToolCallCtx,
 ): Promise<{ output: string; isError: boolean }> {
   const tool = getTool(toolUse.name);
   if (!tool) return { output: `Unknown tool: ${toolUse.name}`, isError: true };
@@ -335,7 +365,10 @@ async function executeChatToolCall(
   }
 
   try {
-    const result = await tool.execute(parsed.data, ctx);
+    const result = await withDb(baseCtx.dbPath, (conn) => {
+      const ctx: ToolContext = { ...baseCtx, conn };
+      return tool.execute(parsed.data, ctx);
+    });
     const isError =
       typeof result === "object" && result !== null && "is_error" in result
         ? (result as { is_error: boolean }).is_error

--- a/src/chat/session.ts
+++ b/src/chat/session.ts
@@ -2,8 +2,7 @@ import type { MessageParam } from "@anthropic-ai/sdk/resources/messages";
 import { loadConfig } from "../config/loader.ts";
 import type { BotholomewConfig } from "../config/schemas.ts";
 import { getDbPath } from "../constants.ts";
-import type { DbConnection } from "../db/connection.ts";
-import { getConnection } from "../db/connection.ts";
+import { withDb } from "../db/connection.ts";
 import { migrate } from "../db/schema.ts";
 import {
   createThread,
@@ -15,18 +14,18 @@ import {
 import { createMcpxClient } from "../mcpx/client.ts";
 import { loadSkills } from "../skills/loader.ts";
 import type { SkillDefinition } from "../skills/parser.ts";
-import type { ToolContext } from "../tools/tool.ts";
 import { generateThreadTitle } from "../utils/title.ts";
 import { type ChatTurnCallbacks, runChatTurn } from "./agent.ts";
 
 export interface ChatSession {
-  conn: DbConnection;
+  dbPath: string;
   threadId: string;
   projectDir: string;
   config: Required<BotholomewConfig>;
   messages: MessageParam[];
-  toolCtx: ToolContext;
   skills: Map<string, SkillDefinition>;
+  // biome-ignore lint/suspicious/noExplicitAny: mcpx client
+  mcpxClient: any;
   cleanup: () => Promise<void>;
 }
 
@@ -42,21 +41,22 @@ export async function startChatSession(
     );
   }
 
-  const conn = await getConnection(getDbPath(projectDir));
-  await migrate(conn);
+  const dbPath = getDbPath(projectDir);
+  await withDb(dbPath, (conn) => migrate(conn));
 
   let threadId: string;
   const messages: MessageParam[] = [];
 
   if (existingThreadId) {
     // Resume existing thread
-    const result = await getThread(conn, existingThreadId);
+    const result = await withDb(dbPath, (conn) =>
+      getThread(conn, existingThreadId),
+    );
     if (!result) {
-      conn.close();
       throw new Error(`Thread not found: ${existingThreadId}`);
     }
     threadId = existingThreadId;
-    await reopenThread(conn, threadId);
+    await withDb(dbPath, (conn) => reopenThread(conn, threadId));
 
     // Rebuild message history from interactions
     let firstUserMessage: string | undefined;
@@ -72,34 +72,29 @@ export async function startChatSession(
 
     // Backfill title for threads that still have the default
     if (result.thread.title === "New chat" && firstUserMessage) {
-      void generateThreadTitle(config, conn, threadId, firstUserMessage);
+      void generateThreadTitle(config, dbPath, threadId, firstUserMessage);
     }
   } else {
-    threadId = await createThread(conn, "chat_session", undefined, "New chat");
+    threadId = await withDb(dbPath, (conn) =>
+      createThread(conn, "chat_session", undefined, "New chat"),
+    );
   }
 
   const mcpxClient = await createMcpxClient(projectDir);
   const skills = await loadSkills(projectDir);
-
-  const toolCtx: ToolContext = {
-    conn,
-    projectDir,
-    config,
-    mcpxClient,
-  };
 
   const cleanup = async () => {
     await mcpxClient?.close();
   };
 
   return {
-    conn,
+    dbPath,
     threadId,
     projectDir,
     config,
     messages,
-    toolCtx,
     skills,
+    mcpxClient,
     cleanup,
   };
 }
@@ -110,11 +105,13 @@ export async function sendMessage(
   callbacks: ChatTurnCallbacks,
 ): Promise<void> {
   // Log and append user message
-  await logInteraction(session.conn, session.threadId, {
-    role: "user",
-    kind: "message",
-    content: userMessage,
-  });
+  await withDb(session.dbPath, (conn) =>
+    logInteraction(conn, session.threadId, {
+      role: "user",
+      kind: "message",
+      content: userMessage,
+    }),
+  );
 
   session.messages.push({ role: "user", content: userMessage });
 
@@ -122,7 +119,7 @@ export async function sendMessage(
   if (session.messages.length === 1) {
     void generateThreadTitle(
       session.config,
-      session.conn,
+      session.dbPath,
       session.threadId,
       userMessage,
     );
@@ -132,15 +129,14 @@ export async function sendMessage(
     messages: session.messages,
     projectDir: session.projectDir,
     config: session.config,
-    conn: session.conn,
+    dbPath: session.dbPath,
     threadId: session.threadId,
-    toolCtx: session.toolCtx,
+    mcpxClient: session.mcpxClient,
     callbacks,
   });
 }
 
 export async function endChatSession(session: ChatSession): Promise<void> {
-  await endThread(session.conn, session.threadId);
+  await withDb(session.dbPath, (conn) => endThread(conn, session.threadId));
   await session.cleanup();
-  session.conn.close();
 }

--- a/src/commands/tools.ts
+++ b/src/commands/tools.ts
@@ -2,6 +2,7 @@ import ansis from "ansis";
 import type { Command } from "commander";
 import { z } from "zod";
 import { loadConfig } from "../config/loader.ts";
+import { getDbPath } from "../constants.ts";
 import { registerAllTools } from "../tools/registry.ts";
 import {
   type AnyToolDefinition,
@@ -112,6 +113,7 @@ function registerToolAsCLI(parent: Command, tool: AnyToolDefinition) {
 
         const ctx: ToolContext = {
           conn,
+          dbPath: getDbPath(dir),
           projectDir: dir,
           config: await loadConfig(dir),
           mcpxClient: null,

--- a/src/commands/with-db.ts
+++ b/src/commands/with-db.ts
@@ -1,23 +1,22 @@
 import type { Command } from "commander";
 import { getDbPath } from "../constants.ts";
 import type { DbConnection } from "../db/connection.ts";
-import { getConnection } from "../db/connection.ts";
+import { withDb as coreWithDb } from "../db/connection.ts";
 import { migrate } from "../db/schema.ts";
 
 /**
  * Open a migrated DB connection from the CLI --dir flag, run the callback,
- * and guarantee the connection is closed afterward.
+ * and guarantee the connection is closed afterward. Retries on lock
+ * conflicts so CLI invocations cooperate with a running daemon/chat.
  */
 export async function withDb<T>(
   program: Command,
   fn: (conn: DbConnection, dir: string) => Promise<T>,
 ): Promise<T> {
   const dir = program.opts().dir;
-  const conn = await getConnection(getDbPath(dir));
-  await migrate(conn);
-  try {
-    return await fn(conn, dir);
-  } finally {
-    conn.close();
-  }
+  const dbPath = getDbPath(dir);
+  return coreWithDb(dbPath, async (conn) => {
+    await migrate(conn);
+    return fn(conn, dir);
+  });
 }

--- a/src/context/fetcher.ts
+++ b/src/context/fetcher.ts
@@ -161,6 +161,7 @@ async function runFetcherLoop(
 
   const toolCtx: ToolContext = {
     conn: null as unknown as DbConnection,
+    dbPath: "",
     projectDir: "",
     config,
     mcpxClient,

--- a/src/context/ingest.ts
+++ b/src/context/ingest.ts
@@ -79,7 +79,9 @@ export interface IngestionResult {
 
 /**
  * Store a prepared ingestion into the database.
- * This is the fast DB-write phase and must be called sequentially.
+ * All statements in BEGIN/COMMIT/ROLLBACK must share one connection, so the
+ * caller must pass a connection that lives long enough for the transaction
+ * (the tool executor wraps each tool call in `withDb`, which satisfies this).
  */
 export async function storeIngestion(
   conn: DbConnection,

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1,7 +1,7 @@
 import ansis from "ansis";
 import { loadConfig } from "../config/loader.ts";
 import { getDbPath } from "../constants.ts";
-import { getConnection } from "../db/connection.ts";
+import { withDb } from "../db/connection.ts";
 import { migrate } from "../db/schema.ts";
 import { createMcpxClient } from "../mcpx/client.ts";
 import { logger } from "../utils/logger.ts";
@@ -49,8 +49,10 @@ export async function startDaemon(
 ): Promise<void> {
   const config = await loadConfig(projectDir);
   const dbPath = getDbPath(projectDir);
-  const conn = await getConnection(dbPath);
-  await migrate(conn);
+
+  // One short-lived connection to apply migrations. After this returns,
+  // the file lock is released so CLI invocations can run freely.
+  await withDb(dbPath, (conn) => migrate(conn));
 
   // Initialize MCPX client for external tool access
   const mcpxClient = await createMcpxClient(projectDir);
@@ -64,7 +66,6 @@ export async function startDaemon(
     logger.info("Daemon shutting down...");
     await mcpxClient?.close();
     await removePidFile(projectDir);
-    conn.close();
     process.exit(0);
   };
 
@@ -81,7 +82,7 @@ export async function startDaemon(
   while (true) {
     let didWork = false;
     try {
-      didWork = await tick(projectDir, conn, config, mcpxClient, callbacks);
+      didWork = await tick(projectDir, dbPath, config, mcpxClient, callbacks);
     } catch (err) {
       logger.error(`Tick failed: ${err}`);
     }

--- a/src/daemon/llm.ts
+++ b/src/daemon/llm.ts
@@ -7,7 +7,7 @@ import type {
 } from "@anthropic-ai/sdk/resources/messages";
 import type { McpxClient } from "@evantahler/mcpx";
 import type { BotholomewConfig } from "../config/schemas.ts";
-import type { DbConnection } from "../db/connection.ts";
+import { withDb } from "../db/connection.ts";
 import { getTask, type Task } from "../db/tasks.ts";
 import { logInteraction } from "../db/threads.ts";
 import { registerAllTools } from "../tools/registry.ts";
@@ -44,32 +44,32 @@ export async function runAgentLoop(input: {
   systemPrompt: string;
   task: Task;
   config: Required<BotholomewConfig>;
-  conn: DbConnection;
+  dbPath: string;
   threadId: string;
   projectDir: string;
   mcpxClient?: McpxClient | null;
   callbacks?: DaemonStreamCallbacks;
 }): Promise<AgentLoopResult> {
-  const { systemPrompt, task, config, conn, threadId, projectDir, callbacks } =
-    input;
+  const {
+    systemPrompt,
+    task,
+    config,
+    dbPath,
+    threadId,
+    projectDir,
+    callbacks,
+  } = input;
 
   const client = new Anthropic({
     apiKey: config.anthropic_api_key || undefined,
   });
-
-  const toolCtx: ToolContext = {
-    conn,
-    projectDir,
-    config,
-    mcpxClient: input.mcpxClient ?? null,
-  };
 
   // Build predecessor context from completed blocking tasks
   let predecessorContext = "";
   if (task.blocked_by.length > 0) {
     const predecessorOutputs: string[] = [];
     for (const blockerId of task.blocked_by) {
-      const blocker = await getTask(conn, blockerId);
+      const blocker = await withDb(dbPath, (conn) => getTask(conn, blockerId));
       if (blocker?.output) {
         predecessorOutputs.push(
           `### ${blocker.name} (${blocker.id})\n${blocker.output}`,
@@ -86,11 +86,13 @@ export async function runAgentLoop(input: {
   const messages: MessageParam[] = [{ role: "user", content: userMessage }];
 
   // Log the initial user message
-  await logInteraction(conn, threadId, {
-    role: "user",
-    kind: "message",
-    content: userMessage,
-  });
+  await withDb(dbPath, (conn) =>
+    logInteraction(conn, threadId, {
+      role: "user",
+      kind: "message",
+      content: userMessage,
+    }),
+  );
 
   clearLargeResults();
   const daemonTools = toAnthropicTools();
@@ -144,13 +146,15 @@ export async function runAgentLoop(input: {
     // Log assistant text blocks
     for (const block of response.content) {
       if (block.type === "text" && block.text) {
-        await logInteraction(conn, threadId, {
-          role: "assistant",
-          kind: "message",
-          content: block.text,
-          durationMs,
-          tokenCount,
-        });
+        await withDb(dbPath, (conn) =>
+          logInteraction(conn, threadId, {
+            role: "assistant",
+            kind: "message",
+            content: block.text,
+            durationMs,
+            tokenCount,
+          }),
+        );
       }
     }
 
@@ -173,20 +177,30 @@ export async function runAgentLoop(input: {
     for (const toolUse of toolUseBlocks) {
       const toolInput = JSON.stringify(toolUse.input);
       callbacks?.onToolStart(toolUse.name, toolInput);
-      await logInteraction(conn, threadId, {
-        role: "assistant",
-        kind: "tool_use",
-        content: `Calling ${toolUse.name}`,
-        toolName: toolUse.name,
-        toolInput,
-      });
+      await withDb(dbPath, (conn) =>
+        logInteraction(conn, threadId, {
+          role: "assistant",
+          kind: "tool_use",
+          content: `Calling ${toolUse.name}`,
+          toolName: toolUse.name,
+          toolInput,
+        }),
+      );
     }
 
-    // Execute all tools in parallel
+    // Execute all tools in parallel. Each tool call opens its own short-lived
+    // connection (or none, if the tool uses dbPath internally) via
+    // executeToolCall — so parallel tool calls share the process-local
+    // DuckDB instance and release the file lock as soon as they finish.
     const execResults = await Promise.all(
       toolUseBlocks.map(async (toolUse) => {
         const start = Date.now();
-        const result = await executeToolCall(toolUse, toolCtx);
+        const result = await executeToolCall(toolUse, {
+          dbPath,
+          projectDir,
+          config,
+          mcpxClient: input.mcpxClient ?? null,
+        });
         const elapsed = Date.now() - start;
         callbacks?.onToolEnd(
           toolUse.name,
@@ -201,13 +215,15 @@ export async function runAgentLoop(input: {
     // Log results and collect tool_result messages
     const toolResults: ToolResultBlockParam[] = [];
     for (const { toolUse, result, durationMs } of execResults) {
-      await logInteraction(conn, threadId, {
-        role: "tool",
-        kind: "tool_result",
-        content: result.output,
-        toolName: toolUse.name,
-        durationMs,
-      });
+      await withDb(dbPath, (conn) =>
+        logInteraction(conn, threadId, {
+          role: "tool",
+          kind: "tool_result",
+          content: result.output,
+          toolName: toolUse.name,
+          durationMs,
+        }),
+      );
 
       if (result.terminal && result.agentResult) {
         return result.agentResult;
@@ -234,9 +250,16 @@ interface ToolCallResult {
   agentResult?: AgentLoopResult;
 }
 
+interface ToolCallCtx {
+  dbPath: string;
+  projectDir: string;
+  config: Required<BotholomewConfig>;
+  mcpxClient: McpxClient | null;
+}
+
 async function executeToolCall(
   toolUse: ToolUseBlock,
-  ctx: ToolContext,
+  baseCtx: ToolCallCtx,
 ): Promise<ToolCallResult> {
   const tool = getTool(toolUse.name);
   if (!tool) {
@@ -261,7 +284,10 @@ async function executeToolCall(
 
   let result: unknown;
   try {
-    result = await tool.execute(parsed.data, ctx);
+    result = await withDb(baseCtx.dbPath, (conn) => {
+      const ctx: ToolContext = { ...baseCtx, conn };
+      return tool.execute(parsed.data, ctx);
+    });
   } catch (err) {
     return {
       output: `Tool ${toolUse.name} threw an error: ${err}. You may retry with different parameters or try an alternative approach.`,

--- a/src/daemon/prompt.ts
+++ b/src/daemon/prompt.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import type { BotholomewConfig } from "../config/schemas.ts";
 import { getBotholomewDir } from "../constants.ts";
 import { embedSingle } from "../context/embedder.ts";
-import type { DbConnection } from "../db/connection.ts";
+import { withDb } from "../db/connection.ts";
 import { hybridSearch } from "../db/embeddings.ts";
 import type { Task } from "../db/tasks.ts";
 import { parseContextFile } from "../utils/frontmatter.ts";
@@ -89,7 +89,7 @@ export function buildMetaHeader(projectDir: string): string[] {
 export async function buildSystemPrompt(
   projectDir: string,
   task?: Task,
-  conn?: DbConnection,
+  dbPath?: string,
   _config?: Required<BotholomewConfig>,
   options?: { hasMcpTools?: boolean },
 ): Promise<string> {
@@ -107,11 +107,13 @@ export async function buildSystemPrompt(
   parts.push(...(await loadPersistentContext(projectDir, taskKeywords)));
 
   // Relevant context from embeddings search
-  if (task && conn && _config?.openai_api_key) {
+  if (task && dbPath && _config?.openai_api_key) {
     try {
       const query = `${task.name} ${task.description}`;
       const queryVec = await embedSingle(query, _config);
-      const results = await hybridSearch(conn, query, queryVec, 5);
+      const results = await withDb(dbPath, (conn) =>
+        hybridSearch(conn, query, queryVec, 5),
+      );
 
       if (results.length > 0) {
         parts.push("## Relevant Context");

--- a/src/daemon/schedules.ts
+++ b/src/daemon/schedules.ts
@@ -1,6 +1,6 @@
 import Anthropic from "@anthropic-ai/sdk";
 import type { BotholomewConfig } from "../config/schemas.ts";
-import type { DbConnection } from "../db/connection.ts";
+import { withDb } from "../db/connection.ts";
 import {
   listSchedules,
   markScheduleRun,
@@ -105,14 +105,17 @@ Is this schedule due to run? If yes, what tasks should be created?`;
 }
 
 export async function processSchedules(
-  conn: DbConnection,
+  dbPath: string,
   config: Required<BotholomewConfig>,
 ): Promise<void> {
-  const schedules = await listSchedules(conn, { enabled: true });
+  const schedules = await withDb(dbPath, (conn) =>
+    listSchedules(conn, { enabled: true }),
+  );
   if (schedules.length === 0) return;
 
   for (const schedule of schedules) {
     try {
+      // LLM evaluation does no DB work — no connection held here.
       const evaluation = await evaluateSchedule(config, schedule);
 
       if (!evaluation.isDue) {
@@ -128,16 +131,18 @@ export async function processSchedules(
           .map((i: number) => createdIds[i])
           .filter(Boolean) as string[];
 
-        const task = await createTask(conn, {
-          name: taskDef.name,
-          description: taskDef.description,
-          priority: taskDef.priority,
-          blocked_by: blockedBy,
-        });
+        const task = await withDb(dbPath, (conn) =>
+          createTask(conn, {
+            name: taskDef.name,
+            description: taskDef.description,
+            priority: taskDef.priority,
+            blocked_by: blockedBy,
+          }),
+        );
         createdIds.push(task.id);
       }
 
-      await markScheduleRun(conn, schedule.id);
+      await withDb(dbPath, (conn) => markScheduleRun(conn, schedule.id));
       logger.info(
         `Schedule "${schedule.name}" fired, created ${createdIds.length} task(s)`,
       );

--- a/src/daemon/tick.ts
+++ b/src/daemon/tick.ts
@@ -1,6 +1,6 @@
 import type { McpxClient } from "@evantahler/mcpx";
 import type { BotholomewConfig } from "../config/schemas.ts";
-import type { DbConnection } from "../db/connection.ts";
+import { withDb } from "../db/connection.ts";
 import {
   claimNextTask,
   resetStaleTasks,
@@ -16,7 +16,7 @@ import { processSchedules } from "./schedules.ts";
 
 export async function tick(
   projectDir: string,
-  conn: DbConnection,
+  dbPath: string,
   config: Required<BotholomewConfig>,
   mcpxClient?: McpxClient | null,
   callbacks?: DaemonStreamCallbacks,
@@ -24,9 +24,8 @@ export async function tick(
   logger.debug("Tick starting...");
 
   // Reset stale tasks stuck in in_progress
-  const resetIds = await resetStaleTasks(
-    conn,
-    config.max_tick_duration_seconds * 3,
+  const resetIds = await withDb(dbPath, (conn) =>
+    resetStaleTasks(conn, config.max_tick_duration_seconds * 3),
   );
   if (resetIds.length > 0) {
     logger.warn(
@@ -36,13 +35,13 @@ export async function tick(
 
   // Process schedules (may create new tasks)
   try {
-    await processSchedules(conn, config);
+    await processSchedules(dbPath, config);
   } catch (err) {
     logger.error(`Schedule processing failed: ${err}`);
   }
 
   // Claim a task
-  const task = await claimNextTask(conn);
+  const task = await withDb(dbPath, (conn) => claimNextTask(conn));
   if (!task) {
     logger.debug("No tasks to work on. Sleeping.");
     return false;
@@ -52,24 +51,27 @@ export async function tick(
   callbacks?.onTaskStart(task);
 
   // Create a thread for this tick
-  const threadId = await createThread(
-    conn,
-    "daemon_tick",
-    task.id,
-    `Working: ${task.name}`,
+  const threadId = await withDb(dbPath, (conn) =>
+    createThread(conn, "daemon_tick", task.id, `Working: ${task.name}`),
   );
 
   // Build system prompt (includes task-relevant context from embeddings)
-  const systemPrompt = await buildSystemPrompt(projectDir, task, conn, config, {
-    hasMcpTools: mcpxClient != null,
-  });
+  const systemPrompt = await buildSystemPrompt(
+    projectDir,
+    task,
+    dbPath,
+    config,
+    {
+      hasMcpTools: mcpxClient != null,
+    },
+  );
 
   try {
     const result = await runAgentLoop({
       systemPrompt,
       task,
       config,
-      conn,
+      dbPath,
       threadId,
       projectDir,
       mcpxClient,
@@ -77,42 +79,50 @@ export async function tick(
     });
 
     // Update task status and store output
-    await updateTaskStatus(
-      conn,
-      task.id,
-      result.status,
-      result.reason,
-      result.reason,
+    await withDb(dbPath, (conn) =>
+      updateTaskStatus(
+        conn,
+        task.id,
+        result.status,
+        result.reason,
+        result.reason,
+      ),
     );
 
     // Log the status change
-    await logInteraction(conn, threadId, {
-      role: "system",
-      kind: "status_change",
-      content: `Task ${task.id} -> ${result.status}${result.reason ? `: ${result.reason}` : ""}`,
-    });
+    await withDb(dbPath, (conn) =>
+      logInteraction(conn, threadId, {
+        role: "system",
+        kind: "status_change",
+        content: `Task ${task.id} -> ${result.status}${result.reason ? `: ${result.reason}` : ""}`,
+      }),
+    );
 
     logger.info(`Task ${task.id} -> ${result.status}`);
 
-    // Generate a descriptive title for the thread
+    // Generate a descriptive title for the thread (fire-and-forget)
     void generateThreadTitle(
       config,
-      conn,
+      dbPath,
       threadId,
       `Task: ${task.name}\nDescription: ${task.description}\nOutcome: ${result.status}${result.reason ? ` — ${result.reason}` : ""}`,
     );
   } catch (err) {
-    await updateTaskStatus(conn, task.id, "failed", String(err), String(err));
+    await withDb(dbPath, (conn) =>
+      updateTaskStatus(conn, task.id, "failed", String(err), String(err)),
+    );
 
-    await logInteraction(conn, threadId, {
-      role: "system",
-      kind: "status_change",
-      content: `Task ${task.id} failed: ${err}`,
-    });
+    await withDb(dbPath, (conn) =>
+      logInteraction(conn, threadId, {
+        role: "system",
+        kind: "status_change",
+        content: `Task ${task.id} failed: ${err}`,
+      }),
+    );
 
     logger.error(`Task ${task.id} failed: ${err}`);
   } finally {
-    await endThread(conn, threadId);
+    await withDb(dbPath, (conn) => endThread(conn, threadId));
   }
 
   return true;

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -11,12 +11,20 @@ export class DbConnection {
   // biome-ignore lint/suspicious/noExplicitAny: DuckDB internal types
   private conn: any;
   // biome-ignore lint/suspicious/noExplicitAny: DuckDB internal types
-  private instance: any;
+  private readonly ownedInstance: any;
+  private readonly dbPath: string;
+  private closed = false;
 
-  // biome-ignore lint/suspicious/noExplicitAny: DuckDB internal types
-  constructor(conn: any, instance: any) {
+  constructor(
+    // biome-ignore lint/suspicious/noExplicitAny: DuckDB internal types
+    conn: any,
+    // biome-ignore lint/suspicious/noExplicitAny: DuckDB internal types
+    ownedInstance: any,
+    dbPath: string,
+  ) {
     this.conn = conn;
-    this.instance = instance;
+    this.ownedInstance = ownedInstance;
+    this.dbPath = dbPath;
   }
 
   /** Execute raw SQL with no return value. */
@@ -62,10 +70,22 @@ export class DbConnection {
     return { changes: result.rowsChanged };
   }
 
-  /** Close the connection and dispose of the instance. */
+  /**
+   * Disconnect and release this connection's share of the DuckDB instance.
+   * For file-backed DBs, the instance is closed (and the OS file lock
+   * released) once every overlapping connection in this process has closed.
+   * For `:memory:` DBs, the instance is owned by this connection and closed
+   * immediately.
+   */
   close(): void {
+    if (this.closed) return;
+    this.closed = true;
     this.conn.disconnectSync();
-    this.instance.closeSync();
+    if (this.ownedInstance) {
+      this.ownedInstance.closeSync();
+    } else {
+      releaseInstance(this.dbPath);
+    }
   }
 }
 
@@ -98,31 +118,140 @@ function flattenParams(params: SqlParam[]): SqlParam[] {
   return params.map((p) => (Array.isArray(p) ? JSON.stringify(p) : p));
 }
 
-export async function getConnection(dbPath?: string): Promise<DbConnection> {
-  const instance = await DuckDBInstance.create(dbPath ?? ":memory:");
-  const conn = await instance.connect();
+/**
+ * Refcounted, process-local cache of open DuckDB instances keyed by dbPath.
+ *
+ * DuckDB's file lock is held at the instance level, so we must close the
+ * instance — not just the connection — to let another process acquire the
+ * writer lock. At the same time, opening two instances for the same file
+ * from one process is unsafe. This cache resolves both: overlapping
+ * `getConnection` calls in the same process share a single instance; once
+ * every connection has closed, the instance is closed and evicted, which
+ * releases the OS file lock.
+ *
+ * `:memory:` paths bypass the cache so each test/caller gets its own
+ * isolated in-memory database.
+ */
+interface CachedInstance {
+  // biome-ignore lint/suspicious/noExplicitAny: DuckDB internal types
+  instance: any;
+  refCount: number;
+}
+const instanceCache = new Map<string, CachedInstance>();
+const pendingInstance = new Map<string, Promise<CachedInstance>>();
 
-  // Load VSS extension for vector similarity search
-  await conn.run("INSTALL vss; LOAD vss;");
-  // Enable HNSW index persistence for file-backed databases
-  await conn.run("SET hnsw_enable_experimental_persistence = true;");
-
-  return new DbConnection(conn, instance);
+function isMemoryPath(path: string): boolean {
+  return path === ":memory:" || path.startsWith(":memory:");
 }
 
+async function acquireSharedInstance(dbPath: string): Promise<CachedInstance> {
+  const existing = instanceCache.get(dbPath);
+  if (existing) {
+    existing.refCount += 1;
+    return existing;
+  }
+  const inFlight = pendingInstance.get(dbPath);
+  if (inFlight) {
+    const cached = await inFlight;
+    cached.refCount += 1;
+    return cached;
+  }
+  const creation = (async () => {
+    const instance = await DuckDBInstance.create(dbPath);
+    const cached: CachedInstance = { instance, refCount: 1 };
+    instanceCache.set(dbPath, cached);
+    return cached;
+  })();
+  pendingInstance.set(dbPath, creation);
+  try {
+    return await creation;
+  } finally {
+    pendingInstance.delete(dbPath);
+  }
+}
+
+function releaseInstance(dbPath: string): void {
+  const cached = instanceCache.get(dbPath);
+  if (!cached) return;
+  cached.refCount -= 1;
+  if (cached.refCount <= 0) {
+    instanceCache.delete(dbPath);
+    cached.instance.closeSync();
+  }
+}
+
+export async function getConnection(dbPath?: string): Promise<DbConnection> {
+  const path = dbPath ?? ":memory:";
+
+  if (isMemoryPath(path)) {
+    const instance = await DuckDBInstance.create(path);
+    const conn = await instance.connect();
+    await conn.run("INSTALL vss; LOAD vss;");
+    await conn.run("SET hnsw_enable_experimental_persistence = true;");
+    return new DbConnection(conn, instance, path);
+  }
+
+  const cached = await acquireSharedInstance(path);
+  try {
+    const conn = await cached.instance.connect();
+    // INSTALL is a no-op after the first successful install (the extension
+    // is persisted to the user's DuckDB extension directory). LOAD is
+    // cheap per connection.
+    await conn.run("INSTALL vss; LOAD vss;");
+    await conn.run("SET hnsw_enable_experimental_persistence = true;");
+    return new DbConnection(conn, null, path);
+  } catch (err) {
+    releaseInstance(path);
+    throw err;
+  }
+}
+
+/**
+ * Open a DuckDB connection for a single logical unit of work and guarantee
+ * it is closed afterward. Retries on lock conflicts so two processes that
+ * race on the file lock cooperate instead of failing hard.
+ *
+ * Prefer one `withDb` per logical operation. The file lock is only released
+ * when every connection (across this process's overlapping callers) has
+ * been closed, so holding the connection across non-DB work (LLM calls,
+ * network I/O, filesystem walks) keeps other processes blocked.
+ */
+export async function withDb<T>(
+  dbPath: string,
+  fn: (conn: DbConnection) => Promise<T>,
+): Promise<T> {
+  const conn = await withRetry(() => getConnection(dbPath));
+  try {
+    return await fn(conn);
+  } finally {
+    conn.close();
+  }
+}
+
+/**
+ * Retry `fn` with exponential backoff when it fails with a DuckDB file-lock
+ * conflict ("Conflicting lock is held…"). Other errors propagate immediately.
+ */
 export async function withRetry<T>(
   fn: () => Promise<T>,
-  maxRetries = 5,
+  maxRetries = 8,
 ): Promise<T> {
   let lastError: unknown;
   for (let attempt = 0; attempt < maxRetries; attempt++) {
     try {
       return await fn();
     } catch (err) {
+      if (!isLockConflict(err)) throw err;
       lastError = err;
       if (attempt === maxRetries - 1) throw err;
+      // 100, 200, 400, 800, 1600, 3200, 6400, 12800 — up to ~25s total
       await Bun.sleep(100 * 2 ** attempt);
     }
   }
   throw lastError;
+}
+
+function isLockConflict(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.includes("Conflicting lock") || msg.includes("could not be set");
 }

--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -5,7 +5,15 @@ import type { BotholomewConfig } from "../config/schemas.ts";
 import type { DbConnection } from "../db/connection.ts";
 
 export interface ToolContext {
+  /**
+   * Short-lived DB connection scoped to this tool call. Safe for single-query
+   * tools. Do NOT hold it across slow work (network, embedding, long loops) —
+   * the instance-level file lock stays held until every connection closes.
+   * For long-running tools, use `dbPath` with `withDb` per logical operation.
+   */
   conn: DbConnection;
+  /** Path to the DuckDB file. Use with `withDb` for long-running tools. */
+  dbPath: string;
   projectDir: string;
   config: Required<BotholomewConfig>;
   mcpxClient: McpxClient | null;

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -7,6 +7,7 @@ import {
   startChatSession,
 } from "../chat/session.ts";
 import { MAX_INLINE_CHARS, PAGE_SIZE_CHARS } from "../daemon/large-results.ts";
+import { withDb } from "../db/connection.ts";
 import type { Interaction } from "../db/threads.ts";
 import { getThread } from "../db/threads.ts";
 import {
@@ -163,7 +164,9 @@ export function App({
         sessionRef.current = session;
 
         if (session.messages.length > 0) {
-          const threadData = await getThread(session.conn, session.threadId);
+          const threadData = await withDb(session.dbPath, (conn) =>
+            getThread(conn, session.threadId),
+          );
           if (threadData) {
             setMessages(
               restoreMessagesFromInteractions(threadData.interactions),
@@ -409,7 +412,9 @@ export function App({
     const refreshTitle = async () => {
       const session = sessionRef.current;
       if (!session) return;
-      const result = await getThread(session.conn, session.threadId);
+      const result = await withDb(session.dbPath, (conn) =>
+        getThread(conn, session.threadId),
+      );
       if (mounted && result?.thread.title) {
         setChatTitle(result.thread.title);
       }
@@ -547,18 +552,18 @@ export function App({
     [exit, processQueue, syncQueue],
   );
 
-  const sessionConn = sessionRef.current?.conn;
+  const sessionDbPath = sessionRef.current?.dbPath;
   const inputBarHeader = useMemo(
     () =>
-      sessionConn ? (
+      sessionDbPath ? (
         <StatusBar
           projectDir={projectDir}
-          conn={sessionConn}
+          dbPath={sessionDbPath}
           chatTitle={chatTitle}
           onDaemonStatusChange={setDaemonRunning}
         />
       ) : null,
-    [projectDir, sessionConn, chatTitle],
+    [projectDir, sessionDbPath, chatTitle],
   );
 
   const sessionSkills = ready ? sessionRef.current?.skills : undefined;
@@ -602,7 +607,7 @@ export function App({
     );
   }
 
-  const conn = sessionRef.current.conn;
+  const dbPath = sessionRef.current.dbPath;
   const threadId = sessionRef.current.threadId;
 
   return (
@@ -642,14 +647,14 @@ export function App({
         flexDirection="column"
         flexGrow={1}
       >
-        <ContextPanel conn={conn} isActive={activeTab === 3} />
+        <ContextPanel dbPath={dbPath} isActive={activeTab === 3} />
       </Box>
       <Box
         display={activeTab === 4 ? "flex" : "none"}
         flexDirection="column"
         flexGrow={1}
       >
-        <TaskPanel conn={conn} isActive={activeTab === 4} />
+        <TaskPanel dbPath={dbPath} isActive={activeTab === 4} />
       </Box>
       <Box
         display={activeTab === 5 ? "flex" : "none"}
@@ -657,7 +662,7 @@ export function App({
         flexGrow={1}
       >
         <ThreadPanel
-          conn={conn}
+          dbPath={dbPath}
           activeThreadId={threadId}
           isActive={activeTab === 5}
         />
@@ -667,7 +672,7 @@ export function App({
         flexDirection="column"
         flexGrow={1}
       >
-        <SchedulePanel conn={conn} isActive={activeTab === 6} />
+        <SchedulePanel dbPath={dbPath} isActive={activeTab === 6} />
       </Box>
       <Box
         display={activeTab === 7 ? "flex" : "none"}

--- a/src/tui/components/ContextPanel.tsx
+++ b/src/tui/components/ContextPanel.tsx
@@ -1,6 +1,6 @@
 import { Box, Text, useInput, useStdout } from "ink";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
-import type { DbConnection } from "../../db/connection.ts";
+import { withDb } from "../../db/connection.ts";
 import {
   type ContextItem,
   deleteContextItem,
@@ -11,7 +11,7 @@ import {
 } from "../../db/context.ts";
 
 interface ContextPanelProps {
-  conn: DbConnection;
+  dbPath: string;
   isActive: boolean;
 }
 
@@ -32,7 +32,7 @@ type Entry = DirEntry | FileEntry;
 const CHROME_LINES = 8;
 
 export const ContextPanel = memo(function ContextPanel({
-  conn,
+  dbPath,
   isActive,
 }: ContextPanelProps) {
   const { stdout } = useStdout();
@@ -64,10 +64,10 @@ export const ContextPanel = memo(function ContextPanel({
 
   const loadEntries = useCallback(
     async (path: string) => {
-      const dirs = await getDistinctDirectories(conn, path);
-      const files = await listContextItemsByPrefix(conn, path, {
-        recursive: false,
-      });
+      const [dirs, files] = await withDb(dbPath, async (conn) => [
+        await getDistinctDirectories(conn, path),
+        await listContextItemsByPrefix(conn, path, { recursive: false }),
+      ]);
 
       const dirEntries: DirEntry[] = dirs.map((d) => ({
         type: "directory",
@@ -84,7 +84,7 @@ export const ContextPanel = memo(function ContextPanel({
       setScrollOffset(0);
       setPreview(null);
     },
-    [conn],
+    [dbPath],
   );
 
   useEffect(() => {
@@ -99,13 +99,15 @@ export const ContextPanel = memo(function ContextPanel({
         setSearchResults(null);
         return;
       }
-      const results = await searchContextByKeyword(conn, query.trim(), 50);
+      const results = await withDb(dbPath, (conn) =>
+        searchContextByKeyword(conn, query.trim(), 50),
+      );
       setSearchResults(results);
       setCursor(0);
       setScrollOffset(0);
       setPreview(null);
     },
-    [conn],
+    [dbPath],
   );
 
   // Compute the items list and visible window for the current view
@@ -171,11 +173,13 @@ export const ContextPanel = memo(function ContextPanel({
         if (input === "y" || input === "d") {
           const entry = entries[cursor];
           if (entry) {
-            if (entry.type === "directory") {
-              deleteContextItemsByPrefix(conn, entry.path);
-            } else {
-              deleteContextItem(conn, entry.item.id);
-            }
+            void withDb(dbPath, async (conn) => {
+              if (entry.type === "directory") {
+                await deleteContextItemsByPrefix(conn, entry.path);
+              } else {
+                await deleteContextItem(conn, entry.item.id);
+              }
+            });
             setConfirmDelete(false);
             loadEntries(currentPath);
           }

--- a/src/tui/components/SchedulePanel.tsx
+++ b/src/tui/components/SchedulePanel.tsx
@@ -1,6 +1,6 @@
 import { Box, Text, useInput, useStdout } from "ink";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
-import type { DbConnection } from "../../db/connection.ts";
+import { withDb } from "../../db/connection.ts";
 import {
   deleteSchedule,
   listSchedules,
@@ -10,7 +10,7 @@ import {
 import { ansi, theme } from "../theme.ts";
 
 interface SchedulePanelProps {
-  conn: DbConnection;
+  dbPath: string;
   isActive: boolean;
 }
 
@@ -108,7 +108,7 @@ function cycleFilter<T>(current: T | null, values: readonly T[]): T | null {
 }
 
 export const SchedulePanel = memo(function SchedulePanel({
-  conn,
+  dbPath,
   isActive,
 }: SchedulePanelProps) {
   const { stdout } = useStdout();
@@ -127,7 +127,9 @@ export const SchedulePanel = memo(function SchedulePanel({
     const refresh = async () => {
       const filters: { enabled?: boolean } = {};
       if (enabledFilter !== null) filters.enabled = enabledFilter;
-      const result = await listSchedules(conn, filters);
+      const result = await withDb(dbPath, (conn) =>
+        listSchedules(conn, filters),
+      );
       if (mounted) {
         setSchedules(result);
         setSelectedIndex((prev) =>
@@ -142,7 +144,7 @@ export const SchedulePanel = memo(function SchedulePanel({
       mounted = false;
       clearInterval(interval);
     };
-  }, [conn, enabledFilter, refreshTick]);
+  }, [dbPath, enabledFilter, refreshTick]);
 
   const selectedSchedule = schedules[selectedIndex];
 
@@ -182,7 +184,9 @@ export const SchedulePanel = memo(function SchedulePanel({
       if (confirmDelete) {
         if (input === "y" || input === "d") {
           if (selectedSchedule) {
-            deleteSchedule(conn, selectedSchedule.id).then(() => {
+            withDb(dbPath, (conn) =>
+              deleteSchedule(conn, selectedSchedule.id),
+            ).then(() => {
               forceRefresh();
             });
           }
@@ -242,9 +246,11 @@ export const SchedulePanel = memo(function SchedulePanel({
         return;
       }
       if (input === "e" && selectedSchedule) {
-        updateSchedule(conn, selectedSchedule.id, {
-          enabled: !selectedSchedule.enabled,
-        }).then(() => {
+        withDb(dbPath, (conn) =>
+          updateSchedule(conn, selectedSchedule.id, {
+            enabled: !selectedSchedule.enabled,
+          }),
+        ).then(() => {
           forceRefresh();
         });
         return;

--- a/src/tui/components/StatusBar.tsx
+++ b/src/tui/components/StatusBar.tsx
@@ -1,13 +1,13 @@
 import { Box, Text } from "ink";
 import { useEffect, useState } from "react";
-import type { DbConnection } from "../../db/connection.ts";
+import { withDb } from "../../db/connection.ts";
 import { listTasks } from "../../db/tasks.ts";
 import { getDaemonStatus } from "../../utils/pid.ts";
 import { LogoChar } from "./Logo.tsx";
 
 interface StatusBarProps {
   projectDir: string;
-  conn: DbConnection;
+  dbPath: string;
   chatTitle?: string;
   onDaemonStatusChange?: (running: boolean) => void;
 }
@@ -20,7 +20,7 @@ interface Status {
 
 export function StatusBar({
   projectDir,
-  conn,
+  dbPath,
   chatTitle,
   onDaemonStatusChange,
 }: StatusBarProps) {
@@ -35,8 +35,10 @@ export function StatusBar({
 
     const refresh = async () => {
       const daemon = await getDaemonStatus(projectDir);
-      const pending = await listTasks(conn, { status: "pending" });
-      const inProgress = await listTasks(conn, { status: "in_progress" });
+      const [pending, inProgress] = await withDb(dbPath, async (conn) => [
+        await listTasks(conn, { status: "pending" }),
+        await listTasks(conn, { status: "in_progress" }),
+      ]);
       if (mounted) {
         const daemonRunning = daemon !== null;
         setStatus({
@@ -54,7 +56,7 @@ export function StatusBar({
       mounted = false;
       clearInterval(interval);
     };
-  }, [projectDir, conn, onDaemonStatusChange]);
+  }, [projectDir, dbPath, onDaemonStatusChange]);
 
   return (
     <Box paddingX={0}>

--- a/src/tui/components/TaskPanel.tsx
+++ b/src/tui/components/TaskPanel.tsx
@@ -1,6 +1,6 @@
 import { Box, Text, useInput, useStdout } from "ink";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
-import type { DbConnection } from "../../db/connection.ts";
+import { withDb } from "../../db/connection.ts";
 import {
   deleteTask,
   listTasks,
@@ -11,7 +11,7 @@ import {
 import { ansi, theme } from "../theme.ts";
 
 interface TaskPanelProps {
-  conn: DbConnection;
+  dbPath: string;
   isActive: boolean;
 }
 
@@ -145,7 +145,7 @@ function cycleFilter<T>(current: T | null, values: readonly T[]): T | null {
 }
 
 export const TaskPanel = memo(function TaskPanel({
-  conn,
+  dbPath,
   isActive,
 }: TaskPanelProps) {
   const { stdout } = useStdout();
@@ -171,7 +171,7 @@ export const TaskPanel = memo(function TaskPanel({
       } = {};
       if (statusFilter) filters.status = statusFilter;
       if (priorityFilter) filters.priority = priorityFilter;
-      const result = await listTasks(conn, filters);
+      const result = await withDb(dbPath, (conn) => listTasks(conn, filters));
       if (mounted) {
         setTasks(result);
         setSelectedIndex((prev) =>
@@ -186,7 +186,7 @@ export const TaskPanel = memo(function TaskPanel({
       mounted = false;
       clearInterval(interval);
     };
-  }, [conn, statusFilter, priorityFilter, refreshTick]);
+  }, [dbPath, statusFilter, priorityFilter, refreshTick]);
 
   const selectedTask = tasks[selectedIndex];
 
@@ -275,7 +275,7 @@ export const TaskPanel = memo(function TaskPanel({
         return;
       }
       if (input === "d" && selectedTask) {
-        deleteTask(conn, selectedTask.id).then(() => {
+        withDb(dbPath, (conn) => deleteTask(conn, selectedTask.id)).then(() => {
           forceRefresh();
         });
         return;

--- a/src/tui/components/ThreadPanel.tsx
+++ b/src/tui/components/ThreadPanel.tsx
@@ -1,6 +1,6 @@
 import { Box, Text, useInput, useStdout } from "ink";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { DbConnection } from "../../db/connection.ts";
+import { withDb } from "../../db/connection.ts";
 import {
   deleteThread,
   getInteractionsAfter,
@@ -13,7 +13,7 @@ import {
 import { ansi, theme } from "../theme.ts";
 
 interface ThreadPanelProps {
-  conn: DbConnection;
+  dbPath: string;
   activeThreadId: string;
   isActive: boolean;
 }
@@ -181,7 +181,7 @@ function cycleFilter<T>(current: T | null, values: readonly T[]): T | null {
 }
 
 export const ThreadPanel = memo(function ThreadPanel({
-  conn,
+  dbPath,
   activeThreadId,
   isActive,
 }: ThreadPanelProps) {
@@ -210,7 +210,7 @@ export const ThreadPanel = memo(function ThreadPanel({
     const refresh = async () => {
       const filters: { type?: Thread["type"] } = {};
       if (typeFilter) filters.type = typeFilter;
-      const result = await listThreads(conn, filters);
+      const result = await withDb(dbPath, (conn) => listThreads(conn, filters));
       if (mounted) {
         setThreads(result);
         setSelectedIndex((prev) =>
@@ -225,7 +225,7 @@ export const ThreadPanel = memo(function ThreadPanel({
       mounted = false;
       clearInterval(interval);
     };
-  }, [conn, typeFilter, refreshTick]);
+  }, [dbPath, typeFilter, refreshTick]);
 
   // Filter threads by search query
   const filteredThreads = useMemo(() => {
@@ -245,16 +245,18 @@ export const ThreadPanel = memo(function ThreadPanel({
       return;
     }
 
-    getThread(conn, selectedThread.id).then((result) => {
-      if (mounted && result) {
-        setSelectedDetail(result);
-      }
-    });
+    withDb(dbPath, (conn) => getThread(conn, selectedThread.id)).then(
+      (result) => {
+        if (mounted && result) {
+          setSelectedDetail(result);
+        }
+      },
+    );
 
     return () => {
       mounted = false;
     };
-  }, [conn, selectedThread?.id, following]);
+  }, [dbPath, selectedThread?.id, following]);
 
   // Follow mode: poll for new interactions every 1s
   // biome-ignore lint/correctness/useExhaustiveDependencies: following and selectedThread?.id are the intentional triggers
@@ -264,10 +266,12 @@ export const ThreadPanel = memo(function ThreadPanel({
 
     const poll = async () => {
       try {
-        const newInteractions = await getInteractionsAfter(
-          conn,
-          selectedThread.id,
-          lastSeenSequenceRef.current,
+        const newInteractions = await withDb(dbPath, (conn) =>
+          getInteractionsAfter(
+            conn,
+            selectedThread.id,
+            lastSeenSequenceRef.current,
+          ),
         );
         if (!mounted || newInteractions.length === 0) return;
 
@@ -286,11 +290,15 @@ export const ThreadPanel = memo(function ThreadPanel({
         // Auto-scroll will be handled by the detailLines/maxDetailScroll recalc
         setDetailScroll(Number.MAX_SAFE_INTEGER);
 
-        const ended = await isThreadEnded(conn, selectedThread.id);
+        const ended = await withDb(dbPath, (conn) =>
+          isThreadEnded(conn, selectedThread.id),
+        );
         if (mounted && ended) {
           setFollowing(false);
           // Refresh the thread to get the ended_at timestamp
-          const result = await getThread(conn, selectedThread.id);
+          const result = await withDb(dbPath, (conn) =>
+            getThread(conn, selectedThread.id),
+          );
           if (mounted && result) {
             setSelectedDetail(result);
           }
@@ -306,7 +314,7 @@ export const ThreadPanel = memo(function ThreadPanel({
       mounted = false;
       clearInterval(interval);
     };
-  }, [conn, following, selectedThread?.id]);
+  }, [dbPath, following, selectedThread?.id]);
 
   const isActiveSelected = selectedThread?.id === activeThreadId;
 
@@ -375,7 +383,9 @@ export const ThreadPanel = memo(function ThreadPanel({
       if (confirmDelete) {
         if (input === "y" || input === "d") {
           if (selectedThread && !isActiveSelected) {
-            deleteThread(conn, selectedThread.id).then(() => {
+            withDb(dbPath, (conn) =>
+              deleteThread(conn, selectedThread.id),
+            ).then(() => {
               forceRefresh();
             });
           }

--- a/src/utils/title.ts
+++ b/src/utils/title.ts
@@ -1,16 +1,18 @@
 import Anthropic from "@anthropic-ai/sdk";
 import type { BotholomewConfig } from "../config/schemas.ts";
-import type { DbConnection } from "../db/connection.ts";
+import { withDb } from "../db/connection.ts";
 import { updateThreadTitle } from "../db/threads.ts";
 import { logger } from "./logger.ts";
 
 /**
  * Generate a short title for a thread using the chunker model (Haiku).
  * Fire-and-forget — errors are logged at debug level and never propagated.
+ * Opens its own short-lived DB connection for the write so callers can
+ * safely `void`-chain without holding a connection during the LLM call.
  */
 export async function generateThreadTitle(
   config: Required<BotholomewConfig>,
-  conn: DbConnection,
+  dbPath: string,
   threadId: string,
   context: string,
 ): Promise<void> {
@@ -39,7 +41,7 @@ export async function generateThreadTitle(
       .trim();
 
     if (title) {
-      await updateThreadTitle(conn, threadId, title);
+      await withDb(dbPath, (conn) => updateThreadTitle(conn, threadId, title));
     }
   } catch (err) {
     logger.warn(`Failed to generate thread title: ${err}`);

--- a/test/chat/session.test.ts
+++ b/test/chat/session.test.ts
@@ -7,6 +7,7 @@ import {
   endChatSession,
   startChatSession,
 } from "../../src/chat/session.ts";
+import { withDb } from "../../src/db/connection.ts";
 import { listThreads } from "../../src/db/threads.ts";
 
 let projectDir: string;
@@ -35,33 +36,36 @@ describe("startChatSession", () => {
   test("creates a session with a thread", async () => {
     session = await startChatSession(projectDir);
     expect(session.threadId).toBeTruthy();
-    expect(session.conn).toBeTruthy();
+    expect(session.dbPath).toBeTruthy();
     expect(session.messages).toEqual([]);
   });
 
   test("creates a chat_session thread in the database", async () => {
     session = await startChatSession(projectDir);
-    const threads = await listThreads(session.conn, {
-      type: "chat_session",
-    });
+    const threads = await withDb(session.dbPath, (conn) =>
+      listThreads(conn, { type: "chat_session" }),
+    );
     expect(threads.length).toBe(1);
     expect(threads[0]?.id).toBe(session.threadId);
   });
 });
 
 describe("endChatSession", () => {
-  test("closes the thread and connection", async () => {
+  test("marks the thread ended", async () => {
     session = await startChatSession(projectDir);
-    const conn = session.conn;
+    const dbPath = session.dbPath;
 
-    // Verify thread exists and is open
-    const threads = await listThreads(conn, { type: "chat_session" });
-    expect(threads[0]?.ended_at).toBeNull();
+    const before = await withDb(dbPath, (conn) =>
+      listThreads(conn, { type: "chat_session" }),
+    );
+    expect(before[0]?.ended_at).toBeNull();
 
     await endChatSession(session);
     session = null;
 
-    // Connection is closed, so we can't query it anymore
-    // But we verified the thread was open before closing
+    const after = await withDb(dbPath, (conn) =>
+      listThreads(conn, { type: "chat_session" }),
+    );
+    expect(after[0]?.ended_at).not.toBeNull();
   });
 });

--- a/test/daemon/llm.test.ts
+++ b/test/daemon/llm.test.ts
@@ -1,8 +1,12 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { DbConnection } from "../../src/db/connection.ts";
 import { createTask } from "../../src/db/tasks.ts";
 import { createThread, getThread } from "../../src/db/threads.ts";
-import { completionResponse, setupTestDb, TEST_CONFIG } from "../helpers.ts";
+import {
+  completionResponse,
+  setupTestDbFile,
+  TEST_CONFIG,
+} from "../helpers.ts";
 
 let mockCreate: ReturnType<typeof mock>;
 
@@ -20,12 +24,18 @@ mock.module("@anthropic-ai/sdk", () => {
 const { runAgentLoop } = await import("../../src/daemon/llm.ts");
 
 let conn: DbConnection;
+let dbPath: string;
+let cleanup: () => Promise<void>;
 
 const testConfig = { ...TEST_CONFIG, max_turns: 10 };
 
 beforeEach(async () => {
-  conn = await setupTestDb();
+  ({ conn, dbPath, cleanup } = await setupTestDbFile());
   mockCreate.mockClear();
+});
+
+afterEach(async () => {
+  await cleanup();
 });
 
 describe("runAgentLoop", () => {
@@ -54,7 +64,7 @@ describe("runAgentLoop", () => {
       systemPrompt: "You are a test agent.",
       task,
       config: testConfig,
-      conn,
+      dbPath,
       threadId,
       projectDir: "/tmp/test",
     });
@@ -87,7 +97,7 @@ describe("runAgentLoop", () => {
       systemPrompt: "You are a test agent.",
       task,
       config: testConfig,
-      conn,
+      dbPath,
       threadId,
       projectDir: "/tmp/test",
     });
@@ -120,7 +130,7 @@ describe("runAgentLoop", () => {
       systemPrompt: "You are a test agent.",
       task,
       config: testConfig,
-      conn,
+      dbPath,
       threadId,
       projectDir: "/tmp/test",
     });
@@ -146,7 +156,7 @@ describe("runAgentLoop", () => {
       systemPrompt: "You are a test agent.",
       task,
       config: testConfig,
-      conn,
+      dbPath,
       threadId,
       projectDir: "/tmp/test",
     });
@@ -182,7 +192,7 @@ describe("runAgentLoop", () => {
       systemPrompt: "You are a test agent.",
       task,
       config: testConfig,
-      conn,
+      dbPath,
       threadId,
       projectDir: "/tmp/test",
     });
@@ -234,7 +244,7 @@ describe("runAgentLoop", () => {
       systemPrompt: "You are a test agent.",
       task,
       config: testConfig,
-      conn,
+      dbPath,
       threadId,
       projectDir: "/tmp/test",
     });
@@ -300,7 +310,7 @@ describe("runAgentLoop", () => {
       systemPrompt: "You are a test agent.",
       task,
       config: testConfig,
-      conn,
+      dbPath,
       threadId,
       projectDir: "/tmp/test",
     });
@@ -367,7 +377,7 @@ describe("runAgentLoop", () => {
       systemPrompt: "You are a test agent.",
       task,
       config: testConfig,
-      conn,
+      dbPath,
       threadId,
       projectDir: "/tmp/test",
     });
@@ -414,7 +424,7 @@ describe("runAgentLoop", () => {
       systemPrompt: "You are a test agent.",
       task,
       config: testConfig,
-      conn,
+      dbPath,
       threadId,
       projectDir: "/tmp/test",
     });

--- a/test/daemon/schedules.test.ts
+++ b/test/daemon/schedules.test.ts
@@ -1,8 +1,8 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { DbConnection } from "../../src/db/connection.ts";
 import { createSchedule, getSchedule } from "../../src/db/schedules.ts";
 import { listTasks } from "../../src/db/tasks.ts";
-import { setupTestDb, TEST_CONFIG } from "../helpers.ts";
+import { setupTestDbFile, TEST_CONFIG } from "../helpers.ts";
 
 let mockResponse: Record<string, unknown> = {};
 
@@ -26,10 +26,16 @@ const { evaluateSchedule, processSchedules } = await import(
 );
 
 let conn: DbConnection;
+let dbPath: string;
+let cleanup: () => Promise<void>;
 
 beforeEach(async () => {
-  conn = await setupTestDb();
+  ({ conn, dbPath, cleanup } = await setupTestDbFile());
   mockResponse = {};
+});
+
+afterEach(async () => {
+  await cleanup();
 });
 
 describe("evaluateSchedule", () => {
@@ -208,7 +214,7 @@ describe("processSchedules", () => {
       frequency: "every morning",
     });
 
-    await processSchedules(conn, TEST_CONFIG);
+    await processSchedules(dbPath, TEST_CONFIG);
 
     const tasks = await listTasks(conn);
     expect(tasks).toHaveLength(1);
@@ -227,7 +233,7 @@ describe("processSchedules", () => {
       frequency: "daily",
     });
 
-    await processSchedules(conn, TEST_CONFIG);
+    await processSchedules(dbPath, TEST_CONFIG);
 
     const updated = await getSchedule(conn, schedule.id);
     expect(updated?.last_run_at).not.toBeNull();
@@ -245,7 +251,7 @@ describe("processSchedules", () => {
       frequency: "weekly",
     });
 
-    await processSchedules(conn, TEST_CONFIG);
+    await processSchedules(dbPath, TEST_CONFIG);
 
     const tasks = await listTasks(conn);
     expect(tasks).toHaveLength(0);
@@ -266,7 +272,7 @@ describe("processSchedules", () => {
     const { updateSchedule } = await import("../../src/db/schedules.ts");
     await updateSchedule(conn, schedule.id, { enabled: false });
 
-    await processSchedules(conn, TEST_CONFIG);
+    await processSchedules(dbPath, TEST_CONFIG);
 
     const tasks = await listTasks(conn);
     expect(tasks).toHaveLength(0);
@@ -292,7 +298,7 @@ describe("processSchedules", () => {
       frequency: "daily",
     });
 
-    await processSchedules(conn, TEST_CONFIG);
+    await processSchedules(dbPath, TEST_CONFIG);
 
     const tasks = await listTasks(conn);
     expect(tasks).toHaveLength(2);
@@ -307,7 +313,7 @@ describe("processSchedules", () => {
 
   test("does nothing with no enabled schedules", async () => {
     // No schedules at all — should return immediately
-    await processSchedules(conn, TEST_CONFIG);
+    await processSchedules(dbPath, TEST_CONFIG);
 
     const tasks = await listTasks(conn);
     expect(tasks).toHaveLength(0);

--- a/test/daemon/self-modify.test.ts
+++ b/test/daemon/self-modify.test.ts
@@ -20,6 +20,7 @@ beforeEach(async () => {
   tempDir = await mkdtemp(join(tmpdir(), "bth-self-modify-"));
   ctx = {
     conn: await setupTestDb(),
+    dbPath: ":memory:",
     projectDir: tempDir,
     config: { ...DEFAULT_CONFIG },
     mcpxClient: null,

--- a/test/daemon/tick.test.ts
+++ b/test/daemon/tick.test.ts
@@ -1,8 +1,12 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { DbConnection } from "../../src/db/connection.ts";
 import { createTask, getTask } from "../../src/db/tasks.ts";
 import { getThread, listThreads } from "../../src/db/threads.ts";
-import { completionResponse, setupTestDb, TEST_CONFIG } from "../helpers.ts";
+import {
+  completionResponse,
+  setupTestDbFile,
+  TEST_CONFIG,
+} from "../helpers.ts";
 
 // Mock the Anthropic SDK before importing tick
 mock.module("@anthropic-ai/sdk", () => {
@@ -19,9 +23,15 @@ mock.module("@anthropic-ai/sdk", () => {
 const { tick } = await import("../../src/daemon/tick.ts");
 
 let conn: DbConnection;
+let dbPath: string;
+let cleanup: () => Promise<void>;
 
 beforeEach(async () => {
-  conn = await setupTestDb();
+  ({ conn, dbPath, cleanup } = await setupTestDbFile());
+});
+
+afterEach(async () => {
+  await cleanup();
 });
 
 describe("daemon tick", () => {
@@ -31,7 +41,7 @@ describe("daemon tick", () => {
       description: "Do a thing",
     });
 
-    const didWork = await tick("/tmp/test-project", conn, TEST_CONFIG);
+    const didWork = await tick("/tmp/test-project", dbPath, TEST_CONFIG);
 
     // Task should be completed
     const updated = await getTask(conn, task.id);
@@ -47,7 +57,7 @@ describe("daemon tick", () => {
       description: "Do a thing",
     });
 
-    await tick("/tmp/test-project", conn, TEST_CONFIG);
+    await tick("/tmp/test-project", dbPath, TEST_CONFIG);
 
     // Should have created a thread
     const threads = await listThreads(conn, { type: "daemon_tick" });
@@ -69,7 +79,7 @@ describe("daemon tick", () => {
   });
 
   test("does nothing when no tasks available", async () => {
-    const didWork = await tick("/tmp/test-project", conn, TEST_CONFIG);
+    const didWork = await tick("/tmp/test-project", dbPath, TEST_CONFIG);
 
     // No threads created
     const threads = await listThreads(conn);
@@ -98,7 +108,7 @@ describe("daemon tick", () => {
       description: "LLM will error",
     });
 
-    await tickFresh("/tmp/test-project", conn, TEST_CONFIG);
+    await tickFresh("/tmp/test-project", dbPath, TEST_CONFIG);
 
     const updated = await getTask(conn, task.id);
     expect(updated?.status).toBe("failed");
@@ -132,7 +142,7 @@ describe("daemon tick", () => {
       priority: "high",
     });
 
-    await tick("/tmp/test-project", conn, TEST_CONFIG);
+    await tick("/tmp/test-project", dbPath, TEST_CONFIG);
 
     // High priority task should be completed
     const updatedHigh = await getTask(conn, highTask.id);

--- a/test/db/connection.test.ts
+++ b/test/db/connection.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { withRetry } from "../../src/db/connection.ts";
 
+const lockError = () => new Error("Conflicting lock is held in bun by user");
+
 describe("withRetry", () => {
   test("returns immediately on first success", async () => {
     let attempts = 0;
@@ -13,12 +15,12 @@ describe("withRetry", () => {
     expect(attempts).toBe(1);
   });
 
-  test("retries on transient errors and succeeds on later attempt", async () => {
+  test("retries lock-conflict errors and succeeds on later attempt", async () => {
     let attempts = 0;
     const result = await withRetry(async () => {
       attempts++;
       if (attempts < 3) {
-        throw new Error("transient error");
+        throw lockError();
       }
       return "recovered";
     }, 5);
@@ -27,28 +29,28 @@ describe("withRetry", () => {
     expect(attempts).toBe(3);
   });
 
-  test("throws after exhausting all retries", async () => {
+  test("throws after exhausting retries on persistent lock conflicts", async () => {
     let attempts = 0;
     await expect(
       withRetry(async () => {
         attempts++;
-        throw new Error("persistent error");
+        throw lockError();
       }, 3),
-    ).rejects.toThrow("persistent error");
+    ).rejects.toThrow(/Conflicting lock/);
 
     expect(attempts).toBe(3);
   });
 
-  test("uses default maxRetries of 5", async () => {
+  test("does not retry non-lock errors", async () => {
     let attempts = 0;
     await expect(
       withRetry(async () => {
         attempts++;
-        throw new Error("always fails");
+        throw new Error("constraint violation: primary key");
       }),
-    ).rejects.toThrow("always fails");
+    ).rejects.toThrow("constraint violation");
 
-    expect(attempts).toBe(5);
+    expect(attempts).toBe(1);
   });
 
   test("works with async functions that return different types", async () => {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { BotholomewConfig } from "../src/config/schemas.ts";
 import { DEFAULT_CONFIG } from "../src/config/schemas.ts";
 import { EMBEDDING_DIMENSION } from "../src/constants.ts";
@@ -97,6 +100,32 @@ export async function setupTestDb(): Promise<DbConnection> {
   return conn;
 }
 
+/**
+ * Create a fresh file-backed database with migrations applied. Use this when
+ * a test needs to pass a `dbPath` to production code that opens/closes its
+ * own connections — `:memory:` can't be shared across `withDb` calls.
+ *
+ * Returns `{ conn, dbPath, cleanup }`. Call `cleanup()` in `afterEach`.
+ */
+export async function setupTestDbFile(): Promise<{
+  conn: DbConnection;
+  dbPath: string;
+  cleanup: () => Promise<void>;
+}> {
+  const dir = await mkdtemp(join(tmpdir(), "both-db-"));
+  const dbPath = join(dir, "test.duckdb");
+  const conn = await getConnection(dbPath);
+  await migrate(conn);
+  return {
+    conn,
+    dbPath,
+    cleanup: async () => {
+      conn.close();
+      await rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
 /** Create a ToolContext backed by a fresh in-memory database. */
 export async function setupToolContext(): Promise<{
   conn: DbConnection;
@@ -105,6 +134,7 @@ export async function setupToolContext(): Promise<{
   const conn = await setupTestDb();
   const ctx: ToolContext = {
     conn,
+    dbPath: ":memory:",
     projectDir: "/tmp/test",
     config: { ...DEFAULT_CONFIG },
     mcpxClient: null,


### PR DESCRIPTION
## Summary

- DuckDB's file lock is held by the instance, not the connection. The daemon and chat TUI each opened one instance at startup and held it for their lifetime, so every CLI invocation (`task list`, `thread list`, etc.) failed with `Conflicting lock is held`. This was the `withRetry`-serializes-writes claim in `docs/architecture.md` — real fix, not just retry.
- Switched every caller to short-lived `withDb(dbPath, fn)` from `src/db/connection.ts`. A refcounted in-process instance cache lets overlapping callers (parallel tool execution) share one instance, and the instance is closed — releasing the OS lock — once every caller has returned. `withRetry` now specifically catches DuckDB lock errors and backs off exponentially.
- Daemon (`tick`, `llm`, `prompt`, `schedules`) and chat (`session`, `agent`) now carry `dbPath` instead of a held `conn`; TUI panels (`TaskPanel`, `ThreadPanel`, etc.) take `dbPath` and wrap each poll in `withDb`. `ToolContext` gains `dbPath` alongside the now-short-lived `conn`. Updated `docs/architecture.md`, `docs/tools.md`, and `CLAUDE.md` with the new pattern.

## Test plan

- [x] `bun run lint` (tsc + biome)
- [x] `bun test` — 651/651 pass
- [x] End-to-end: start daemon, run three parallel CLI commands against the shared DB — all succeed, no lock errors