### PR TITLE
Make mcpx CLI a thin passthrough; add list and deauth

### DIFF
--- a/docs/mcpx.md
+++ b/docs/mcpx.md
@@ -62,11 +62,13 @@ access per user. MCPX accepts both shapes.
 
 ```bash
 botholomew mcpx servers                                      # list configured server names
+botholomew mcpx list                                         # every tool / resource / prompt across all configured servers
 botholomew mcpx ping                                         # check connectivity to all servers (or pass names to filter)
-botholomew mcpx add gmail --command npx --args -y @modelcontextprotocol/server-gmail
+botholomew mcpx add gmail --command npx --args "-y,@modelcontextprotocol/server-gmail"
 botholomew mcpx add arcade --url https://api.arcade.dev/mcp/engineering
-botholomew mcpx remove gmail
+botholomew mcpx remove gmail                                 # --dry-run to preview, --keep-auth to keep stored tokens
 botholomew mcpx auth arcade                                  # OAuth / token flow for HTTP servers
+botholomew mcpx deauth arcade                                # clear stored OAuth tokens for a server
 botholomew mcpx search "read email"                          # keyword + semantic search over all tools
 botholomew mcpx info gmail                                   # server overview
 botholomew mcpx info gmail list_messages                     # input schema for one tool
@@ -78,11 +80,18 @@ botholomew mcpx prompt arcade                                # list prompts for 
 botholomew mcpx task <action> <server> [taskId]              # list/get/result/cancel async tool tasks
 ```
 
+Every subcommand is a thin passthrough to the `mcpx` CLI, so
+`botholomew mcpx <cmd> --help` shows the upstream reference — including
+every option and argument for that command. The only exception is
+`import-global`, which is Botholomew-specific.
+
 `mcpx exec` is the fastest way to confirm a server is wired up before
 handing it to the agent. `mcpx auth` runs the OAuth flow for HTTP
 servers that need it (most Arcade gateways do), and `mcpx
 import-global` is the usual way to bootstrap a new project from your
-global `~/.mcpx/` configuration.
+global `~/.mcpx/` configuration. Note that `--args` and `--env` take
+**comma-separated** values — quote them so your shell doesn't split
+them (e.g. `--args "-y,@scope/pkg"`).
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Local, autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/commands/mcpx.ts
+++ b/src/commands/mcpx.ts
@@ -51,155 +51,64 @@ function getDir(program: Command): string {
   return program.opts().dir;
 }
 
+// Slice process.argv from the token after "mcpx" so flags (including --help)
+// and positional args flow through to upstream mcpx verbatim.
+function getRawMcpxArgs(): string[] {
+  const idx = process.argv.indexOf("mcpx");
+  return idx === -1 ? [] : process.argv.slice(idx + 1);
+}
+
+const PASSTHROUGH_SUBCOMMANDS: ReadonlyArray<[name: string, desc: string]> = [
+  ["servers", "List configured MCP server names"],
+  ["info", "Show server overview or schema for a specific tool"],
+  ["search", "Search tools by keyword and/or semantic similarity"],
+  ["exec", "Execute a tool call"],
+  ["add", "Add an MCP server"],
+  ["remove", "Remove an MCP server"],
+  ["ping", "Check connectivity to MCP servers"],
+  ["auth", "Authenticate with an HTTP MCP server"],
+  ["deauth", "Remove stored authentication for a server"],
+  ["resource", "List resources for a server, or read a specific resource"],
+  ["prompt", "List prompts for a server, or get a specific prompt"],
+  ["task", "Manage async tool tasks (list, get, result, cancel)"],
+  ["index", "Build the search index from all configured servers"],
+];
+
 export function registerMcpxCommand(program: Command) {
   const mcpx = program
     .command("mcpx")
     .description("Manage MCP servers via MCPX");
 
-  // --- servers ---
+  for (const [name, description] of PASSTHROUGH_SUBCOMMANDS) {
+    mcpx
+      .command(name)
+      .description(description)
+      .allowUnknownOption(true)
+      .helpOption(false)
+      .argument("[args...]", "arguments forwarded to mcpx")
+      .action(async () => {
+        await runMcpx(getDir(program), getRawMcpxArgs(), { inherit: true });
+      });
+  }
+
+  // Upstream mcpx's "list" is the default action when invoked with no
+  // subcommand — not a registered subcommand — so we strip the "list"
+  // token before forwarding.
   mcpx
-    .command("servers")
-    .description("List configured MCP server names")
+    .command("list")
+    .description(
+      "List all tools, resources, and prompts across all configured servers",
+    )
+    .allowUnknownOption(true)
+    .helpOption(false)
+    .argument("[args...]", "arguments forwarded to mcpx")
     .action(async () => {
-      const out = await runMcpx(getDir(program), ["servers"]);
-      process.stdout.write(out);
+      const raw = getRawMcpxArgs();
+      const args = raw[0] === "list" ? raw.slice(1) : raw;
+      await runMcpx(getDir(program), args, { inherit: true });
     });
 
-  // --- info ---
-  mcpx
-    .command("info <first> [second]")
-    .description(
-      "Show server overview, or schema for a specific tool (server is optional if tool name is unambiguous)",
-    )
-    .action(async (first: string, second?: string) => {
-      const out = await runMcpx(getDir(program), ["info", first, second]);
-      process.stdout.write(out);
-    });
-
-  // --- search ---
-  mcpx
-    .command("search <terms...>")
-    .description("Search tools by keyword and/or semantic similarity")
-    .action(async (terms: string[]) => {
-      const out = await runMcpx(getDir(program), ["search", ...terms]);
-      process.stdout.write(out);
-    });
-
-  // --- exec ---
-  mcpx
-    .command("exec <first> [second] [third]")
-    .description(
-      "Execute a tool call (server is optional if tool name is unambiguous)",
-    )
-    .action(async (first: string, second?: string, third?: string) => {
-      const out = await runMcpx(getDir(program), [
-        "exec",
-        first,
-        second,
-        third,
-      ]);
-      process.stdout.write(out);
-    });
-
-  // --- add ---
-  mcpx
-    .command("add <name>")
-    .description("Add an MCP server")
-    .option("--command <cmd>", "Stdio server command")
-    .option("--args <args...>", "Stdio server arguments")
-    .option("--url <url>", "HTTP server URL")
-    .option("--transport <type>", "HTTP transport: sse or streamable-http")
-    .option("--env <pairs...>", "Environment variables as KEY=VALUE pairs")
-    .action(
-      async (
-        name: string,
-        opts: {
-          command?: string;
-          args?: string[];
-          url?: string;
-          transport?: string;
-          env?: string[];
-        },
-      ) => {
-        const cliArgs: string[] = ["add", name];
-        if (opts.command) cliArgs.push("--command", opts.command);
-        if (opts.args) {
-          for (const a of opts.args) cliArgs.push("--args", a);
-        }
-        if (opts.url) cliArgs.push("--url", opts.url);
-        if (opts.transport) cliArgs.push("--transport", opts.transport);
-        if (opts.env) {
-          for (const e of opts.env) cliArgs.push("--env", e);
-        }
-        const out = await runMcpx(getDir(program), cliArgs);
-        process.stdout.write(out);
-      },
-    );
-
-  // --- remove ---
-  mcpx
-    .command("remove <name>")
-    .description("Remove an MCP server")
-    .action(async (name: string) => {
-      const out = await runMcpx(getDir(program), ["remove", name]);
-      process.stdout.write(out);
-    });
-
-  // --- ping ---
-  mcpx
-    .command("ping [servers...]")
-    .description("Check connectivity to MCP servers")
-    .action(async (servers: string[]) => {
-      const out = await runMcpx(getDir(program), ["ping", ...servers]);
-      process.stdout.write(out);
-    });
-
-  // --- auth ---
-  mcpx
-    .command("auth <server>")
-    .description("Authenticate with an HTTP MCP server")
-    .action(async (server: string) => {
-      await runMcpx(getDir(program), ["auth", server], { inherit: true });
-    });
-
-  // --- resource ---
-  mcpx
-    .command("resource [server] [uri]")
-    .description("List resources for a server, or read a specific resource")
-    .action(async (server?: string, uri?: string) => {
-      const out = await runMcpx(getDir(program), ["resource", server, uri]);
-      process.stdout.write(out);
-    });
-
-  // --- prompt ---
-  mcpx
-    .command("prompt [server] [name] [args]")
-    .description("List prompts for a server, or get a specific prompt")
-    .action(async (server?: string, name?: string, argsJson?: string) => {
-      const out = await runMcpx(getDir(program), [
-        "prompt",
-        server,
-        name,
-        argsJson,
-      ]);
-      process.stdout.write(out);
-    });
-
-  // --- task ---
-  mcpx
-    .command("task <action> <server> [taskId]")
-    .description("Manage async tasks (actions: list, get, result, cancel)")
-    .action(async (action: string, server: string, taskId?: string) => {
-      const out = await runMcpx(getDir(program), [
-        "task",
-        action,
-        server,
-        taskId,
-      ]);
-      process.stdout.write(out);
-    });
-
-  // --- import-global ---
+  // Botholomew-specific: copy system-wide MCPX settings into this project.
   mcpx
     .command("import-global")
     .description("Copy system-wide MCPX settings (~/.mcpx) into this project")
@@ -233,13 +142,5 @@ export function registerMcpxCommand(program: Command) {
           `Imported ${copied} file(s) from ~/.mcpx into ${projectMcpxDir}`,
         );
       }
-    });
-
-  // --- index ---
-  mcpx
-    .command("index")
-    .description("Build the search index from all configured servers")
-    .action(async () => {
-      await runMcpx(getDir(program), ["index"], { inherit: true });
     });
 }

--- a/test/commands/mcpx.test.ts
+++ b/test/commands/mcpx.test.ts
@@ -5,12 +5,30 @@ import { runMcpx } from "../../src/commands/mcpx.ts";
 
 const TMP_DIR = join(import.meta.dir, ".tmp-mcpx-cmd-test");
 const MCPX_DIR = join(TMP_DIR, ".botholomew", "mcpx");
+const CLI_PATH = join(import.meta.dir, "..", "..", "src", "cli.ts");
 
 afterEach(() => {
   if (existsSync(TMP_DIR)) {
     rmSync(TMP_DIR, { recursive: true });
   }
 });
+
+async function runBotholomewCli(args: string[]): Promise<{
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}> {
+  const proc = Bun.spawn(["bun", CLI_PATH, "-d", TMP_DIR, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const exitCode = await proc.exited;
+  return { stdout, stderr, exitCode };
+}
 
 describe("mcpx CLI proxy", () => {
   test("servers returns empty array when no config exists", async () => {
@@ -37,5 +55,106 @@ describe("mcpx CLI proxy", () => {
   test("filters out undefined args", async () => {
     const out = await runMcpx(TMP_DIR, ["servers", undefined]);
     expect(JSON.parse(out)).toEqual([]);
+  });
+});
+
+describe("mcpx CLI passthrough (end-to-end)", () => {
+  // Regression test: previously the wrapper declared --args as variadic and
+  // forwarded each value with a repeated --args flag, but upstream mcpx
+  // treats --args as a single comma-separated value, so last-one-wins would
+  // silently drop all but the final arg.
+  test("add preserves every value in a comma-separated --args", async () => {
+    const result = await runBotholomewCli([
+      "mcpx",
+      "add",
+      "echo",
+      "--command",
+      "echo",
+      "--args",
+      "hello,world",
+      "--no-auth",
+      "--no-index",
+    ]);
+    expect(result.exitCode).toBe(0);
+
+    const servers = await Bun.file(join(MCPX_DIR, "servers.json")).json();
+    expect(servers.mcpServers.echo).toEqual({
+      command: "echo",
+      args: ["hello", "world"],
+    });
+  });
+
+  test("add rejects when neither --command nor --url is given", async () => {
+    const result = await runBotholomewCli(["mcpx", "add", "foo"]);
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  test("mcpx exec --help forwards to upstream help renderer", async () => {
+    const result = await runBotholomewCli(["mcpx", "exec", "--help"]);
+    expect(result.exitCode).toBe(0);
+    // Upstream help text includes option descriptions that the old wrapper
+    // did not surface, e.g. --ttl and --no-wait.
+    expect(result.stdout).toContain("--ttl");
+    expect(result.stdout).toContain("--no-wait");
+  });
+
+  test("remove --dry-run leaves servers.json untouched", async () => {
+    mkdirSync(MCPX_DIR, { recursive: true });
+    const initial = {
+      mcpServers: {
+        echo: { command: "echo", args: ["hi"] },
+      },
+    };
+    await Bun.write(
+      join(MCPX_DIR, "servers.json"),
+      JSON.stringify(initial, null, 2),
+    );
+
+    const out = await runMcpx(TMP_DIR, ["remove", "echo", "--dry-run"]);
+    expect(out).toContain("Would remove");
+
+    const after = await Bun.file(join(MCPX_DIR, "servers.json")).json();
+    expect(after).toEqual(initial);
+  });
+
+  test("remove --keep-auth preserves auth.json entry", async () => {
+    mkdirSync(MCPX_DIR, { recursive: true });
+    await Bun.write(
+      join(MCPX_DIR, "servers.json"),
+      JSON.stringify({
+        mcpServers: { arcade: { url: "https://example.test/mcp" } },
+      }),
+    );
+    await Bun.write(
+      join(MCPX_DIR, "auth.json"),
+      JSON.stringify({ arcade: { access_token: "abc" } }),
+    );
+
+    await runMcpx(TMP_DIR, ["remove", "arcade", "--keep-auth"]);
+
+    const auth = await Bun.file(join(MCPX_DIR, "auth.json")).json();
+    expect(auth.arcade).toEqual({ access_token: "abc" });
+
+    const servers = await Bun.file(join(MCPX_DIR, "servers.json")).json();
+    expect(servers.mcpServers.arcade).toBeUndefined();
+  });
+
+  test("deauth removes the entry from auth.json", async () => {
+    mkdirSync(MCPX_DIR, { recursive: true });
+    await Bun.write(
+      join(MCPX_DIR, "auth.json"),
+      JSON.stringify({ arcade: { access_token: "abc" } }),
+    );
+
+    const out = await runMcpx(TMP_DIR, ["deauth", "arcade"]);
+    expect(out).toContain("Deauthenticated");
+
+    const auth = await Bun.file(join(MCPX_DIR, "auth.json")).json();
+    expect(auth.arcade).toBeUndefined();
+  });
+
+  test("list exits 0 with an empty config", async () => {
+    const result = await runBotholomewCli(["mcpx", "list"]);
+    expect(result.exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Every `botholomew mcpx <cmd>` subcommand now forwards args, options, and `--help` verbatim to upstream `@evantahler/mcpx`, so `botholomew mcpx exec --help` shows the real reference (previously stripped to a useless one-liner), and `add --args "a,b"` stops silently dropping values — the wrapper's half-mirrored option layer was the source of that bug. Also adds `list` (every tool/resource/prompt across all servers) and `deauth <server>` (clear stored OAuth tokens). `import-global` stays as its own action since it's Botholomew-specific.

## Test plan

- [x] `bun run lint` clean
- [x] `bun test test/commands/mcpx.test.ts` — 10/10 pass (adds regression test for the variadic-args bug, an `exec --help` assertion that checks upstream option descriptions survive, and coverage for `remove --dry-run` / `--keep-auth`, `deauth`, `list`)
- [x] Manual: `botholomew mcpx add echo --command echo --args "hello,world"` now writes both args to `servers.json`
- [x] Manual: `botholomew mcpx <sub> --help` renders upstream help for every subcommand

🤖 Generated with [Claude Code](https://claude.com/claude-code)