### PR TITLE
Render markdown context previews with Bun.markdown.ansi

### DIFF
--- a/docs/tui.md
+++ b/docs/tui.md
@@ -92,6 +92,11 @@ filesystem" — see [virtual-filesystem.md](virtual-filesystem.md) and
 - `/` opens a hybrid (keyword + vector) search across all context.
 - `d` deletes the selected item.
 
+Markdown files (detected by `mime_type === "text/markdown"` or a `.md`
+extension on `source_path` / `context_path`) are rendered through
+`Bun.markdown.ansi` so headers, emphasis, lists, and fenced code blocks
+show with terminal formatting. Other file types render as plain text.
+
 ### 4. Tasks
 
 The task queue, with filters for status (pending / in_progress /

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "description": "Local, autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/tui/components/ContextPanel.tsx
+++ b/src/tui/components/ContextPanel.tsx
@@ -9,6 +9,7 @@ import {
   listContextItemsByPrefix,
   searchContextByKeyword,
 } from "../../db/context.ts";
+import { isMarkdownItem, renderMarkdown } from "../markdown.ts";
 
 interface ContextPanelProps {
   dbPath: string;
@@ -118,10 +119,15 @@ export const ContextPanel = memo(function ContextPanel({
     [items, scrollOffset, visibleRows],
   );
 
-  // Preview content split into lines for scrolling
+  // Preview content split into lines for scrolling. Markdown files are
+  // rendered through Bun.markdown.ansi so headers/emphasis/code display
+  // with ANSI formatting in the terminal.
   const previewLines = useMemo(() => {
     if (!preview?.content) return [];
-    return preview.content.split("\n");
+    const body = isMarkdownItem(preview)
+      ? renderMarkdown(preview.content)
+      : preview.content;
+    return body.split("\n");
   }, [preview]);
 
   useInput(

--- a/src/tui/components/MessageList.tsx
+++ b/src/tui/components/MessageList.tsx
@@ -1,6 +1,7 @@
 import { Box, Text, useStdout } from "ink";
 import Spinner from "ink-spinner";
 import { memo, useMemo } from "react";
+import { renderMarkdown } from "../markdown.ts";
 import { theme } from "../theme.ts";
 import { ToolCall, type ToolCallData } from "./ToolCall.tsx";
 
@@ -46,11 +47,6 @@ function wrapAndPad(text: string, width: number): string {
     }
   }
   return lines.join("\n");
-}
-
-function renderMarkdown(text: string): string {
-  if (!text) return "";
-  return Bun.markdown.ansi(text).trimEnd();
 }
 
 export const MessageBubble = memo(function MessageBubble({

--- a/src/tui/markdown.ts
+++ b/src/tui/markdown.ts
@@ -1,0 +1,15 @@
+import type { ContextItem } from "../db/context.ts";
+
+export function renderMarkdown(text: string): string {
+  if (!text) return "";
+  return Bun.markdown.ansi(text).trimEnd();
+}
+
+export function isMarkdownItem(
+  item: Pick<ContextItem, "mime_type" | "source_path" | "context_path">,
+): boolean {
+  if (item.mime_type === "text/markdown") return true;
+  if (item.source_path?.toLowerCase().endsWith(".md")) return true;
+  if (item.context_path.toLowerCase().endsWith(".md")) return true;
+  return false;
+}

--- a/test/tui/markdown.test.ts
+++ b/test/tui/markdown.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { isMarkdownItem, renderMarkdown } from "../../src/tui/markdown.ts";
+
+type DetectShape = Parameters<typeof isMarkdownItem>[0];
+
+function item(overrides: Partial<DetectShape>): DetectShape {
+  return {
+    mime_type: "text/plain",
+    source_path: null,
+    context_path: "/notes/file.txt",
+    ...overrides,
+  };
+}
+
+describe("isMarkdownItem", () => {
+  test("matches mime_type text/markdown", () => {
+    expect(isMarkdownItem(item({ mime_type: "text/markdown" }))).toBe(true);
+  });
+
+  test("matches .md source_path", () => {
+    expect(isMarkdownItem(item({ source_path: "/abs/path/README.md" }))).toBe(
+      true,
+    );
+  });
+
+  test("matches .md context_path when source_path is null", () => {
+    expect(
+      isMarkdownItem(item({ source_path: null, context_path: "/docs/x.md" })),
+    ).toBe(true);
+  });
+
+  test("is case-insensitive on extension", () => {
+    expect(isMarkdownItem(item({ context_path: "/docs/README.MD" }))).toBe(
+      true,
+    );
+  });
+
+  test("returns false for plain text", () => {
+    expect(isMarkdownItem(item({}))).toBe(false);
+  });
+
+  test("returns false for .txt files", () => {
+    expect(
+      isMarkdownItem(item({ source_path: "/a.txt", context_path: "/a.txt" })),
+    ).toBe(false);
+  });
+
+  test("returns false for .md in the middle of a filename", () => {
+    expect(isMarkdownItem(item({ context_path: "/notes/readme.md.bak" }))).toBe(
+      false,
+    );
+  });
+});
+
+describe("renderMarkdown", () => {
+  test("returns empty string for empty input", () => {
+    expect(renderMarkdown("")).toBe("");
+  });
+
+  test("renders non-empty markdown to a non-empty string", () => {
+    const out = renderMarkdown("# Heading\n\nhello");
+    expect(out.length).toBeGreaterThan(0);
+    expect(out.endsWith("\n")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- TUI Context panel now renders `*.md` files with ANSI formatting (headers, emphasis, lists, fenced code) via `Bun.markdown.ansi`, matching the existing chat-assistant path.
- Detection checks `mime_type === "text/markdown"` first, then falls back to `.md` on `source_path` or `context_path` (case-insensitive). Non-markdown files continue to render as plain text.
- Extracted the existing `renderMarkdown` helper from `MessageList.tsx` into a shared `src/tui/markdown.ts` alongside a new `isMarkdownItem` helper.

## Test plan
- [x] `bun run lint`
- [x] `bun test` (683 passing, including 9 new tests in `test/tui/markdown.test.ts`)
- [ ] Manual: `bun run dev chat` → Context tab → open a `.md` file and confirm formatting renders; open a non-markdown file and confirm plain text is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)