### PR TITLE
Fix capabilities command hanging ~30s after success

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/commands/capabilities.ts
+++ b/src/commands/capabilities.ts
@@ -36,10 +36,11 @@ export function registerCapabilitiesCommand(program: Command) {
           });
         } catch (err) {
           spinner.error({ text: `Failed: ${(err as Error).message}` });
-          process.exit(1);
-        } finally {
           await mcpxClient?.close();
+          process.exit(1);
         }
+        await mcpxClient?.close();
+        process.exit(0);
       }),
     );
 }

--- a/src/context/capabilities.ts
+++ b/src/context/capabilities.ts
@@ -268,22 +268,17 @@ async function summarizeViaLLM(
   const userPrompt = `Summarize this tool inventory. Return via the \`${SUMMARIZE_TOOL_NAME}\` tool.\n\n${renderInventoryForPrompt(inv)}`;
 
   try {
-    const response = await Promise.race([
-      client.messages.create({
+    const response = await client.messages.create(
+      {
         model: config.chunker_model,
         max_tokens: SUMMARIZE_MAX_TOKENS,
         system: SUMMARIZE_SYSTEM,
         tools: [SUMMARIZE_TOOL],
         tool_choice: { type: "tool", name: SUMMARIZE_TOOL_NAME },
         messages: [{ role: "user", content: userPrompt }],
-      }),
-      new Promise<never>((_, reject) =>
-        setTimeout(
-          () => reject(new Error("Capability summarization timeout")),
-          SUMMARIZE_TIMEOUT_MS,
-        ),
-      ),
-    ]);
+      },
+      { timeout: SUMMARIZE_TIMEOUT_MS },
+    );
 
     const toolBlock = response.content.find((b) => b.type === "tool_use");
     if (!toolBlock || toolBlock.type !== "tool_use") return null;


### PR DESCRIPTION
## Summary
- The setTimeout inside summarizeViaLLM's Promise.race was never cleared when the API call won, keeping the Node event loop alive for ~30s after the work completed. Replaced with the Anthropic SDK's per-request `timeout` option.
- Added an explicit `process.exit(0)` in the capabilities CLI action to match the convention used by other Anthropic-SDK commands (e.g., `context add`).
- Bumped version to 0.8.9.

## Test plan
- [x] `bun run lint`
- [x] `bun test test/context/capabilities.test.ts test/tools/capabilities-refresh.test.ts` (12/12 pass)
- [ ] Manual: `time bun run dev capabilities` returns promptly instead of hanging ~30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)