### PR TITLE
Dedup context add by source_path before LLM placement

### DIFF
--- a/docs/context-and-search.md
+++ b/docs/context-and-search.md
@@ -172,17 +172,27 @@ virtual filesystem:
 
 ### Collision handling
 
-Every context item is keyed by a unique `context_path`. When a write
-targets an existing path, the policy is controlled by `--on-conflict`:
+Before doing anything expensive, `context add` checks each input's
+`source_path` (absolute file path for local files, URL for remote items)
+against what's already in context. If the same source was ingested
+before — whether under the same or a different `context_path` — the
+item is routed by `--on-conflict` **before** any LLM placement call, so
+re-runs don't burn tokens re-picking paths for files the database
+already knows about.
+
+The same `--on-conflict` policy also governs the rarer case where a
+newly-placed item's target `context_path` happens to collide with an
+unrelated existing item (e.g. two different source files with the same
+basename the LLM placed in the same folder).
 
 | Policy      | Behavior                                                                 |
 | ----------- | ------------------------------------------------------------------------ |
-| `error` *(default)* | Skip the colliding item, keep going through the batch, and exit with a non-zero status listing every collision. |
-| `overwrite` | Replace the existing item and re-embed (the original pre-0.7.7 default). |
+| `error` *(default)* | Fast-fail before LLM placement if any source is already in context. For target-path collisions encountered mid-run, exit with a non-zero status listing every collision. |
+| `overwrite` | For already-ingested sources, refresh content from disk/URL (diff + selective re-embed) while preserving the original `context_path`. For target-path collisions, replace and re-embed. |
 | `skip`      | Log and move on — no write, no error.                                    |
 
-Re-running `context add` on the same path with the default policy is
-now a loud error rather than a silent overwrite. Use
+Re-running `context add` on already-ingested files with the default
+policy is a loud error rather than a silent overwrite. Use
 `--on-conflict=overwrite` when you genuinely want to refresh stored
 content (or `botholomew context refresh` for the idiomatic flow).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "Local, autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -25,6 +25,7 @@ import {
   createContextItemStrict,
   deleteContextItemByPath,
   getContextItemByPath,
+  getContextItemBySourcePath,
   listContextItems,
   listContextItemsByPrefix,
   PathConflictError,
@@ -193,9 +194,126 @@ export function registerContextCommand(program: Command) {
           text: `Found ${totalCount} item(s) to add (${filesToAdd.length} file(s), ${urlsToAdd.length} URL(s)).`,
         });
 
-        // Phase 1.5: LLM placement for files without an explicit path
         const config = await loadConfig(dir);
         const CONCURRENCY = 10;
+
+        // Phase 0: Source-path dedup — items whose source_path is already in
+        // context are routed per --on-conflict before we pay for LLM placement.
+        type AlreadyInContext = {
+          sourcePath: string;
+          sourceType: "file" | "url";
+          existing: ContextItem;
+        };
+        const alreadyInContext: AlreadyInContext[] = [];
+        const remainingFiles: FileToAdd[] = [];
+        const remainingUrls: { url: string; contextPath: string }[] = [];
+
+        for (const f of filesToAdd) {
+          const existing = await getContextItemBySourcePath(
+            conn,
+            f.filePath,
+            "file",
+          );
+          if (existing) {
+            alreadyInContext.push({
+              sourcePath: f.filePath,
+              sourceType: "file",
+              existing,
+            });
+          } else {
+            remainingFiles.push(f);
+          }
+        }
+        for (const u of urlsToAdd) {
+          const existing = await getContextItemBySourcePath(conn, u.url, "url");
+          if (existing) {
+            alreadyInContext.push({
+              sourcePath: u.url,
+              sourceType: "url",
+              existing,
+            });
+          } else {
+            remainingUrls.push(u);
+          }
+        }
+
+        let refreshedCount = 0;
+        let refreshedChunks = 0;
+        const dedupSkipped: string[] = [];
+
+        if (alreadyInContext.length > 0) {
+          if (policy === "error") {
+            logger.error(
+              `${alreadyInContext.length} item(s) already in context (matched by source path):`,
+            );
+            for (const a of alreadyInContext) {
+              console.log(
+                `  ${ansis.red("✗")} ${a.sourcePath} → ${a.existing.context_path} (id: ${a.existing.id})`,
+              );
+            }
+            logger.dim(
+              "Re-run with --on-conflict=skip to ignore these items or --on-conflict=overwrite to refresh them from disk.",
+            );
+            process.exit(1);
+          }
+
+          if (policy === "skip") {
+            for (const a of alreadyInContext) {
+              logger.dim(
+                `⊘ already in context: ${a.sourcePath} → ${a.existing.context_path}`,
+              );
+              dedupSkipped.push(a.existing.context_path);
+            }
+          } else {
+            // overwrite: refresh existing items (diff + selective re-embed),
+            // preserving their original context_path.
+            const itemsToRefresh = alreadyInContext.map((a) => a.existing);
+            const hasUrls = itemsToRefresh.some((i) => i.source_type === "url");
+            const mcpxClient = hasUrls ? await createMcpxClient(dir) : null;
+
+            const refreshSpinner = createSpinner(
+              `Refreshing 0/${itemsToRefresh.length} existing item(s)...`,
+            ).start();
+            const refreshResult = await refreshContextItems(
+              conn,
+              itemsToRefresh,
+              config,
+              mcpxClient,
+              {
+                onItemProgress: (done, total) => {
+                  refreshSpinner.update({
+                    text: `Refreshing ${done}/${total} existing item(s)...`,
+                  });
+                },
+              },
+            );
+            refreshSpinner.success({
+              text: `Refreshed ${refreshResult.checked} existing item(s): ${refreshResult.updated} updated, ${refreshResult.unchanged} unchanged, ${refreshResult.missing} missing.`,
+            });
+
+            // Count everything we processed OK (updated + unchanged) as
+            // "refreshed" for the summary. Missing/error items are reported
+            // inline below and don't count toward success.
+            refreshedCount = refreshResult.updated + refreshResult.unchanged;
+            refreshedChunks = refreshResult.chunks;
+            for (const item of refreshResult.items) {
+              if (item.status === "missing") {
+                logger.warn(`  Missing: ${item.source_path}`);
+              } else if (item.status === "error") {
+                logger.warn(
+                  `  Error refreshing ${item.source_path}: ${item.error}`,
+                );
+              }
+            }
+          }
+        }
+
+        // Drop already-handled items from the work lists so downstream phases
+        // (LLM placement, description, insert, embed) see only truly-new items.
+        filesToAdd.splice(0, filesToAdd.length, ...remainingFiles);
+        urlsToAdd.splice(0, urlsToAdd.length, ...remainingUrls);
+
+        // Phase 1.5: LLM placement for files without an explicit path
         const needsPlacement = filesToAdd.filter((f) => f.contextPath === null);
         // description cache keyed by filePath — populated when LLM placement runs,
         // reused in addFile to avoid a second describe call.
@@ -378,10 +496,13 @@ export function registerContextCommand(program: Command) {
           }
         }
 
-        // Report conflicts before embeddings so the user sees them prominently
+        // Report conflicts before embeddings so the user sees them prominently.
+        // Phase 0 already handled source-path matches, so anything here is a
+        // target-path collision — an LLM-suggested (or explicit) path that
+        // another unrelated item already occupies.
         if (conflicts.length > 0) {
           logger.error(
-            `${conflicts.length} path collision(s) — nothing written for these items:`,
+            `${conflicts.length} target-path collision(s) — nothing written for these items:`,
           );
           for (const c of conflicts) {
             console.log(
@@ -389,24 +510,34 @@ export function registerContextCommand(program: Command) {
             );
           }
           logger.dim(
-            "Re-run with --on-conflict=overwrite to replace, --on-conflict=skip to ignore, or --name / --prefix to place elsewhere.",
+            "The suggested path is already in use by a different source. Re-run with --prefix to place these items elsewhere, or delete the existing item first.",
           );
         }
+
+        // Merge Phase 0 skips into the skip list used by the final summary.
+        skipped.push(...dedupSkipped);
 
         // Phase 3: Chunk + embed in parallel (network I/O)
         if (itemIds.length === 0 || !config.openai_api_key) {
           if (!config.openai_api_key) {
             logger.dim("Skipping embeddings (no OpenAI API key configured).");
           }
-          const msg = `Added ${itemIds.length}/${totalCount} item(s), 0 chunks indexed.`;
+          const msg = buildSummary({
+            added: itemIds.length,
+            refreshed: refreshedCount,
+            skipped: skipped.length,
+            chunks: refreshedChunks,
+            totalCount,
+            handled: itemIds.length + refreshedCount + skipped.length,
+          });
           if (conflicts.length > 0) {
             logger.error(msg);
             process.exit(1);
           }
-          if (itemIds.length === totalCount - skipped.length) {
+          if (itemIds.length + skipped.length + refreshedCount >= totalCount) {
             logger.success(msg);
             process.exit(0);
-          } else if (itemIds.length === 0) {
+          } else if (itemIds.length === 0 && refreshedCount === 0) {
             logger.error(msg);
             process.exit(1);
           } else {
@@ -452,15 +583,20 @@ export function registerContextCommand(program: Command) {
           else filesAdded++;
         }
 
-        const parts: string[] = [];
-        if (filesAdded > 0) parts.push(`${filesAdded} added`);
-        if (filesUpdated > 0) parts.push(`${filesUpdated} updated`);
-        const summary = `${parts.join(", ")} — ${chunks} chunk(s) indexed (${itemIds.length}/${totalCount} item(s)).`;
+        const summary = buildSummary({
+          added: filesAdded,
+          updated: filesUpdated,
+          refreshed: refreshedCount,
+          skipped: skipped.length,
+          chunks: chunks + refreshedChunks,
+          totalCount,
+          handled: itemIds.length + refreshedCount + skipped.length,
+        });
         if (conflicts.length > 0) {
           logger.error(summary);
           process.exit(1);
         }
-        if (itemIds.length === totalCount - skipped.length) {
+        if (itemIds.length + skipped.length + refreshedCount >= totalCount) {
           logger.success(summary);
           process.exit(0);
         } else {
@@ -674,6 +810,26 @@ async function resolveItems(
 }
 
 type ConflictPolicy = "error" | "overwrite" | "skip";
+
+/** Format the final "X added, Y refreshed, Z skipped — N chunks" line. */
+function buildSummary(args: {
+  added: number;
+  updated?: number;
+  refreshed: number;
+  skipped: number;
+  chunks: number;
+  totalCount: number;
+  handled?: number;
+}): string {
+  const parts: string[] = [];
+  if (args.added > 0) parts.push(`${args.added} added`);
+  if (args.updated && args.updated > 0) parts.push(`${args.updated} updated`);
+  if (args.refreshed > 0) parts.push(`${args.refreshed} refreshed`);
+  if (args.skipped > 0) parts.push(`${args.skipped} skipped`);
+  const body = parts.length > 0 ? parts.join(", ") : "0 added";
+  const handled = args.handled ?? args.added + args.refreshed + args.skipped;
+  return `${body} — ${args.chunks} chunk(s) indexed (${handled}/${args.totalCount} item(s)).`;
+}
 
 type AddFileResult =
   | { kind: "added"; id: string; contextPath: string }

--- a/src/db/context.ts
+++ b/src/db/context.ts
@@ -179,6 +179,19 @@ export async function getContextItemByPath(
   return row ? rowToContextItem(row) : null;
 }
 
+export async function getContextItemBySourcePath(
+  db: DbConnection,
+  sourcePath: string,
+  sourceType: "file" | "url",
+): Promise<ContextItem | null> {
+  const row = await db.queryGet<ContextItemRow>(
+    "SELECT * FROM context_items WHERE source_path = ?1 AND source_type = ?2 LIMIT 1",
+    sourcePath,
+    sourceType,
+  );
+  return row ? rowToContextItem(row) : null;
+}
+
 /**
  * Look up a context item by UUID (if the value looks like one) or by context_path.
  */

--- a/test/commands/context-add-dedup.test.ts
+++ b/test/commands/context-add-dedup.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getDbPath } from "../../src/constants.ts";
+import { getConnection } from "../../src/db/connection.ts";
+import {
+  createContextItem,
+  getContextItemByPath,
+} from "../../src/db/context.ts";
+import { migrate } from "../../src/db/schema.ts";
+import { initProject } from "../../src/init/index.ts";
+
+let tempDir: string;
+
+afterEach(async () => {
+  if (tempDir) {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+const CLI = join(import.meta.dir, "..", "..", "src", "cli.ts");
+
+async function run(
+  args: string[],
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  const proc = Bun.spawn(["bun", CLI, "--dir", tempDir, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, NO_COLOR: "1" },
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const code = await proc.exited;
+  return { code, stdout, stderr };
+}
+
+/**
+ * Seed a context item with an explicit source_path so the Phase 0 dedup sees
+ * it. Mirrors what a previous `context add` would have stored.
+ */
+async function seedFile(
+  sourcePath: string,
+  contextPath: string,
+  content: string,
+): Promise<void> {
+  await writeFile(sourcePath, content);
+  const conn = await getConnection(getDbPath(tempDir));
+  try {
+    await migrate(conn);
+    await createContextItem(conn, {
+      title: "seeded",
+      content,
+      sourceType: "file",
+      sourcePath,
+      contextPath,
+    });
+  } finally {
+    conn.close();
+  }
+}
+
+describe("context add source-path dedup", () => {
+  test("default policy errors fast when source is already in context", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "botholomew-test-"));
+    await initProject(tempDir);
+
+    const filePath = join(tempDir, "already.md");
+    await seedFile(filePath, "/user-guides/already.md", "content");
+
+    const result = await run(["context", "add", filePath]);
+
+    expect(result.code).toBe(1);
+    const output = result.stdout + result.stderr;
+    expect(output).toContain("already in context");
+    expect(output).toContain(filePath);
+    expect(output).toContain("/user-guides/already.md");
+    // No LLM placement happened — the "Choosing paths" spinner shouldn't fire.
+    expect(output).not.toContain("Choosing paths");
+  });
+
+  test("--on-conflict=skip exits cleanly and does not re-add", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "botholomew-test-"));
+    await initProject(tempDir);
+
+    const filePath = join(tempDir, "skip-me.md");
+    await seedFile(filePath, "/notes/skip-me.md", "original");
+
+    const result = await run([
+      "context",
+      "add",
+      filePath,
+      "--on-conflict=skip",
+    ]);
+
+    expect(result.code).toBe(0);
+    const output = result.stdout + result.stderr;
+    expect(output).toContain("already in context");
+    expect(output).toContain("1 skipped");
+
+    // Still exactly one row with that context_path.
+    const conn = await getConnection(getDbPath(tempDir));
+    try {
+      await migrate(conn);
+      const item = await getContextItemByPath(conn, "/notes/skip-me.md");
+      expect(item?.content).toBe("original");
+    } finally {
+      conn.close();
+    }
+  });
+
+  test("--on-conflict=overwrite reuses existing context_path and refreshes", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "botholomew-test-"));
+    await initProject(tempDir);
+
+    const filePath = join(tempDir, "refresh-me.md");
+    await seedFile(filePath, "/notes/refresh-me.md", "v1");
+
+    // Simulate on-disk edit so refresh detects a content change.
+    await writeFile(filePath, "v2");
+
+    const result = await run([
+      "context",
+      "add",
+      filePath,
+      "--on-conflict=overwrite",
+    ]);
+
+    expect(result.code).toBe(0);
+    const output = result.stdout + result.stderr;
+    expect(output).toContain("Refreshed");
+
+    const conn = await getConnection(getDbPath(tempDir));
+    try {
+      await migrate(conn);
+      // Original context_path preserved, content updated.
+      const item = await getContextItemByPath(conn, "/notes/refresh-me.md");
+      expect(item?.content).toBe("v2");
+    } finally {
+      conn.close();
+    }
+  });
+});

--- a/test/db/context.test.ts
+++ b/test/db/context.test.ts
@@ -11,6 +11,7 @@ import {
   deleteContextItemsByPrefix,
   getContextItem,
   getContextItemByPath,
+  getContextItemBySourcePath,
   getDistinctDirectories,
   listContextItems,
   listContextItemsByPrefix,
@@ -204,6 +205,52 @@ describe("context CRUD", () => {
 
     const missing = await getContextItemByPath(conn, "/nonexistent");
     expect(missing).toBeNull();
+  });
+
+  test("get by source_path scoped to source_type", async () => {
+    await createContextItem(conn, {
+      title: "mcpx",
+      content: "mcpx docs",
+      sourceType: "file",
+      sourcePath: "/Users/me/docs/mcpx.md",
+      contextPath: "/user-guides/mcpx.md",
+    });
+    await createContextItem(conn, {
+      title: "Example",
+      content: "remote",
+      sourceType: "url",
+      sourcePath: "https://example.com",
+      contextPath: "/example.com.md",
+    });
+
+    const byFile = await getContextItemBySourcePath(
+      conn,
+      "/Users/me/docs/mcpx.md",
+      "file",
+    );
+    expect(byFile?.context_path).toBe("/user-guides/mcpx.md");
+
+    const byUrl = await getContextItemBySourcePath(
+      conn,
+      "https://example.com",
+      "url",
+    );
+    expect(byUrl?.context_path).toBe("/example.com.md");
+
+    // source_type discriminates — looking up a URL string under "file" misses.
+    const miss = await getContextItemBySourcePath(
+      conn,
+      "https://example.com",
+      "file",
+    );
+    expect(miss).toBeNull();
+
+    const unknown = await getContextItemBySourcePath(
+      conn,
+      "/not/ingested.md",
+      "file",
+    );
+    expect(unknown).toBeNull();
   });
 
   test("list with filters", async () => {


### PR DESCRIPTION
## Summary

- Re-running `context add` on already-ingested files no longer wastes Anthropic tokens picking target paths the DB already knows about. A new Phase 0 looks up each input's `source_path` and applies `--on-conflict` before LLM placement.
- `error` (default): grouped fast-fail listing each source and its existing `context_path`. `skip`: silent no-op. `overwrite`: routes through `refreshContextItems` to diff + selectively re-embed, preserving the original `context_path`.
- Extends the final summary to report `added / refreshed / skipped` and updates `docs/context-and-search.md` accordingly.

## Test plan

- [x] `bun run lint` clean
- [x] `bun test` — 671/671 pass
- [x] New DB test: `getContextItemBySourcePath` round-trips and is scoped by `source_type`
- [x] New CLI integration tests cover `error`, `skip`, and `overwrite` paths end-to-end
- [ ] Manual: re-run `context add docs` against a seeded project and confirm no LLM call fires under default policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)