### PR TITLE
Allow TUI chat agent to call context_tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "description": "Local, autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/chat/agent.ts
+++ b/src/chat/agent.ts
@@ -36,6 +36,7 @@ const CHAT_TOOL_NAMES = new Set([
   "context_search",
   "context_info",
   "context_refresh",
+  "context_tree",
   "search_grep",
   "search_semantic",
   "list_threads",

--- a/test/chat/agent.test.ts
+++ b/test/chat/agent.test.ts
@@ -43,6 +43,7 @@ describe("getChatTools", () => {
     expect(names).toContain("context_search");
     expect(names).toContain("context_info");
     expect(names).toContain("context_refresh");
+    expect(names).toContain("context_tree");
     expect(names).toContain("update_beliefs");
     expect(names).toContain("update_goals");
     expect(names).toContain("list_schedules");


### PR DESCRIPTION
## Summary
- Adds `context_tree` to the `CHAT_TOOL_NAMES` allow-list in `src/chat/agent.ts` so the `botholomew chat` TUI agent can render virtual filesystem trees. Previously only the daemon worker had access.
- Updates the `getChatTools` test to assert `context_tree` is present, and bumps the version to 0.7.13.

## Test plan
- [x] `bun run lint`
- [x] `bun test` (683 pass)
- [ ] Manual: in `bun run dev chat`, ask the agent to show a tree of `.botholomew`

🤖 Generated with [Claude Code](https://claude.com/claude-code)