### PR TITLE
Checkpoint after migrations to prevent WAL-replay crash on reopen

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Local, autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -45,6 +45,7 @@ export async function migrate(db: DbConnection): Promise<void> {
   const applied = new Set(rows.map((row) => row.id));
 
   // Run pending migrations in order
+  let appliedAny = false;
   for (const migration of loadMigrations()) {
     if (applied.has(migration.id)) continue;
 
@@ -63,5 +64,15 @@ export async function migrate(db: DbConnection): Promise<void> {
       migration.id,
       migration.name,
     );
+    appliedAny = true;
+  }
+
+  // Flush the WAL so the next open has no schema entries to replay. DuckDB's
+  // WAL replay of ALTER TABLE re-binds all column defaults on the target
+  // table, and our CREATE TABLE defaults use `current_timestamp::VARCHAR` —
+  // which cannot be resolved during replay (no default database attached yet),
+  // crashing the process on reopen.
+  if (appliedAny) {
+    await db.exec("CHECKPOINT");
   }
 }

--- a/test/db/schema.test.ts
+++ b/test/db/schema.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { getConnection } from "../../src/db/connection.ts";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getConnection, withDb } from "../../src/db/connection.ts";
 import { migrate } from "../../src/db/schema.ts";
 
 describe("schema migrations", () => {
@@ -23,6 +26,33 @@ describe("schema migrations", () => {
     expect(tables).toContain("daemon_state");
 
     db.close();
+  });
+
+  test("reopening a freshly migrated file-backed DB does not crash on WAL replay", async () => {
+    // Regression: migration 9 (ALTER TABLE context_items ADD COLUMN ...)
+    // used to leave an ALTER entry in the WAL. On reopen, DuckDB replayed
+    // the ALTER and re-bound *all* existing column defaults — including
+    // `created_at DEFAULT (current_timestamp::VARCHAR)` — which it can't
+    // resolve during replay (no default database attached), crashing the
+    // process. `migrate()` now CHECKPOINTs after applying migrations.
+    const dir = await mkdtemp(join(tmpdir(), "both-schema-wal-"));
+    const dbPath = join(dir, "test.duckdb");
+    try {
+      await withDb(dbPath, async (conn) => {
+        await migrate(conn);
+      });
+
+      // Re-open; this would crash before the fix.
+      await withDb(dbPath, async (conn) => {
+        await migrate(conn);
+        const row = await conn.queryGet<{ count: number }>(
+          "SELECT COUNT(*) AS count FROM context_items",
+        );
+        expect(row?.count).toBe(0);
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 
   test("migrate is idempotent", async () => {


### PR DESCRIPTION
## Summary

Running `context add` on a fresh DB followed by `context refresh` crashed at startup with `Failure while replaying WAL file: Calling DatabaseManager::GetDefaultDatabase with no default database set`. DuckDB replays the WAL on open and, for an `ALTER TABLE ADD COLUMN` entry (migration 9), re-binds every existing column default on the target table — including our `created_at DEFAULT (current_timestamp::VARCHAR)` — which can't be resolved during replay. `migrate()` now runs `CHECKPOINT` after applying any migration so the next open has nothing schema-shaped to replay.

## Test plan

- [x] `bun run lint`
- [x] `bun test` (660 pass)
- [x] Added regression test: reopen a file-backed DB after migrate and confirm it doesn't crash
- [x] End-to-end: `rm -rf .botholomew/data.duckdb* && bun dev context add README.md && bun dev context refresh --all` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)