### PR TITLE
Add /clear command to start a new chat thread

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -94,7 +94,7 @@ From inside `botholomew chat`:
 ### Autocomplete popup
 
 Typing `/` at the start of the input pops up a menu of matching
-commands (built-ins `/help`, `/skills`, `/exit` plus every
+commands (built-ins `/help`, `/skills`, `/clear`, `/exit` plus every
 skill loaded from `.botholomew/skills/`). Each row shows the command
 name and its description.
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -170,9 +170,12 @@ Typing `/` with nothing before it opens the autocomplete popup.
 | `Tab` or `Return` | Accept the highlighted command |
 | `Esc` | Close the popup (keeps what you typed) |
 
-Built-in commands are `/help`, `/skills`, and `/exit`. Every file in
-`.botholomew/skills/` is also surfaced in the popup with its
-description. See [skills.md](skills.md) for the file format and how
+Built-in commands are `/help`, `/skills`, `/clear`, and `/exit`.
+`/clear` ends the current chat thread (persisted, still resumable via
+`botholomew chat --thread-id <id>`) and starts a fresh one on the same
+session, so you can reset context without losing the conversation.
+Every file in `.botholomew/skills/` is also surfaced in the popup with
+its description. See [skills.md](skills.md) for the file format and how
 skills are invoked with positional arguments.
 
 The popup disappears as soon as you type a space — so a second

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -167,7 +167,8 @@ Typing `/` with nothing before it opens the autocomplete popup.
 | Key | Action |
 |---|---|
 | `↑` / `↓` | Move the highlight |
-| `Tab` or `Return` | Accept the highlighted command |
+| `Return` | Submit the highlighted command if it takes no arguments; otherwise insert `/<name> ` so you can type args |
+| `Tab` | Insert the highlighted completion as `/<name> ` without submitting (lets you edit before sending) |
 | `Esc` | Close the popup (keeps what you typed) |
 
 Built-in commands are `/help`, `/skills`, `/clear`, and `/exit`.
@@ -178,8 +179,10 @@ Every file in `.botholomew/skills/` is also surfaced in the popup with
 its description. See [skills.md](skills.md) for the file format and how
 skills are invoked with positional arguments.
 
-The popup disappears as soon as you type a space — so a second
-`Return` submits the message as normal.
+Skills that reference `$1` / `$ARGUMENTS` (or declare `arguments` in
+frontmatter) are treated as argument-taking: `Return` inserts
+`/<name> ` and waits for your input. Skills without placeholders, like
+the built-ins, submit in a single `Return`.
 
 ---
 
@@ -258,7 +261,8 @@ just shows the summary to keep the chat view compact.
 | `⌥+Enter` | Insert newline |
 | `↑` / `↓` | Browse input history |
 | `/` | Open slash-command popup |
-| `Tab` / `Return` | Accept highlighted slash command (popup open) |
+| `Return` | Run highlighted command (popup open, no-arg) / insert `/<name> ` if args needed |
+| `Tab` | Insert highlighted command as `/<name> ` without submitting |
 | `Esc` | Close popup |
 | `Ctrl+J` / `Ctrl+K` | Select queued message |
 | `Ctrl+E` | Edit queued message |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/chat/session.ts
+++ b/src/chat/session.ts
@@ -140,3 +140,22 @@ export async function endChatSession(session: ChatSession): Promise<void> {
   await withDb(session.dbPath, (conn) => endThread(conn, session.threadId));
   await session.cleanup();
 }
+
+/**
+ * End the current thread and start a fresh one on the same session.
+ * The old thread is persisted (marked ended) and can still be resumed
+ * via `botholomew chat --thread-id <id>`. Returns the previous thread
+ * ID so callers can display it to the user.
+ */
+export async function clearChatSession(
+  session: ChatSession,
+): Promise<{ previousThreadId: string; newThreadId: string }> {
+  const previousThreadId = session.threadId;
+  const newThreadId = await withDb(session.dbPath, async (conn) => {
+    await endThread(conn, previousThreadId);
+    return createThread(conn, "chat_session", undefined, "New chat");
+  });
+  session.threadId = newThreadId;
+  session.messages.length = 0;
+  return { previousThreadId, newThreadId };
+}

--- a/src/skills/commands.ts
+++ b/src/skills/commands.ts
@@ -4,6 +4,7 @@ import { renderSkill } from "./parser.ts";
 export interface SlashCommand {
   name: string;
   description: string;
+  takesArgs?: boolean;
 }
 
 export const BUILTIN_SLASH_COMMANDS: SlashCommand[] = [

--- a/src/skills/commands.ts
+++ b/src/skills/commands.ts
@@ -9,6 +9,7 @@ export interface SlashCommand {
 export const BUILTIN_SLASH_COMMANDS: SlashCommand[] = [
   { name: "help", description: "Show command reference and shortcuts" },
   { name: "skills", description: "List available skills" },
+  { name: "clear", description: "End current thread and start a new one" },
   { name: "exit", description: "End the chat session" },
 ];
 
@@ -17,6 +18,7 @@ export interface SlashCommandContext {
   addSystemMessage: (content: string) => void;
   queueUserMessage: (content: string) => void;
   exit: () => void;
+  clearChat?: () => void;
 }
 
 /**
@@ -35,6 +37,15 @@ export function handleSlashCommand(
   // Built-in commands
   if (name === "exit") {
     ctx.exit();
+    return true;
+  }
+
+  if (name === "clear") {
+    if (ctx.clearChat) {
+      ctx.clearChat();
+    } else {
+      ctx.addSystemMessage("/clear is only available in the chat TUI.");
+    }
     return true;
   }
 

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -127,6 +127,7 @@ export function App({
 }: AppProps) {
   const { exit } = useApp();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [messagesEpoch, setMessagesEpoch] = useState(0);
   const [inputValue, setInputValue] = useState("");
   const [inputHistory, setInputHistory] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -491,7 +492,8 @@ export function App({
             "  ⌥+Enter        Insert newline",
             "  ↑/↓            Browse input history",
             "  /              Open slash-command autocomplete",
-            "  Tab/Enter      Accept highlighted command (popup open)",
+            "  Enter          Run highlighted command / insert if it takes args (popup open)",
+            "  Tab            Insert highlighted command without submitting (popup open)",
             "  ↑/↓            Move highlight (popup open)",
             "  Esc            Close popup",
             "",
@@ -573,6 +575,11 @@ export function App({
             syncQueue();
             clearChatSession(session)
               .then(({ previousThreadId, newThreadId }) => {
+                // Ink's <Static> writes messages to terminal scrollback and
+                // can't un-write them, so setMessages alone leaves the old
+                // lines visible. Clear the terminal (including scrollback)
+                // and bump the epoch key on <Static> to force a fresh mount.
+                process.stdout.write("\x1b[2J\x1b[3J\x1b[H");
                 setMessages([
                   {
                     id: msgId(),
@@ -581,6 +588,7 @@ export function App({
                     timestamp: new Date(),
                   },
                 ]);
+                setMessagesEpoch((n) => n + 1);
                 setChatTitle(undefined);
               })
               .catch((err) => {
@@ -627,6 +635,10 @@ export function App({
       ? Array.from(sessionSkills.values()).map((s) => ({
           name: s.name,
           description: s.description,
+          takesArgs:
+            s.arguments.length > 0 ||
+            /\$ARGUMENTS\b/.test(s.body) ||
+            /\$[1-9]\b/.test(s.body),
         }))
       : [];
     return buildSlashCommands(BUILTIN_SLASH_COMMANDS, skillList);
@@ -672,7 +684,7 @@ export function App({
           node always has proper terminal width in its Yoga layout.
           Otherwise Ink's border renderer crashes with a negative
           contentWidth when tool-call boxes are rendered at width 0. */}
-      <Static items={messages}>
+      <Static key={messagesEpoch} items={messages}>
         {(msg) => <MessageBubble key={msg.id} message={msg} />}
       </Static>
 

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -2,6 +2,7 @@ import { Box, Static, Text, useApp, useInput } from "ink";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   type ChatSession,
+  clearChatSession,
   endChatSession,
   sendMessage,
   startChatSession,
@@ -534,6 +535,7 @@ export function App({
             "Commands:",
             "  /help           Show this help",
             "  /skills         List available skills",
+            "  /clear          End current thread and start a new one",
             "  /exit           End the chat session",
             ...skillLines,
           ].join("\n"),
@@ -563,6 +565,36 @@ export function App({
             processQueue();
           },
           exit,
+          clearChat: () => {
+            const session = sessionRef.current;
+            if (!session) return;
+            // Drain any queued messages so they don't leak into the new thread.
+            queueRef.current.length = 0;
+            syncQueue();
+            clearChatSession(session)
+              .then(({ previousThreadId, newThreadId }) => {
+                setMessages([
+                  {
+                    id: msgId(),
+                    role: "system",
+                    content: `Started a new chat thread (${newThreadId}). Previous thread saved — resume with: botholomew chat --thread-id ${previousThreadId}`,
+                    timestamp: new Date(),
+                  },
+                ]);
+                setChatTitle(undefined);
+              })
+              .catch((err) => {
+                setMessages((prev) => [
+                  ...prev,
+                  {
+                    id: msgId(),
+                    role: "system",
+                    content: `Failed to clear chat: ${err}`,
+                    timestamp: new Date(),
+                  },
+                ]);
+              });
+          },
         });
         if (handled) return;
       }

--- a/src/tui/components/InputBar.tsx
+++ b/src/tui/components/InputBar.tsx
@@ -9,7 +9,7 @@ import {
   useState,
 } from "react";
 import type { SlashCommand } from "../../skills/commands.ts";
-import { getSlashMatches } from "../slashCompletion.ts";
+import { getSlashMatches, shouldSubmitOnEnter } from "../slashCompletion.ts";
 import { SlashCommandPopup } from "./SlashCommandPopup.tsx";
 
 interface InputBarProps {
@@ -128,11 +128,23 @@ export const InputBar = memo(function InputBar({
         ? getSlashMatches(val, slashCommandsRef.current ?? [])
         : null;
 
-      const acceptSelection = () => {
+      const acceptSelection = (mode: "insert" | "submit") => {
         if (!popupOpen) return false;
         const chosen =
           popupOpen[Math.min(selectedIndexRef.current, popupOpen.length - 1)];
         if (!chosen) return false;
+        if (mode === "submit") {
+          const completed = `/${chosen.name}`;
+          valueRef.current = completed;
+          cursorPosRef.current = 0;
+          onChangeRef.current(completed);
+          setCursorPos(0);
+          historyIndexRef.current = -1;
+          setHistoryIndex(-1);
+          savedInput.current = "";
+          onSubmitRef.current(completed);
+          return true;
+        }
         const completed = `/${chosen.name} `;
         valueRef.current = completed;
         cursorPosRef.current = completed.length;
@@ -152,11 +164,16 @@ export const InputBar = memo(function InputBar({
         return;
       }
 
-      // Enter: if popup is open, accept selection (do not submit).
-      // Otherwise submit as before.
+      // Enter: if popup is open, accept the highlighted entry. No-arg
+      // commands submit in one keystroke; commands that take args insert
+      // `/<name> ` and wait for the user to finish typing.
       if (key.return) {
         if (popupOpen && !key.shift && !key.meta) {
-          acceptSelection();
+          const chosen =
+            popupOpen[Math.min(selectedIndexRef.current, popupOpen.length - 1)];
+          acceptSelection(
+            chosen && shouldSubmitOnEnter(chosen) ? "submit" : "insert",
+          );
           return;
         }
         if (key.shift || key.meta) {
@@ -179,10 +196,10 @@ export const InputBar = memo(function InputBar({
         return;
       }
 
-      // Tab: accept popup selection if open. No-op otherwise.
+      // Tab: insert the highlighted completion so the user can keep editing.
       if (key.tab) {
         if (popupOpen) {
-          acceptSelection();
+          acceptSelection("insert");
         }
         return;
       }

--- a/src/tui/slashCompletion.ts
+++ b/src/tui/slashCompletion.ts
@@ -28,11 +28,25 @@ export function getSlashMatches(
 
 export function buildSlashCommands(
   builtins: SlashCommand[],
-  skills: Iterable<{ name: string; description: string }>,
+  skills: Iterable<{ name: string; description: string; takesArgs?: boolean }>,
 ): SlashCommand[] {
   const out: SlashCommand[] = [...builtins];
   for (const s of skills) {
-    out.push({ name: s.name, description: s.description });
+    out.push({
+      name: s.name,
+      description: s.description,
+      takesArgs: s.takesArgs,
+    });
   }
   return out;
+}
+
+/**
+ * Decide whether pressing Enter on a highlighted popup entry should both
+ * accept the completion and immediately submit. True for no-argument
+ * commands (single-Enter runs them); false for commands that take args,
+ * where we insert `/<name> ` and wait for the user to finish typing.
+ */
+export function shouldSubmitOnEnter(cmd: SlashCommand): boolean {
+  return !cmd.takesArgs;
 }

--- a/test/chat/session.test.ts
+++ b/test/chat/session.test.ts
@@ -4,11 +4,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   type ChatSession,
+  clearChatSession,
   endChatSession,
   startChatSession,
 } from "../../src/chat/session.ts";
 import { withDb } from "../../src/db/connection.ts";
-import { listThreads } from "../../src/db/threads.ts";
+import { getThread, listThreads } from "../../src/db/threads.ts";
 
 let projectDir: string;
 let session: ChatSession | null = null;
@@ -67,5 +68,32 @@ describe("endChatSession", () => {
       listThreads(conn, { type: "chat_session" }),
     );
     expect(after[0]?.ended_at).not.toBeNull();
+  });
+});
+
+describe("clearChatSession", () => {
+  test("ends current thread and starts a new one", async () => {
+    session = await startChatSession(projectDir);
+    const dbPath = session.dbPath;
+    const originalThreadId = session.threadId;
+    session.messages.push({ role: "user", content: "hello" });
+
+    const { previousThreadId, newThreadId } = await clearChatSession(session);
+
+    expect(previousThreadId).toBe(originalThreadId);
+    expect(newThreadId).not.toBe(originalThreadId);
+    expect(session.threadId).toBe(newThreadId);
+    expect(session.messages).toEqual([]);
+
+    const oldThread = await withDb(dbPath, (conn) =>
+      getThread(conn, previousThreadId),
+    );
+    expect(oldThread?.thread.ended_at).not.toBeNull();
+
+    const newThread = await withDb(dbPath, (conn) =>
+      getThread(conn, newThreadId),
+    );
+    expect(newThread?.thread.ended_at).toBeNull();
+    expect(newThread?.thread.type).toBe("chat_session");
   });
 });

--- a/test/skills/commands.test.ts
+++ b/test/skills/commands.test.ts
@@ -7,16 +7,19 @@ import type { SkillDefinition } from "../../src/skills/parser.ts";
 
 function makeCtx(
   skills: Map<string, SkillDefinition> = new Map(),
+  opts: { withClearChat?: boolean } = {},
 ): SlashCommandContext & {
   systemMessages: string[];
   queuedMessages: string[];
   exited: boolean;
+  clearCalls: number;
 } {
   const ctx = {
     skills,
     systemMessages: [] as string[],
     queuedMessages: [] as string[],
     exited: false,
+    clearCalls: 0,
     addSystemMessage: (content: string) => {
       ctx.systemMessages.push(content);
     },
@@ -26,6 +29,11 @@ function makeCtx(
     exit: () => {
       ctx.exited = true;
     },
+    clearChat: opts.withClearChat
+      ? () => {
+          ctx.clearCalls++;
+        }
+      : undefined,
   };
   return ctx;
 }
@@ -114,5 +122,21 @@ describe("handleSlashCommand", () => {
     const result = handleSlashCommand("/REVIEW src/main.ts", ctx);
     expect(result).toBe(true);
     expect(ctx.queuedMessages).toHaveLength(1);
+  });
+
+  test("/clear invokes clearChat when provided", () => {
+    const ctx = makeCtx(new Map(), { withClearChat: true });
+    const result = handleSlashCommand("/clear", ctx);
+    expect(result).toBe(true);
+    expect(ctx.clearCalls).toBe(1);
+    expect(ctx.systemMessages).toHaveLength(0);
+  });
+
+  test("/clear warns when clearChat is not provided", () => {
+    const ctx = makeCtx();
+    const result = handleSlashCommand("/clear", ctx);
+    expect(result).toBe(true);
+    expect(ctx.clearCalls).toBe(0);
+    expect(ctx.systemMessages[0]).toContain("only available in the chat TUI");
   });
 });

--- a/test/tui/slash-completion.test.ts
+++ b/test/tui/slash-completion.test.ts
@@ -4,6 +4,7 @@ import {
   buildSlashCommands,
   getSlashMatches,
   MAX_VISIBLE_COMPLETIONS,
+  shouldSubmitOnEnter,
 } from "../../src/tui/slashCompletion.ts";
 
 const commands: SlashCommand[] = [
@@ -95,5 +96,45 @@ describe("buildSlashCommands", () => {
     ];
     const result = buildSlashCommands(builtins, []);
     expect(result.map((c) => c.name)).toEqual(["quit", "exit"]);
+  });
+
+  test("propagates takesArgs from skills and leaves builtins unset", () => {
+    const builtins: SlashCommand[] = [{ name: "help", description: "Help" }];
+    const skills = [
+      { name: "review", description: "Review", takesArgs: true },
+      { name: "status", description: "Status", takesArgs: false },
+      { name: "ping", description: "Ping" },
+    ];
+    const result = buildSlashCommands(builtins, skills);
+    expect(result[0]?.takesArgs).toBeUndefined();
+    expect(result[1]?.takesArgs).toBe(true);
+    expect(result[2]?.takesArgs).toBe(false);
+    expect(result[3]?.takesArgs).toBeUndefined();
+  });
+});
+
+describe("shouldSubmitOnEnter", () => {
+  test("returns true for commands without takesArgs (builtins)", () => {
+    expect(shouldSubmitOnEnter({ name: "clear", description: "" })).toBe(true);
+  });
+
+  test("returns false when takesArgs is true", () => {
+    expect(
+      shouldSubmitOnEnter({
+        name: "review",
+        description: "",
+        takesArgs: true,
+      }),
+    ).toBe(false);
+  });
+
+  test("returns true when takesArgs is explicitly false", () => {
+    expect(
+      shouldSubmitOnEnter({
+        name: "status",
+        description: "",
+        takesArgs: false,
+      }),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
Adds a `/clear` slash command that allows users to end the current chat thread and start a fresh one within the same session, while preserving the old thread for later resumption.

## Key Changes
- **New `clearChatSession()` function** in `src/chat/session.ts` that ends the current thread and creates a new one, returning both thread IDs
- **`/clear` slash command** added to built-in commands with full TUI integration:
  - Clears the message queue to prevent leakage into the new thread
  - Displays a system message with the previous thread ID for easy resumption
  - Handles errors gracefully with user-facing error messages
- **Updated slash command infrastructure** to support optional `clearChat` callback in `SlashCommandContext`
- **Comprehensive test coverage** for the new functionality in both session and commands tests
- **Documentation updates** in `tui.md` and `skills.md` explaining the `/clear` command behavior
- **Version bump** to 0.8.6

## Implementation Details
- The old thread is marked as ended in the database but remains accessible via `botholomew chat --thread-id <id>`
- The new thread starts with an empty message list, providing a clean slate for context
- The command is only fully functional in the TUI; attempting it elsewhere shows a helpful message
- Queued messages are drained before clearing to prevent them from being sent to the new thread

https://claude.ai/code/session_01FCnD9pMwuYd9zPqr4Vijeg