### PR TITLE
Mark milestone 9 (Worker Agents) as Done

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -10,7 +10,7 @@
 | 6 | [Daemon Watchdog & Distribution](milestone-6-daemon-watchdog-and-distribution.md) | **Superseded (→M9)** | OS-level watchdog replaced; agent self-modification retained |
 | 7 | [Skills (Slash-Commands)](milestone-7-skills.md) | **Done** | User-defined slash-commands loaded from `.botholomew/skills/` markdown files |
 | 8 | [Remote Context](milestone-8-remote-context.md) | **Done** | Ingest context from URLs via LLM-driven MCPX tool selection |
-| 9 | [Worker Agents](milestone-9-worker-agents.md) | **In Progress** | Replace OS watchdog with in-DB worker registration + heartbeats; multi-worker support; chat-dispatched one-shot workers |
+| 9 | [Worker Agents](milestone-9-worker-agents.md) | **Done** | Replace OS watchdog with in-DB worker registration + heartbeats; multi-worker support; chat-dispatched one-shot workers |
 
 ## Stub/TODO Coverage
 

--- a/docs/plans/milestone-9-worker-agents.md
+++ b/docs/plans/milestone-9-worker-agents.md
@@ -194,4 +194,4 @@ migration touched tables from migration 2 so it never mattered.
      `~/.config/systemd/user/botholomew-*.*` files are written.
 4. `package.json` version bumped.
 
-## Status: **In Progress**
+## Status: **Done**


### PR DESCRIPTION
## Summary
- Flip milestone 9 status from **In Progress** to **Done** in both `docs/plans/README.md` and `docs/plans/milestone-9-worker-agents.md`. All M9 files, CLI subcommands, config keys, and tests are present; lint is clean and 691 tests pass.

## Test plan
- [x] `bun run lint`
- [x] `bun test`