### PR TITLE
Return structured not_found errors from context_info / context_read

### DIFF
--- a/docs/virtual-filesystem.md
+++ b/docs/virtual-filesystem.md
@@ -77,6 +77,45 @@ botholomew context tree /
 
 ---
 
+## Structured errors from `context_read` / `context_info`
+
+When the agent passes a path that doesn't resolve, these tools return a
+structured `is_error: true` response (they do **not** throw) so the model
+can recover inside the same tool loop:
+
+```json
+{
+  "is_error": true,
+  "error_type": "not_found",
+  "message": "No context item at /projects/foo/README.md",
+  "next_action_hint": "Nearby paths under /projects/foo: /projects/foo/docs/a.md, /projects/foo/notes.md. Call context_tree({path:\"/projects/foo\"}) to see more."
+}
+```
+
+On success, `context_info` returns the metadata under a `file` key:
+
+```json
+{
+  "is_error": false,
+  "file": {
+    "id": "...", "title": "...", "context_path": "/projects/foo/notes.md",
+    "mime_type": "text/markdown", "is_textual": true,
+    "size": 1234, "lines": 42, ...
+  }
+}
+```
+
+The hint is built from `findNearbyContextPaths` — up to five immediate
+siblings of the requested path's parent directory, walking up until it
+finds a populated ancestor. `context_read` also returns
+`error_type: "no_text_content"` when the target exists but is binary
+(e.g. an image row).
+
+CLI callers of the underlying resolver still throw — this shape is only
+used by the agent-facing tools.
+
+---
+
 ## Patch format for `context_edit`
 
 ```ts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/db/context.ts
+++ b/src/db/context.ts
@@ -228,6 +228,53 @@ export async function resolveContextItemOrThrow(
   return item;
 }
 
+export interface NearbyContextPaths {
+  /** Directory we found neighbours under (may be an ancestor if the direct parent was empty). */
+  parent: string;
+  /** Exact `context_path` values of the parent's immediate children. */
+  siblings: string[];
+  /** True if we walked up from the requested path's direct parent to find a populated ancestor. */
+  walkedUp: boolean;
+}
+
+/**
+ * Find context items near a requested path to power "did you mean?" suggestions
+ * when a lookup misses. Returns up to `limit` exact `context_path` values of the
+ * requested path's parent-dir neighbours; if the parent has no rows, walks up
+ * until it finds a populated ancestor (or hits root).
+ */
+export async function findNearbyContextPaths(
+  db: DbConnection,
+  requestedPath: string,
+  limit = 5,
+): Promise<NearbyContextPaths> {
+  let parent = parentDir(requestedPath);
+  let walkedUp = false;
+  while (true) {
+    const items = await listContextItemsByPrefix(db, parent, {
+      recursive: false,
+      limit,
+    });
+    if (items.length > 0 || parent === "/") {
+      return {
+        parent,
+        siblings: items.map((i) => i.context_path),
+        walkedUp,
+      };
+    }
+    parent = parentDir(parent);
+    walkedUp = true;
+  }
+}
+
+function parentDir(p: string): string {
+  if (!p || p === "/") return "/";
+  const trimmed = p.endsWith("/") && p.length > 1 ? p.slice(0, -1) : p;
+  const idx = trimmed.lastIndexOf("/");
+  if (idx <= 0) return "/";
+  return trimmed.slice(0, idx);
+}
+
 export async function listContextItems(
   db: DbConnection,
   filters?: {

--- a/src/tools/file/info.ts
+++ b/src/tools/file/info.ts
@@ -1,12 +1,15 @@
 import { z } from "zod";
-import { resolveContextItemOrThrow } from "../../db/context.ts";
+import {
+  findNearbyContextPaths,
+  resolveContextItem,
+} from "../../db/context.ts";
 import type { ToolDefinition } from "../tool.ts";
 
 const inputSchema = z.object({
   path: z.string().describe("File path or context item ID"),
 });
 
-const outputSchema = z.object({
+const fileSchema = z.object({
   id: z.string(),
   title: z.string(),
   description: z.string(),
@@ -19,7 +22,14 @@ const outputSchema = z.object({
   indexed_at: z.string().nullable(),
   created_at: z.string(),
   updated_at: z.string(),
+});
+
+const outputSchema = z.object({
+  file: fileSchema.optional(),
   is_error: z.boolean(),
+  error_type: z.string().optional(),
+  message: z.string().optional(),
+  next_action_hint: z.string().optional(),
 });
 
 export const contextInfoTool = {
@@ -30,22 +40,40 @@ export const contextInfoTool = {
   inputSchema,
   outputSchema,
   execute: async (input, ctx) => {
-    const item = await resolveContextItemOrThrow(ctx.conn, input.path);
+    const item = await resolveContextItem(ctx.conn, input.path);
+    if (!item) {
+      const { parent, siblings, walkedUp } = await findNearbyContextPaths(
+        ctx.conn,
+        input.path,
+      );
+      const hint =
+        siblings.length > 0
+          ? `${walkedUp ? `Parent ${parent} has no direct entries; ` : ""}Nearby paths under ${parent}: ${siblings.join(", ")}. Call context_tree({path:"${parent}"}) to see more.`
+          : `No items found under ${parent}. Call context_tree({path:"/"}) to discover what exists.`;
+      return {
+        is_error: true,
+        error_type: "not_found",
+        message: `No context item at ${input.path}`,
+        next_action_hint: hint,
+      };
+    }
 
     const content = item.content ?? "";
     return {
-      id: item.id,
-      title: item.title,
-      description: item.description,
-      mime_type: item.mime_type,
-      is_textual: item.is_textual,
-      size: content.length,
-      lines: content ? content.split("\n").length : 0,
-      source_path: item.source_path,
-      context_path: item.context_path,
-      indexed_at: item.indexed_at?.toISOString() ?? null,
-      created_at: item.created_at.toISOString(),
-      updated_at: item.updated_at.toISOString(),
+      file: {
+        id: item.id,
+        title: item.title,
+        description: item.description,
+        mime_type: item.mime_type,
+        is_textual: item.is_textual,
+        size: content.length,
+        lines: content ? content.split("\n").length : 0,
+        source_path: item.source_path,
+        context_path: item.context_path,
+        indexed_at: item.indexed_at?.toISOString() ?? null,
+        created_at: item.created_at.toISOString(),
+        updated_at: item.updated_at.toISOString(),
+      },
       is_error: false,
     };
   },

--- a/src/tools/file/read.ts
+++ b/src/tools/file/read.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
-import { resolveContextItemOrThrow } from "../../db/context.ts";
+import {
+  findNearbyContextPaths,
+  resolveContextItem,
+} from "../../db/context.ts";
 import type { ToolDefinition } from "../tool.ts";
 
 const inputSchema = z.object({
@@ -12,8 +15,11 @@ const inputSchema = z.object({
 });
 
 const outputSchema = z.object({
-  content: z.string(),
+  content: z.string().optional(),
   is_error: z.boolean(),
+  error_type: z.string().optional(),
+  message: z.string().optional(),
+  next_action_hint: z.string().optional(),
 });
 
 export const contextReadTool = {
@@ -24,8 +30,33 @@ export const contextReadTool = {
   inputSchema,
   outputSchema,
   execute: async (input, ctx) => {
-    const item = await resolveContextItemOrThrow(ctx.conn, input.path);
-    if (item.content == null) throw new Error(`No text content: ${input.path}`);
+    const item = await resolveContextItem(ctx.conn, input.path);
+    if (!item) {
+      const { parent, siblings, walkedUp } = await findNearbyContextPaths(
+        ctx.conn,
+        input.path,
+      );
+      const hint =
+        siblings.length > 0
+          ? `${walkedUp ? `Parent ${parent} has no direct entries; ` : ""}Nearby paths under ${parent}: ${siblings.join(", ")}. Call context_tree({path:"${parent}"}) to see more.`
+          : `No items found under ${parent}. Call context_tree({path:"/"}) to discover what exists.`;
+      return {
+        is_error: true,
+        error_type: "not_found",
+        message: `No context item at ${input.path}`,
+        next_action_hint: hint,
+      };
+    }
+
+    if (item.content == null) {
+      return {
+        is_error: true,
+        error_type: "no_text_content",
+        message: `Context item ${item.context_path} has no text content (mime: ${item.mime_type})`,
+        next_action_hint:
+          "Binary items can't be read as text. Call context_info to inspect metadata, or pick a textual sibling.",
+      };
+    }
 
     let content = item.content;
 

--- a/test/tools/file.test.ts
+++ b/test/tools/file.test.ts
@@ -78,8 +78,8 @@ describe("context_write", () => {
       ctx,
     );
     const info = await contextInfoTool.execute({ path: "/doc.md" }, ctx);
-    expect(info.title).toBe("My Doc");
-    expect(info.description).toBe("A document");
+    expect(info.file?.title).toBe("My Doc");
+    expect(info.file?.description).toBe("A document");
   });
 
   test("writes base64 content", async () => {
@@ -129,17 +129,35 @@ describe("context_read", () => {
     expect(result.content).toBe("found by id");
   });
 
-  test("throws for nonexistent file", async () => {
-    expect(contextReadTool.execute({ path: "/nope.txt" }, ctx)).rejects.toThrow(
-      "Not found",
+  test("returns not_found error with sibling hints", async () => {
+    await seedFile(conn, "/dir/real.txt", "hi");
+    const result = await contextReadTool.execute(
+      { path: "/dir/missing.txt" },
+      ctx,
     );
+    expect(result.is_error).toBe(true);
+    expect(result.error_type).toBe("not_found");
+    expect(result.content).toBeUndefined();
+    expect(result.next_action_hint).toContain("/dir/real.txt");
   });
 
-  test("throws for file with no text content", async () => {
+  test("walks up when requested parent is empty", async () => {
+    await seedFile(conn, "/root.txt", "root");
+    const result = await contextReadTool.execute(
+      { path: "/nonexistent/deep/missing.txt" },
+      ctx,
+    );
+    expect(result.is_error).toBe(true);
+    expect(result.error_type).toBe("not_found");
+    expect(result.next_action_hint).toContain("/root.txt");
+  });
+
+  test("returns no_text_content error for binary files", async () => {
     await seedBinaryFile(conn, "/image.png");
-    expect(
-      contextReadTool.execute({ path: "/image.png" }, ctx),
-    ).rejects.toThrow("No text content");
+    const result = await contextReadTool.execute({ path: "/image.png" }, ctx);
+    expect(result.is_error).toBe(true);
+    expect(result.error_type).toBe("no_text_content");
+    expect(result.content).toBeUndefined();
   });
 });
 
@@ -336,15 +354,16 @@ describe("context_info", () => {
       description: "A test file",
     });
     const info = await contextInfoTool.execute({ path: "/meta.txt" }, ctx);
-    expect(info.title).toBe("Meta");
-    expect(info.description).toBe("A test file");
-    expect(info.mime_type).toBe("text/plain");
-    expect(info.is_textual).toBe(true);
-    expect(info.lines).toBe(2);
-    expect(info.size).toBe(11);
-    expect(info.context_path).toBe("/meta.txt");
-    expect(info.created_at).toBeTruthy();
-    expect(info.updated_at).toBeTruthy();
+    expect(info.is_error).toBe(false);
+    expect(info.file?.title).toBe("Meta");
+    expect(info.file?.description).toBe("A test file");
+    expect(info.file?.mime_type).toBe("text/plain");
+    expect(info.file?.is_textual).toBe(true);
+    expect(info.file?.lines).toBe(2);
+    expect(info.file?.size).toBe(11);
+    expect(info.file?.context_path).toBe("/meta.txt");
+    expect(info.file?.created_at).toBeTruthy();
+    expect(info.file?.updated_at).toBeTruthy();
   });
 
   test("returns metadata by ID", async () => {
@@ -352,14 +371,41 @@ describe("context_info", () => {
       title: "MetaID",
     });
     const info = await contextInfoTool.execute({ path: item.id }, ctx);
-    expect(info.title).toBe("MetaID");
-    expect(info.context_path).toBe("/meta-id.txt");
+    expect(info.file?.title).toBe("MetaID");
+    expect(info.file?.context_path).toBe("/meta-id.txt");
   });
 
-  test("throws for nonexistent file", async () => {
-    expect(contextInfoTool.execute({ path: "/nope.txt" }, ctx)).rejects.toThrow(
-      "Not found",
+  test("returns not_found error with sibling hints", async () => {
+    await seedFile(conn, "/docs/readme.md", "hi");
+    await seedFile(conn, "/docs/guide.md", "g");
+    const result = await contextInfoTool.execute(
+      { path: "/docs/architecture.md" },
+      ctx,
     );
+    expect(result.is_error).toBe(true);
+    expect(result.error_type).toBe("not_found");
+    expect(result.file).toBeUndefined();
+    expect(result.message).toContain("/docs/architecture.md");
+    expect(result.next_action_hint).toContain("/docs/readme.md");
+    expect(result.next_action_hint).toContain("/docs/guide.md");
+  });
+
+  test("not_found at empty root returns discovery hint", async () => {
+    const result = await contextInfoTool.execute({ path: "/nope.txt" }, ctx);
+    expect(result.is_error).toBe(true);
+    expect(result.error_type).toBe("not_found");
+    expect(result.next_action_hint).toContain("context_tree");
+  });
+
+  test("not_found walks up past empty parents", async () => {
+    await seedFile(conn, "/a.txt", "a");
+    const result = await contextInfoTool.execute(
+      { path: "/missing/deeper/file.md" },
+      ctx,
+    );
+    expect(result.is_error).toBe(true);
+    expect(result.error_type).toBe("not_found");
+    expect(result.next_action_hint).toContain("/a.txt");
   });
 });
 
@@ -504,8 +550,8 @@ describe("context edge cases", () => {
     const content = "Hello";
     await seedFile(conn, "/sized.txt", content);
     const info = await contextInfoTool.execute({ path: "/sized.txt" }, ctx);
-    expect(info.size).toBe(5);
-    expect(info.lines).toBe(1);
+    expect(info.file?.size).toBe(5);
+    expect(info.file?.lines).toBe(1);
   });
 
   test("read with offset beyond file length returns empty", async () => {


### PR DESCRIPTION
## Summary

- A chat session showed the agent giving up after `context_info` threw a bare `Not found: X` for a guessed path; the resolver was working correctly but gave the model nothing to recover with.
- `context_info` and `context_read` now return `is_error: true` with `error_type: "not_found"` (plus `"no_text_content"` for binary reads) and a `next_action_hint` listing up to five real sibling paths from the requested path's parent directory, walking up until a populated ancestor is found.
- New `findNearbyContextPaths` helper in `src/db/context.ts`; `context_info` happy path now wraps metadata in a `file` sub-object so the schema stays tight; `resolveContextItemOrThrow` and CLI callers are unchanged.

## Test plan

- [x] `bun run lint` clean
- [x] `bun test` — 694/694 pass, including new cases for sibling hints, walk-up, and `no_text_content`

🤖 Generated with [Claude Code](https://claude.com/claude-code)