### PR TITLE
Require mcp_info before mcp_exec in agent prompts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/chat/agent.ts
+++ b/src/chat/agent.ts
@@ -65,18 +65,16 @@ export async function buildChatSystemPrompt(
     keywordSource?: string;
     dbPath?: string;
     config?: Required<BotholomewConfig>;
+    hasMcpTools?: boolean;
   },
 ): Promise<string> {
-  const parts: string[] = [];
-
-  parts.push(...buildMetaHeader(projectDir));
+  let prompt = buildMetaHeader(projectDir);
 
   const keywordSource = options?.keywordSource?.trim();
   const taskKeywords = keywordSource ? extractKeywords(keywordSource) : null;
 
-  parts.push(...(await loadPersistentContext(projectDir, taskKeywords)));
+  prompt += await loadPersistentContext(projectDir, taskKeywords);
 
-  // Relevant context from embeddings search
   const dbPath = options?.dbPath;
   const config = options?.config;
   if (dbPath && config?.openai_api_key && keywordSource) {
@@ -87,14 +85,14 @@ export async function buildChatSystemPrompt(
       );
 
       if (results.length > 0) {
-        parts.push("## Relevant Context");
+        prompt += "## Relevant Context\n";
         for (const r of results) {
           const path = r.source_path || r.context_item_id;
-          parts.push(`### ${r.title} (${path})`);
+          prompt += `### ${r.title} (${path})\n`;
           if (r.chunk_content) {
-            parts.push(r.chunk_content.slice(0, 1000));
+            prompt += `${r.chunk_content.slice(0, 1000)}\n`;
           }
-          parts.push("");
+          prompt += "\n";
         }
       }
     } catch (err) {
@@ -102,28 +100,30 @@ export async function buildChatSystemPrompt(
     }
   }
 
-  parts.push("## Instructions");
-  parts.push(
-    "You are Botholomew, an AI agent personified by a wise owl. This is your interactive chat interface. Help the user manage tasks, review results from background worker activity, search context, and answer questions.",
-  );
-  parts.push(
-    "You do NOT execute long-running work directly — enqueue tasks for a background worker instead using create_task, and spawn a worker via spawn_worker when the user wants the task run now.",
-  );
-  parts.push(
-    "Use the available tools to look up tasks, threads, schedules, and context when the user asks about them. Context items can be looked up by virtual path or by UUID via `context_info` and refreshed via `context_refresh`.",
-  );
-  parts.push(
-    "When multiple tool calls are independent of each other (i.e., one does not depend on the result of another), call them all in a single response. They will be executed in parallel, which is faster than calling them one at a time.",
-  );
-  parts.push(
-    "You can update the agent's beliefs and goals files when the user asks you to.",
-  );
-  parts.push(
-    "Format your responses using Markdown. Use headings, bold, italic, lists, and code blocks to make your responses clear and well-structured.",
-  );
-  parts.push("");
+  prompt += `## Instructions
+You are Botholomew, an AI agent personified by a wise owl. This is your interactive chat interface. Help the user manage tasks, review results from background worker activity, search context, and answer questions.
+You do NOT execute long-running work directly — enqueue tasks for a background worker instead using create_task, and spawn a worker via spawn_worker when the user wants the task run now.
+Use the available tools to look up tasks, threads, schedules, and context when the user asks about them. Context items can be looked up by virtual path or by UUID via \`context_info\` and refreshed via \`context_refresh\`.
+When multiple tool calls are independent of each other (i.e., one does not depend on the result of another), call them all in a single response. They will be executed in parallel, which is faster than calling them one at a time.
+You can update the agent's beliefs and goals files when the user asks you to.
+Format your responses using Markdown. Use headings, bold, italic, lists, and code blocks to make your responses clear and well-structured.
+`;
 
-  return parts.join("\n");
+  if (options?.hasMcpTools) {
+    prompt += `
+## External Tools (MCP)
+
+You have access to external tools via MCP servers. Before calling any MCP tool you haven't used yet this session, you MUST fetch its schema first:
+
+1. Discover tools with \`mcp_search\` (preferred — semantic) or \`mcp_list_tools\`.
+2. Call \`mcp_info\` with the exact \`server\` and \`tool\` to read the tool's input schema, required fields, and types.
+3. Only then call \`mcp_exec\` with arguments that conform to that schema.
+
+Skip step 2 only if you already called \`mcp_info\` for that exact server+tool earlier in this conversation. Do not guess arguments from the tool's description alone — descriptions omit types and required/optional markers.
+`;
+  }
+
+  return prompt;
 }
 
 export interface ToolEndMeta {
@@ -202,6 +202,7 @@ export async function runChatTurn(input: {
       keywordSource,
       dbPath,
       config,
+      hasMcpTools: mcpxClient != null,
     });
 
     fitToContextWindow(messages, systemPrompt, maxInputTokens);

--- a/src/worker/prompt.ts
+++ b/src/worker/prompt.ts
@@ -29,16 +29,16 @@ export function extractKeywords(text: string): Set<string> {
 }
 
 /**
- * Load persistent context files from .botholomew/ directory.
- * Returns an array of formatted string sections for "always" loaded files.
- * If taskKeywords are provided, also includes "contextual" files that match.
+ * Load persistent context files from .botholomew/ directory as a single
+ * formatted string. Includes "always" files unconditionally and "contextual"
+ * files whose content overlaps the provided taskKeywords.
  */
 export async function loadPersistentContext(
   projectDir: string,
   taskKeywords?: Set<string> | null,
-): Promise<string[]> {
+): Promise<string> {
   const dotDir = getBotholomewDir(projectDir);
-  const parts: string[] = [];
+  let out = "";
 
   try {
     const files = await readdir(dotDir);
@@ -50,18 +50,14 @@ export async function loadPersistentContext(
       const { meta, content } = parseContextFile(raw);
 
       if (meta.loading === "always") {
-        parts.push(`## ${filename}`);
-        parts.push(content);
-        parts.push("");
+        out += `## ${filename}\n${content}\n\n`;
       } else if (meta.loading === "contextual" && taskKeywords) {
         const contentLower = content.toLowerCase();
         const hasOverlap = [...taskKeywords].some((kw) =>
           contentLower.includes(kw),
         );
         if (hasOverlap) {
-          parts.push(`## ${filename} (contextual)`);
-          parts.push(content);
-          parts.push("");
+          out += `## ${filename} (contextual)\n${content}\n\n`;
         }
       }
     }
@@ -69,21 +65,20 @@ export async function loadPersistentContext(
     // .botholomew dir might not have md files yet
   }
 
-  return parts;
+  return out;
 }
 
 /**
  * Build common meta header (version, time, OS, user).
  */
-export function buildMetaHeader(projectDir: string): string[] {
-  return [
-    `# Botholomew v${pkg.version}`,
-    `Current time: ${new Date().toISOString()}`,
-    `Project directory: ${projectDir}`,
-    `OS: ${process.platform} ${process.arch}`,
-    `User: ${process.env.USER || process.env.USERNAME || "unknown"}`,
-    "",
-  ];
+export function buildMetaHeader(projectDir: string): string {
+  return `# Botholomew v${pkg.version}
+Current time: ${new Date().toISOString()}
+Project directory: ${projectDir}
+OS: ${process.platform} ${process.arch}
+User: ${process.env.USER || process.env.USERNAME || "unknown"}
+
+`;
 }
 
 export async function buildSystemPrompt(
@@ -93,20 +88,14 @@ export async function buildSystemPrompt(
   _config?: Required<BotholomewConfig>,
   options?: { hasMcpTools?: boolean },
 ): Promise<string> {
-  const parts: string[] = [];
+  let prompt = buildMetaHeader(projectDir);
 
-  // Meta information
-  parts.push(...buildMetaHeader(projectDir));
-
-  // Build keyword set from task for contextual loading
   const taskKeywords = task
     ? extractKeywords(`${task.name} ${task.description}`)
     : null;
 
-  // Load context files from .botholomew/
-  parts.push(...(await loadPersistentContext(projectDir, taskKeywords)));
+  prompt += await loadPersistentContext(projectDir, taskKeywords);
 
-  // Relevant context from embeddings search
   if (task && dbPath && _config?.openai_api_key) {
     try {
       const query = `${task.name} ${task.description}`;
@@ -116,14 +105,14 @@ export async function buildSystemPrompt(
       );
 
       if (results.length > 0) {
-        parts.push("## Relevant Context");
+        prompt += "## Relevant Context\n";
         for (const r of results) {
           const path = r.source_path || r.context_item_id;
-          parts.push(`### ${r.title} (${path})`);
+          prompt += `### ${r.title} (${path})\n`;
           if (r.chunk_content) {
-            parts.push(r.chunk_content.slice(0, 1000));
+            prompt += `${r.chunk_content.slice(0, 1000)}\n`;
           }
-          parts.push("");
+          prompt += "\n";
         }
       }
     } catch (err) {
@@ -131,19 +120,25 @@ export async function buildSystemPrompt(
     }
   }
 
-  // Instructions
-  parts.push("## Instructions");
-  parts.push(
-    "You are Botholomew, a wise-owl worker that works through tasks. Use available tools to complete your assigned task, then call complete_task, fail_task, or wait_task. Use create_task for subtasks and update_task to refine pending tasks. Batch independent tool calls in a single response for parallel execution.\n\nWhen calling complete_task, write a summary that captures your key findings, decisions, and outputs. This summary becomes the task's output and is provided to any downstream tasks that depend on this one. Include specific results (data, names, paths, conclusions) rather than vague descriptions of what you did — downstream tasks will rely on this information to do their work.",
-  );
-  if (options?.hasMcpTools) {
-    parts.push("");
-    parts.push("## External Tools (MCP)");
-    parts.push(
-      "You have access to external tools via MCP servers. Use `mcp_list_tools` or `mcp_search` to discover available tools, `mcp_info` to get a tool's input schema, then `mcp_exec` to call them.",
-    );
-  }
-  parts.push("");
+  prompt += `## Instructions
+You are Botholomew, a wise-owl worker that works through tasks. Use available tools to complete your assigned task, then call complete_task, fail_task, or wait_task. Use create_task for subtasks and update_task to refine pending tasks. Batch independent tool calls in a single response for parallel execution.
 
-  return parts.join("\n");
+When calling complete_task, write a summary that captures your key findings, decisions, and outputs. This summary becomes the task's output and is provided to any downstream tasks that depend on this one. Include specific results (data, names, paths, conclusions) rather than vague descriptions of what you did — downstream tasks will rely on this information to do their work.
+`;
+
+  if (options?.hasMcpTools) {
+    prompt += `
+## External Tools (MCP)
+
+You have access to external tools via MCP servers. Before calling any MCP tool you haven't used yet this session, you MUST fetch its schema first:
+
+1. Discover tools with \`mcp_search\` (preferred — semantic) or \`mcp_list_tools\`.
+2. Call \`mcp_info\` with the exact \`server\` and \`tool\` to read the tool's input schema, required fields, and types.
+3. Only then call \`mcp_exec\` with arguments that conform to that schema.
+
+Skip step 2 only if you already called \`mcp_info\` for that exact server+tool earlier in this conversation. Do not guess arguments from the tool's description alone — descriptions omit types and required/optional markers.
+`;
+  }
+
+  return prompt;
 }

--- a/test/chat/agent.test.ts
+++ b/test/chat/agent.test.ts
@@ -138,6 +138,28 @@ describe("buildChatSystemPrompt", () => {
     expect(prompt).not.toContain("Our invoicing system uses Stripe");
   });
 
+  test("includes MCP section with mcp_info requirement when hasMcpTools is true", async () => {
+    const prompt = await buildChatSystemPrompt(projectDir, {
+      hasMcpTools: true,
+    });
+    expect(prompt).toContain("## External Tools (MCP)");
+    expect(prompt).toContain("MUST fetch its schema first");
+    expect(prompt).toContain("`mcp_info`");
+    expect(prompt).toContain("`mcp_exec`");
+    expect(prompt).toContain("`mcp_search`");
+    expect(prompt).toContain("`mcp_list_tools`");
+  });
+
+  test("omits MCP section when hasMcpTools is false or absent", async () => {
+    const promptNoOpts = await buildChatSystemPrompt(projectDir);
+    expect(promptNoOpts).not.toContain("## External Tools (MCP)");
+
+    const promptFalse = await buildChatSystemPrompt(projectDir, {
+      hasMcpTools: false,
+    });
+    expect(promptFalse).not.toContain("## External Tools (MCP)");
+  });
+
   test("always-loaded files appear even when keywordSource matches nothing", async () => {
     const always = serializeContextFile(
       { loading: "always", "agent-modification": true },

--- a/test/worker/prompt.test.ts
+++ b/test/worker/prompt.test.ts
@@ -183,6 +183,40 @@ describe("buildSystemPrompt", () => {
     expect(prompt).toContain("## Instructions");
   });
 
+  test("includes MCP section with mcp_info requirement when hasMcpTools is true", async () => {
+    const prompt = await buildSystemPrompt(
+      projectDir,
+      undefined,
+      undefined,
+      undefined,
+      {
+        hasMcpTools: true,
+      },
+    );
+    expect(prompt).toContain("## External Tools (MCP)");
+    expect(prompt).toContain("MUST fetch its schema first");
+    expect(prompt).toContain("`mcp_info`");
+    expect(prompt).toContain("`mcp_exec`");
+    expect(prompt).toContain("`mcp_search`");
+    expect(prompt).toContain("`mcp_list_tools`");
+  });
+
+  test("omits MCP section when hasMcpTools is false or absent", async () => {
+    const promptNoOpts = await buildSystemPrompt(projectDir);
+    expect(promptNoOpts).not.toContain("## External Tools (MCP)");
+
+    const promptFalse = await buildSystemPrompt(
+      projectDir,
+      undefined,
+      undefined,
+      undefined,
+      {
+        hasMcpTools: false,
+      },
+    );
+    expect(promptFalse).not.toContain("## External Tools (MCP)");
+  });
+
   test("keyword extraction filters short words", async () => {
     const contextual = serializeContextFile(
       { loading: "contextual", "agent-modification": false },


### PR DESCRIPTION
## Summary

- Rewrites the External Tools (MCP) section in `buildSystemPrompt` (worker) and adds the same section to `buildChatSystemPrompt` (chat) so the agent MUST call `mcp_info` for a tool's schema before calling `mcp_exec` — previously a soft suggestion in the worker prompt and entirely absent from chat.
- Wires `hasMcpTools: mcpxClient != null` through `runChatTurn` into the chat prompt builder, matching the worker's gating pattern.
- Refactors both prompt builders plus `buildMetaHeader` / `loadPersistentContext` to concatenate directly to a string instead of pushing into a `parts: string[]` array.
- Adds tests asserting the MCP section is present with `hasMcpTools: true` and omitted otherwise, for both prompts. Bumps version to 0.8.10.

## Test plan

- [x] `bun run lint` passes
- [x] `bun test` passes (695/695)