### PR TITLE
Show directory path in Context tab search results

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "description": "Local, autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/tui/components/ContextPanel.tsx
+++ b/src/tui/components/ContextPanel.tsx
@@ -272,13 +272,17 @@ export const ContextPanel = memo(function ContextPanel({
           {visibleItems.map((item, vi) => {
             const i = vi + scrollOffset;
             const ci = item as ContextItem;
+            const slashIdx = ci.context_path.lastIndexOf("/");
+            const dir =
+              slashIdx >= 0 ? ci.context_path.slice(0, slashIdx + 1) : "";
             return (
               <Box key={ci.id}>
                 <Text
                   backgroundColor={i === cursor ? "#333" : undefined}
                   color={i === cursor ? "cyan" : undefined}
                 >
-                  {"  "}📄 {ci.context_path}
+                  {"  "}📄 <Text dimColor>{dir}</Text>
+                  {ci.title}
                   <Text dimColor> ({ci.mime_type})</Text>
                 </Text>
               </Box>


### PR DESCRIPTION
## Summary
- In the TUI Context tab, search-result rows now render the directory prefix dimmed, the filename normal, and the mime type dimmed — so nested hits like `/poems/foo.md` are visually distinguishable from root-level hits at a glance.
- Bumps version to `0.7.13`.

## Test plan
- [x] `bun run lint` clean
- [x] `bun test` — 683/683 pass
- [ ] Manual: `bun run dev chat` → Context tab → `/` → confirm root hits render as `📄 / filename.md (mime)` (with `/` dim) and nested hits as `📄 /poems/ filename.md (mime)` (with `/poems/` dim); selection highlight covers the full row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)