### PR TITLE
Return tree snapshot from context_write and context_refresh

### DIFF
--- a/docs/context-and-search.md
+++ b/docs/context-and-search.md
@@ -200,6 +200,9 @@ The agent-side `context_write` tool follows the same convention:
 defaults to `on_conflict='error'` and returns a PATs-style
 `error_type: "path_conflict"` with a `next_action_hint` that guides the
 agent to `context_read` first or pass `on_conflict='overwrite'`.
+On success, `context_write` also returns a `tree` field — a `context_tree`
+snapshot of the filesystem after the write — so the agent can see what
+else is nearby without a follow-up call.
 
 ### Remote content via a loading agent
 
@@ -272,7 +275,9 @@ same arguments as the CLI (`path` for a single item or subtree,
 `all: true` for every sourced item) and returns a structured summary
 (`checked`, `updated`, `unchanged`, `missing`, `reembedded`,
 `chunks`, per-item statuses) so the agent can report back or feed a
-downstream task via `complete_task`.
+downstream task via `complete_task`. On success the tool also returns
+a `tree` field — a post-refresh `context_tree` snapshot so the agent
+sees the current filesystem layout without a follow-up call.
 
 Under the hood, URL fetches from the daemon open a nested fetcher
 loop with the project's MCPX client — the same path the CLI uses.

--- a/docs/virtual-filesystem.md
+++ b/docs/virtual-filesystem.md
@@ -58,7 +58,7 @@ instances in `src/tools/dir/` and `src/tools/file/`.
 | Tool | What it does |
 |---|---|
 | `context_read`        | `getContextItemByPath(path)` → slice lines (`offset`/`limit`) |
-| `context_write`       | Upsert a row, trigger re-chunk + re-embed |
+| `context_write`       | Upsert a row, trigger re-chunk + re-embed, return a tree snapshot |
 | `context_edit`        | Apply git-style line-range patches |
 | `context_delete`      | Remove by path (or recursively by prefix) |
 | `context_copy`        | Duplicate a row with a new `context_path` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/tools/context/refresh.ts
+++ b/src/tools/context/refresh.ts
@@ -6,6 +6,7 @@ import {
   listContextItemsByPrefix,
   resolveContextItem,
 } from "../../db/context.ts";
+import { buildContextTree } from "../dir/tree.ts";
 import type { ToolDefinition } from "../tool.ts";
 
 const inputSchema = z.object({
@@ -43,6 +44,12 @@ const outputSchema = z.object({
   ),
   message: z.string(),
   is_error: z.boolean(),
+  tree: z
+    .string()
+    .optional()
+    .describe(
+      "Snapshot of the context filesystem after the refresh so you can see what's currently stored.",
+    ),
 });
 
 const empty = {
@@ -54,6 +61,7 @@ const empty = {
   chunks: 0,
   embeddings_skipped: false,
   items: [],
+  tree: undefined as string | undefined,
 };
 
 export const contextRefreshTool = {
@@ -127,10 +135,13 @@ export const contextRefreshTool = {
       parts.push("embeddings skipped (no OpenAI API key configured)");
     }
 
+    const { tree } = await buildContextTree(ctx.conn);
+
     return {
       ...result,
       message: parts.join(", "),
       is_error: false,
+      tree,
     };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/dir/tree.ts
+++ b/src/tools/dir/tree.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { DbConnection } from "../../db/connection.ts";
 import {
   countContextItemsByPrefix,
   listContextItemsByPrefix,
@@ -8,6 +9,185 @@ import type { ToolDefinition } from "../tool.ts";
 const DEFAULT_MAX_DEPTH = 3;
 const DEFAULT_ITEMS_PER_DIR = 15;
 const HARD_FETCH_CAP = 1000;
+
+export interface BuildContextTreeOptions {
+  path?: string;
+  maxDepth?: number;
+  itemsPerDir?: number;
+}
+
+export interface BuildContextTreeResult {
+  tree: string;
+  total_items: number;
+  truncated_dirs: Array<{ path: string; shown: number; total: number }>;
+  hint: string;
+}
+
+interface DirNode {
+  name: string;
+  fullPath: string;
+  isDir: true;
+  children: TreeEntry[];
+}
+
+interface FileNode {
+  name: string;
+  fullPath: string;
+  isDir: false;
+}
+
+type TreeEntry = DirNode | FileNode;
+
+export async function buildContextTree(
+  conn: DbConnection,
+  options: BuildContextTreeOptions = {},
+): Promise<BuildContextTreeResult> {
+  const path = options.path ?? "/";
+  const maxDepth = options.maxDepth ?? DEFAULT_MAX_DEPTH;
+  const itemsPerDir = options.itemsPerDir ?? DEFAULT_ITEMS_PER_DIR;
+  const normalizedPath = path.endsWith("/") ? path : `${path}/`;
+
+  const totalItems = await countContextItemsByPrefix(conn, path, {
+    recursive: true,
+  });
+
+  if (totalItems === 0) {
+    return {
+      tree: `${path}\n  (empty)`,
+      total_items: 0,
+      truncated_dirs: [],
+      hint: "Directory is empty.",
+    };
+  }
+
+  const items = await listContextItemsByPrefix(conn, path, {
+    recursive: true,
+    limit: HARD_FETCH_CAP,
+  });
+
+  // Build tree structure: dirs map child name -> child node
+  const root: DirNode = {
+    name: path,
+    fullPath: path,
+    isDir: true,
+    children: [],
+  };
+  const dirIndex = new Map<string, DirNode>();
+  dirIndex.set(stripTrailingSlash(path), root);
+
+  for (const item of items) {
+    const relative = item.context_path.slice(normalizedPath.length);
+    if (relative.length === 0) continue; // root itself, skip
+    const parts = relative.split("/").filter((p) => p.length > 0);
+    const isExplicitDir = item.mime_type === "inode/directory";
+
+    // Walk segments, creating intermediate directories as needed
+    let parentDir = root;
+    let currentRel = "";
+    for (let i = 0; i < parts.length; i++) {
+      const segment = parts[i];
+      if (!segment) continue;
+      currentRel = currentRel ? `${currentRel}/${segment}` : segment;
+      const fullPath = `${normalizedPath}${currentRel}`;
+      const isLeaf = i === parts.length - 1;
+      const isDirHere = !isLeaf || isExplicitDir;
+
+      if (isDirHere) {
+        const key = stripTrailingSlash(fullPath);
+        let dir = dirIndex.get(key);
+        if (!dir) {
+          dir = {
+            name: segment,
+            fullPath,
+            isDir: true,
+            children: [],
+          };
+          dirIndex.set(key, dir);
+          parentDir.children.push(dir);
+        }
+        parentDir = dir;
+      } else {
+        parentDir.children.push({
+          name: segment,
+          fullPath,
+          isDir: false,
+        });
+      }
+    }
+  }
+
+  // Sort each directory's children: dirs first, then alphabetical
+  for (const dir of dirIndex.values()) {
+    dir.children.sort((a, b) => {
+      if (a.isDir !== b.isDir) return a.isDir ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    });
+  }
+
+  const truncatedDirs: Array<{
+    path: string;
+    shown: number;
+    total: number;
+  }> = [];
+  const depthLimitedDirs: string[] = [];
+
+  const lines: string[] = [path];
+
+  const render = (dir: DirNode, indent: string, currentDepth: number): void => {
+    const children = dir.children;
+    const total = children.length;
+    const shown = Math.min(total, itemsPerDir);
+    const visible = children.slice(0, shown);
+    const overflow = total - shown;
+
+    if (overflow > 0) {
+      truncatedDirs.push({
+        path: stripTrailingSlash(dir.fullPath),
+        shown,
+        total,
+      });
+    }
+
+    for (let i = 0; i < visible.length; i++) {
+      const child = visible[i];
+      if (!child) continue;
+      const isLastVisible = i === visible.length - 1 && overflow === 0;
+      const connector = isLastVisible ? "└── " : "├── ";
+      const childIndent = isLastVisible ? "    " : "│   ";
+
+      if (child.isDir) {
+        const atDepthLimit = currentDepth + 1 >= maxDepth;
+        if (atDepthLimit && child.children.length > 0) {
+          depthLimitedDirs.push(stripTrailingSlash(child.fullPath));
+          const subCount = countDescendants(child);
+          lines.push(
+            `${indent}${connector}${child.name}/ (${subCount} ${
+              subCount === 1 ? "item" : "items"
+            }, drill in)`,
+          );
+        } else {
+          lines.push(`${indent}${connector}${child.name}/`);
+          render(child, indent + childIndent, currentDepth + 1);
+        }
+      } else {
+        lines.push(`${indent}${connector}${child.name}`);
+      }
+    }
+
+    if (overflow > 0) {
+      lines.push(`${indent}└── ... (+${overflow} more)`);
+    }
+  };
+
+  render(root, "", 0);
+
+  return {
+    tree: lines.join("\n"),
+    total_items: totalItems,
+    truncated_dirs: truncatedDirs,
+    hint: buildHint({ truncatedDirs, depthLimitedDirs, totalItems }),
+  };
+}
 
 const inputSchema = z.object({
   path: z
@@ -48,21 +228,6 @@ const outputSchema = z.object({
   hint: z.string(),
 });
 
-interface DirNode {
-  name: string;
-  fullPath: string;
-  isDir: true;
-  children: TreeEntry[];
-}
-
-interface FileNode {
-  name: string;
-  fullPath: string;
-  isDir: false;
-}
-
-type TreeEntry = DirNode | FileNode;
-
 export const contextTreeTool = {
   name: "context_tree",
   description:
@@ -71,163 +236,12 @@ export const contextTreeTool = {
   inputSchema,
   outputSchema,
   execute: async (input, ctx) => {
-    const path = input.path ?? "/";
-    const maxDepth = input.max_depth ?? DEFAULT_MAX_DEPTH;
-    const itemsPerDir = input.items_per_dir ?? DEFAULT_ITEMS_PER_DIR;
-    const normalizedPath = path.endsWith("/") ? path : `${path}/`;
-
-    const totalItems = await countContextItemsByPrefix(ctx.conn, path, {
-      recursive: true,
+    const result = await buildContextTree(ctx.conn, {
+      path: input.path,
+      maxDepth: input.max_depth,
+      itemsPerDir: input.items_per_dir,
     });
-
-    if (totalItems === 0) {
-      return {
-        tree: `${path}\n  (empty)`,
-        is_error: false,
-        total_items: 0,
-        truncated_dirs: [],
-        hint: "Directory is empty.",
-      };
-    }
-
-    const items = await listContextItemsByPrefix(ctx.conn, path, {
-      recursive: true,
-      limit: HARD_FETCH_CAP,
-    });
-
-    // Build tree structure: dirs map child name -> child node
-    const root: DirNode = {
-      name: path,
-      fullPath: path,
-      isDir: true,
-      children: [],
-    };
-    const dirIndex = new Map<string, DirNode>();
-    dirIndex.set(stripTrailingSlash(path), root);
-
-    for (const item of items) {
-      const relative = item.context_path.slice(normalizedPath.length);
-      if (relative.length === 0) continue; // root itself, skip
-      const parts = relative.split("/").filter((p) => p.length > 0);
-      const isExplicitDir = item.mime_type === "inode/directory";
-
-      // Walk segments, creating intermediate directories as needed
-      let parentDir = root;
-      let currentRel = "";
-      for (let i = 0; i < parts.length; i++) {
-        const segment = parts[i];
-        if (!segment) continue;
-        currentRel = currentRel ? `${currentRel}/${segment}` : segment;
-        const fullPath = `${normalizedPath}${currentRel}`;
-        const isLeaf = i === parts.length - 1;
-        const isDirHere = !isLeaf || isExplicitDir;
-
-        if (isDirHere) {
-          const key = stripTrailingSlash(fullPath);
-          let dir = dirIndex.get(key);
-          if (!dir) {
-            dir = {
-              name: segment,
-              fullPath,
-              isDir: true,
-              children: [],
-            };
-            dirIndex.set(key, dir);
-            parentDir.children.push(dir);
-          }
-          parentDir = dir;
-        } else {
-          parentDir.children.push({
-            name: segment,
-            fullPath,
-            isDir: false,
-          });
-        }
-      }
-    }
-
-    // Sort each directory's children: dirs first, then alphabetical
-    for (const dir of dirIndex.values()) {
-      dir.children.sort((a, b) => {
-        if (a.isDir !== b.isDir) return a.isDir ? -1 : 1;
-        return a.name.localeCompare(b.name);
-      });
-    }
-
-    const truncatedDirs: Array<{
-      path: string;
-      shown: number;
-      total: number;
-    }> = [];
-    const depthLimitedDirs: string[] = [];
-
-    const lines: string[] = [path];
-
-    const render = (
-      dir: DirNode,
-      indent: string,
-      currentDepth: number,
-    ): void => {
-      const children = dir.children;
-      const total = children.length;
-      const shown = Math.min(total, itemsPerDir);
-      const visible = children.slice(0, shown);
-      const overflow = total - shown;
-
-      if (overflow > 0) {
-        truncatedDirs.push({
-          path: stripTrailingSlash(dir.fullPath),
-          shown,
-          total,
-        });
-      }
-
-      for (let i = 0; i < visible.length; i++) {
-        const child = visible[i];
-        if (!child) continue;
-        const isLastVisible = i === visible.length - 1 && overflow === 0;
-        const connector = isLastVisible ? "└── " : "├── ";
-        const childIndent = isLastVisible ? "    " : "│   ";
-
-        if (child.isDir) {
-          const atDepthLimit = currentDepth + 1 >= maxDepth;
-          if (atDepthLimit && child.children.length > 0) {
-            depthLimitedDirs.push(stripTrailingSlash(child.fullPath));
-            const subCount = countDescendants(child);
-            lines.push(
-              `${indent}${connector}${child.name}/ (${subCount} ${
-                subCount === 1 ? "item" : "items"
-              }, drill in)`,
-            );
-          } else {
-            lines.push(`${indent}${connector}${child.name}/`);
-            render(child, indent + childIndent, currentDepth + 1);
-          }
-        } else {
-          lines.push(`${indent}${connector}${child.name}`);
-        }
-      }
-
-      if (overflow > 0) {
-        lines.push(`${indent}└── ... (+${overflow} more)`);
-      }
-    };
-
-    render(root, "", 0);
-
-    const hint = buildHint({
-      truncatedDirs,
-      depthLimitedDirs,
-      totalItems,
-    });
-
-    return {
-      tree: lines.join("\n"),
-      is_error: false,
-      total_items: totalItems,
-      truncated_dirs: truncatedDirs,
-      hint,
-    };
+    return { ...result, is_error: false };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;
 

--- a/src/tools/file/write.ts
+++ b/src/tools/file/write.ts
@@ -6,6 +6,7 @@ import {
   PathConflictError,
   upsertContextItem,
 } from "../../db/context.ts";
+import { buildContextTree } from "../dir/tree.ts";
 import type { ToolDefinition } from "../tool.ts";
 
 function mimeFromPath(path: string): string {
@@ -49,6 +50,12 @@ const outputSchema = z.object({
   error_type: z.string().optional(),
   message: z.string().optional(),
   next_action_hint: z.string().optional(),
+  tree: z
+    .string()
+    .optional()
+    .describe(
+      "Snapshot of the context filesystem after the write so you can see the surrounding files.",
+    ),
 });
 
 export const contextWriteTool = {
@@ -86,7 +93,13 @@ export const contextWriteTool = {
             });
 
       await ingestByPath(ctx.conn, input.path, ctx.config);
-      return { id: item.id, path: item.context_path, is_error: false };
+      const { tree } = await buildContextTree(ctx.conn);
+      return {
+        id: item.id,
+        path: item.context_path,
+        is_error: false,
+        tree,
+      };
     } catch (err) {
       if (err instanceof PathConflictError) {
         return {

--- a/test/tools/context-refresh.test.ts
+++ b/test/tools/context-refresh.test.ts
@@ -133,4 +133,13 @@ describe("context_refresh tool", () => {
     expect(result.embeddings_skipped).toBe(true);
     expect(result.message).toContain("embeddings skipped");
   });
+
+  test("returns a tree snapshot on successful refresh", async () => {
+    await seedFileBackedItem("drift.md", "new disk content", "old stored");
+    const result = await contextRefreshTool.execute({ all: true }, ctx);
+    expect(result.is_error).toBe(false);
+    expect(result.tree).toBeTruthy();
+    expect(result.tree).toContain("docs/");
+    expect(result.tree).toContain("drift.md");
+  });
 });

--- a/test/tools/file.test.ts
+++ b/test/tools/file.test.ts
@@ -90,6 +90,19 @@ describe("context_write", () => {
     );
     expect(result.path).toBe("/data.bin");
   });
+
+  test("returns a tree snapshot on success", async () => {
+    await seedFile(conn, "/notes/existing.md", "already here");
+    const result = await contextWriteTool.execute(
+      { path: "/notes/new.md", content: "fresh" },
+      ctx,
+    );
+    expect(result.is_error).toBe(false);
+    expect(result.tree).toBeTruthy();
+    expect(result.tree).toContain("notes/");
+    expect(result.tree).toContain("new.md");
+    expect(result.tree).toContain("existing.md");
+  });
 });
 
 // ── context_read ───────────────────────────────────────────────


### PR DESCRIPTION
Agents lose track of what's in the virtual filesystem after mutating
it. Returning a post-op context_tree snapshot inline gives them
immediate visibility into surrounding files without a follow-up call.

- Extracts buildContextTree() helper from the context_tree tool
- Adds an optional tree field to context_write and context_refresh outputs
- Bumps version to 0.8.5

https://claude.ai/code/session_01L3ivfkfJ3XkrpCoKVCeVPs