### PR TITLE
Prefer local context over MCP for retrieval in agent prompts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/chat/agent.ts
+++ b/src/chat/agent.ts
@@ -115,6 +115,8 @@ Format your responses using Markdown. Use headings, bold, italic, lists, and cod
     prompt += `
 ## External Tools (MCP)
 
+Before reaching for MCP tools to **find** information, check local context first — content from Drive, Gmail, GitHub, URLs, and prior agent runs is often already ingested. Use \`search_semantic\` (semantic) or \`context_search\` (keyword) across drives, then \`context_read\` / \`context_tree\` to drill in. Only fall through to \`mcp_exec\` when the data is fresh, write-side (sending an email, creating an issue), or genuinely missing locally.
+
 You have access to external tools via MCP servers. Before calling any MCP tool you haven't used yet this session, you MUST fetch its schema first:
 
 1. Discover tools with \`mcp_search\` (preferred — semantic) or \`mcp_list_tools\`.

--- a/src/worker/prompt.ts
+++ b/src/worker/prompt.ts
@@ -131,6 +131,8 @@ When calling complete_task, write a summary that captures your key findings, dec
     prompt += `
 ## External Tools (MCP)
 
+Before reaching for MCP tools to **find** information, check local context first — content from Drive, Gmail, GitHub, URLs, and prior agent runs is often already ingested. Use \`search_semantic\` (semantic) or \`context_search\` (keyword) across drives, then \`context_read\` / \`context_tree\` to drill in. Only fall through to \`mcp_exec\` when the data is fresh, write-side (sending an email, creating an issue), or genuinely missing locally.
+
 You have access to external tools via MCP servers. Before calling any MCP tool you haven't used yet this session, you MUST fetch its schema first:
 
 1. Discover tools with \`mcp_search\` (preferred — semantic) or \`mcp_list_tools\`.

--- a/test/chat/agent.test.ts
+++ b/test/chat/agent.test.ts
@@ -148,6 +148,9 @@ describe("buildChatSystemPrompt", () => {
     expect(prompt).toContain("`mcp_exec`");
     expect(prompt).toContain("`mcp_search`");
     expect(prompt).toContain("`mcp_list_tools`");
+    expect(prompt).toContain("check local context first");
+    expect(prompt).toContain("`search_semantic`");
+    expect(prompt).toContain("`context_search`");
   });
 
   test("omits MCP section when hasMcpTools is false or absent", async () => {

--- a/test/worker/prompt.test.ts
+++ b/test/worker/prompt.test.ts
@@ -199,6 +199,9 @@ describe("buildSystemPrompt", () => {
     expect(prompt).toContain("`mcp_exec`");
     expect(prompt).toContain("`mcp_search`");
     expect(prompt).toContain("`mcp_list_tools`");
+    expect(prompt).toContain("check local context first");
+    expect(prompt).toContain("`search_semantic`");
+    expect(prompt).toContain("`context_search`");
   });
 
   test("omits MCP section when hasMcpTools is false or absent", async () => {


### PR DESCRIPTION
## Summary

- Adds a "check context first" precondition to the `## External Tools (MCP)` block in both `buildSystemPrompt` (worker) and `buildChatSystemPrompt` (chat), instructing agents to use `search_semantic` / `context_search` over ingested drives before calling `mcp_exec`.
- MCP is now framed as the fallback for fresh data, write-side actions (sending email, creating issues), or content genuinely missing from local context.
- Extends the existing MCP-section tests in `test/worker/prompt.test.ts` and `test/chat/agent.test.ts` to assert the new wording, and bumps `package.json` to `0.9.5`.

## Test plan

- [x] `bun run lint`
- [x] `bun test` (705/705 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)