### PR TITLE
Resolve context items by source_path in refresh/chunks/delete

### DIFF
--- a/docs/context-and-search.md
+++ b/docs/context-and-search.md
@@ -248,9 +248,16 @@ distinguishing file-backed vs. URL-backed items.
 ### Refreshing stale content
 
 ```bash
-botholomew context refresh /docs/strategy.md   # refresh one item
+botholomew context refresh /docs/strategy.md   # by virtual context_path
+botholomew context refresh README.md           # by on-disk source_path (relative or absolute)
+botholomew context refresh https://example.com # by URL source_path
 botholomew context refresh --all               # refresh every sourced item
 ```
+
+The `path` argument matches, in order, a UUID, a `context_path`, a URL
+`source_path`, or (after resolving against the current working
+directory) a file `source_path` — so the same argument you used for
+`context add` works here too.
 
 `refresh` works for both `file` and `url` source types: for files it
 re-reads from disk, for URLs it re-runs the loading agent. In both

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Local, autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/db/context.ts
+++ b/src/db/context.ts
@@ -1,3 +1,4 @@
+import { resolve as resolvePath } from "node:path";
 import type { DbConnection } from "./connection.ts";
 import { buildSetClauses, buildWhereClause, sanitizeInt } from "./query.ts";
 import { isUuid, uuidv7 } from "./uuid.ts";
@@ -193,15 +194,26 @@ export async function getContextItemBySourcePath(
 }
 
 /**
- * Look up a context item by UUID (if the value looks like one) or by context_path.
+ * Look up a context item by UUID, `context_path`, or `source_path`.
+ *
+ * `source_path` fallbacks let users pass the same argument they used for
+ * `context add` (e.g. a bare `README.md`) to management commands like
+ * `context refresh` / `context chunks`. Relative file paths are resolved
+ * against `process.cwd()` to match the absolute `source_path` stored on add.
  */
 export async function resolveContextItem(
   db: DbConnection,
   pathOrId: string,
 ): Promise<ContextItem | null> {
-  return isUuid(pathOrId)
-    ? getContextItem(db, pathOrId)
-    : getContextItemByPath(db, pathOrId);
+  if (isUuid(pathOrId)) return getContextItem(db, pathOrId);
+
+  const byContextPath = await getContextItemByPath(db, pathOrId);
+  if (byContextPath) return byContextPath;
+
+  const byUrl = await getContextItemBySourcePath(db, pathOrId, "url");
+  if (byUrl) return byUrl;
+
+  return getContextItemBySourcePath(db, resolvePath(pathOrId), "file");
 }
 
 /**

--- a/test/db/context.test.ts
+++ b/test/db/context.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, test } from "bun:test";
+import { resolve as resolvePath } from "node:path";
 import type { DbConnection } from "../../src/db/connection.ts";
 import {
   applyPatchesToContextItem,
@@ -17,6 +18,7 @@ import {
   listContextItemsByPrefix,
   moveContextItem,
   PathConflictError,
+  resolveContextItem,
   searchContextByKeyword,
   updateContextItem,
   updateContextItemContent,
@@ -251,6 +253,47 @@ describe("context CRUD", () => {
       "file",
     );
     expect(unknown).toBeNull();
+  });
+
+  test("resolveContextItem: by UUID, context_path, and source_path", async () => {
+    const relFile = "fixtures/readme.md";
+    const absFile = resolvePath(relFile);
+
+    const file = await createContextItem(conn, {
+      title: "Readme",
+      content: "hi",
+      sourceType: "file",
+      sourcePath: absFile,
+      contextPath: "/projects/demo/readme.md",
+    });
+    const url = await createContextItem(conn, {
+      title: "Example",
+      content: "remote",
+      sourceType: "url",
+      sourcePath: "https://example.com",
+      contextPath: "/example.com.md",
+    });
+
+    const byId = await resolveContextItem(conn, file.id);
+    expect(byId?.id).toBe(file.id);
+
+    const byContextPath = await resolveContextItem(
+      conn,
+      "/projects/demo/readme.md",
+    );
+    expect(byContextPath?.id).toBe(file.id);
+
+    const byRelativeSource = await resolveContextItem(conn, relFile);
+    expect(byRelativeSource?.id).toBe(file.id);
+
+    const byAbsoluteSource = await resolveContextItem(conn, absFile);
+    expect(byAbsoluteSource?.id).toBe(file.id);
+
+    const byUrlSource = await resolveContextItem(conn, "https://example.com");
+    expect(byUrlSource?.id).toBe(url.id);
+
+    const miss = await resolveContextItem(conn, "nope/does-not-exist.md");
+    expect(miss).toBeNull();
   });
 
   test("list with filters", async () => {


### PR DESCRIPTION
## Summary

- `context refresh README.md` (and `chunks`, `delete`) used to fail right after `context add README.md` because the lookup only matched the virtual `context_path`, not the absolute `source_path` that `add` stores.
- `resolveContextItem` now falls back to URL and cwd-resolved file `source_path` after the existing UUID/`context_path` checks, so every management command that goes through it inherits the fix.
- Adds a unit test covering UUID, `context_path`, URL source, absolute + relative file source, and miss; updates `docs/context-and-search.md`; bumps version to 0.8.2.

## Test plan

- [x] `bun run lint`
- [x] `bun test` (661/661)
- [ ] Manual repro: `context add README.md` then `context refresh README.md` resolves the item