### PR TITLE
Replace HNSW + ILIKE with linear cosine + FTS BM25 for hybrid search

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,8 @@ An AI agent for knowledge work. See `docs/plans/README.md` for the milestone roa
 - **Timestamps**: stored as ISO 8601 TEXT (`datetime('now')`), converted to `Date` objects in TypeScript interfaces
 - **Booleans**: stored as INTEGER (0/1) in DuckDB, converted to `boolean` in TypeScript
 - **Arrays**: `blocked_by`/`context_ids` are JSON TEXT columns — `JSON.stringify()` on write, `JSON.parse()` on read
-- **Vectors**: embedding columns use DuckDB's native `FLOAT[N]` array type with HNSW indexes and `array_cosine_distance()` for similarity search
+- **Vectors**: embedding columns use DuckDB's native `FLOAT[N]` array type with `array_cosine_distance()` (core DuckDB, no extension) for similarity search; no HNSW index — linear scan is plenty fast at our scale.
+- **Full-text search**: keyword search over `embeddings.chunk_content` + `title` uses the `fts` extension's `match_bm25`. The FTS index is a snapshot — any code that writes to `embeddings` must call `rebuildSearchIndex(conn)` from `src/db/embeddings.ts` after its transaction commits. Ingest (`src/context/ingest.ts`) is the only writer today and already does this.
 - **Row mapping**: each module has a `RowType` interface (raw DuckDB values) and a `rowToX()` function that converts to the public TypeScript interface with proper types
 
 ## Testing

--- a/docs/context-and-search.md
+++ b/docs/context-and-search.md
@@ -16,7 +16,8 @@ agent writes via `context_write`), this happens:
  content ─► create context_item row  (drive, path)
          ─► LLM-driven chunker (claude-haiku-4-5 by default)
          ─► embedder (OpenAI text-embedding-3-small, 1536-dim)
-         ─► embeddings table (FLOAT[1536] + HNSW index)
+         ─► embeddings table (FLOAT[1536])
+         ─► rebuild FTS index (BM25 over chunk_content + title)
          ─► indexed_at set on the context_item
 ```
 
@@ -91,9 +92,20 @@ CREATE TABLE embeddings (
 );
 ```
 
-The VSS extension provides an HNSW index with cosine distance
-(`src/db/sql/6-vss_index.sql`). `SET hnsw_enable_experimental_persistence = true;`
-is run at connection time so the index survives process restarts.
+Vector similarity uses `array_cosine_distance` — a core DuckDB function,
+no extension required. There is no HNSW index: at our scale (hundreds
+to low thousands of rows) a linear scan beats the operational cost of
+the experimental-persistence HNSW path, which has bitten us with
+intermittent corruption more than once. Revisit when row counts reach
+the millions.
+
+Keyword search uses the **DuckDB FTS extension** (`INSTALL fts; LOAD
+fts;`) for BM25 ranking over `chunk_content` and `title`. The FTS index
+is a **snapshot** — it does not update incrementally on INSERT /
+DELETE. Every writer must call `rebuildSearchIndex(conn)` from
+`src/db/embeddings.ts` after its transaction commits. The ingest
+pipeline (`src/context/ingest.ts`) is the only writer today and does
+this automatically.
 
 ---
 
@@ -101,12 +113,14 @@ is run at connection time so the index survives process restarts.
 
 `hybridSearch()` in `src/db/embeddings.ts` combines two signals:
 
-1. **Keyword** — `LIKE` match on `chunk_content` and `title`.
-2. **Vector** — `array_cosine_distance(embedding, $query_embedding)` via
-   the HNSW index, which turns what would be a full scan into a
-   logarithmic probe.
+1. **Keyword** — `fts_main_embeddings.match_bm25(id, query)` over
+   `chunk_content` and `title`. BM25 handles tokenization, stemming,
+   stopwords, and length-normalized scoring, so multi-term queries
+   strictly *increase* recall over single-term queries.
+2. **Vector** — `array_cosine_distance(embedding, $query_embedding)`
+   via a linear scan over the `embeddings` table.
 
-Results are merged with reciprocal rank fusion, joined back to
+Results are merged with reciprocal rank fusion (k=60), joined back to
 `context_items` to pick up each hit's `drive` and `path`, and returned
 as `(ref, title, score, snippet)`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/context/ingest.ts
+++ b/src/context/ingest.ts
@@ -1,7 +1,11 @@
 import type { BotholomewConfig } from "../config/schemas.ts";
 import type { DbConnection } from "../db/connection.ts";
 import { getContextItem, getContextItemById } from "../db/context.ts";
-import { createEmbedding, deleteEmbeddingsForItem } from "../db/embeddings.ts";
+import {
+  createEmbedding,
+  deleteEmbeddingsForItem,
+  rebuildSearchIndex,
+} from "../db/embeddings.ts";
 import { logger } from "../utils/logger.ts";
 import { chunk } from "./chunker.ts";
 import { type DriveTarget, formatDriveRef } from "./drives.ts";
@@ -120,6 +124,9 @@ export async function storeIngestion(
     await conn.exec("ROLLBACK");
     throw err;
   }
+
+  // FTS index is a snapshot and doesn't see the writes above until rebuilt.
+  await rebuildSearchIndex(conn);
 
   const action = isUpdate ? "updated" : "added";
   logger.info(

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -186,8 +186,7 @@ export async function getConnection(dbPath?: string): Promise<DbConnection> {
   if (isMemoryPath(path)) {
     const instance = await DuckDBInstance.create(path);
     const conn = await instance.connect();
-    await conn.run("INSTALL vss; LOAD vss;");
-    await conn.run("SET hnsw_enable_experimental_persistence = true;");
+    await conn.run("INSTALL fts; LOAD fts;");
     return new DbConnection(conn, instance, path);
   }
 
@@ -197,8 +196,7 @@ export async function getConnection(dbPath?: string): Promise<DbConnection> {
     // INSTALL is a no-op after the first successful install (the extension
     // is persisted to the user's DuckDB extension directory). LOAD is
     // cheap per connection.
-    await conn.run("INSTALL vss; LOAD vss;");
-    await conn.run("SET hnsw_enable_experimental_persistence = true;");
+    await conn.run("INSTALL fts; LOAD fts;");
     return new DbConnection(conn, null, path);
   } catch (err) {
     releaseInstance(path);

--- a/src/db/embeddings.ts
+++ b/src/db/embeddings.ts
@@ -45,6 +45,11 @@ function rowToEmbedding(row: EmbeddingRow): Embedding {
   };
 }
 
+/**
+ * Insert a single embedding row. Callers that bulk-write embeddings are
+ * responsible for calling `rebuildSearchIndex()` afterward — the FTS index is
+ * a snapshot and will not reflect new rows until rebuilt.
+ */
 export async function createEmbedding(
   conn: DbConnection,
   params: {
@@ -92,6 +97,11 @@ export async function getEmbeddingsForItem(
   return rows.map(rowToEmbedding);
 }
 
+/**
+ * Delete all embeddings for a context item. Callers are responsible for
+ * calling `rebuildSearchIndex()` afterward — the FTS index is a snapshot and
+ * will still reference the deleted rows until rebuilt.
+ */
 export async function deleteEmbeddingsForItem(
   conn: DbConnection,
   contextItemId: string,
@@ -138,6 +148,18 @@ export interface HybridSearchResult extends EmbeddingSearchResult {
   path: string | null;
 }
 
+/**
+ * Rebuild the FTS index over (chunk_content, title). DuckDB's FTS index is a
+ * snapshot — it does not update incrementally on INSERT/UPDATE/DELETE, so any
+ * batch writer must call this once its transaction commits. Cheap at our
+ * scale (hundreds to low thousands of rows).
+ */
+export async function rebuildSearchIndex(conn: DbConnection): Promise<void> {
+  await conn.exec(
+    "PRAGMA create_fts_index('embeddings', 'id', 'chunk_content', 'title', overwrite = 1)",
+  );
+}
+
 export async function hybridSearch(
   conn: DbConnection,
   query: string,
@@ -146,10 +168,16 @@ export async function hybridSearch(
 ): Promise<HybridSearchResult[]> {
   const k = 60; // RRF constant
 
+  // Keyword side: BM25 over chunk_content + title via the FTS extension.
+  // `match_bm25` returns NULL for rows with no token overlap; we keep only
+  // scored rows and order by descending score so RRF sees the best matches
+  // at the lowest ranks. Stemming, stopwords, and tokenization are handled
+  // by FTS — more query terms produce higher scores, which is exactly the
+  // behaviour a naive per-token ILIKE loop fails to provide.
   const keywordRows = await conn.queryAll<EmbeddingRow>(
     `SELECT * FROM embeddings
-     WHERE chunk_content ILIKE '%' || ?1 || '%'
-        OR title ILIKE '%' || ?1 || '%'
+     WHERE fts_main_embeddings.match_bm25(id, ?1) IS NOT NULL
+     ORDER BY fts_main_embeddings.match_bm25(id, ?1) DESC
      LIMIT 100`,
     query,
   );

--- a/src/db/sql/11-rebuild_hnsw.sql
+++ b/src/db/sql/11-rebuild_hnsw.sql
@@ -1,9 +1,8 @@
--- The HNSW index from migration 6 can end up in an internally-inconsistent
--- state after a native-side crash during embedding writes: the buffered WAL
--- replay tries to re-insert a node that HNSW's high-level wrapper already has,
--- and search_semantic then fails with "Duplicate keys not allowed in
--- high-level wrappers". Dropping and recreating the index rebuilds it cleanly
--- from the current contents of the embeddings table.
-DROP INDEX IF EXISTS idx_embeddings_cosine;
-
-CREATE INDEX idx_embeddings_cosine ON embeddings USING HNSW (embedding) WITH (metric = 'cosine');
+-- Historical: this migration used to drop and recreate the HNSW index
+-- to clean up an internally-inconsistent state after native-side crashes
+-- during embedding writes. HNSW is now gone (see migration 14) and the
+-- VSS extension is no longer loaded at connection time, so the original
+-- DDL would fail on fresh DBs. Kept as a no-op to preserve migration
+-- numbering for existing databases that have already recorded id 11 in
+-- _migrations.
+SELECT 1;

--- a/src/db/sql/13-drive-paths.sql
+++ b/src/db/sql/13-drive-paths.sql
@@ -44,6 +44,4 @@ CREATE TABLE embeddings (
   UNIQUE(context_item_id, chunk_index)
 );
 
-CREATE INDEX idx_embeddings_cosine ON embeddings USING HNSW (embedding) WITH (metric = 'cosine');
-
 CHECKPOINT;

--- a/src/db/sql/14-drop_hnsw_index.sql
+++ b/src/db/sql/14-drop_hnsw_index.sql
@@ -1,0 +1,8 @@
+-- HNSW has caused two separate corruption modes in this project: the
+-- "Duplicate keys not allowed in high-level wrappers" failure addressed by
+-- migration 11, and a second mode where the index silently returns zero rows
+-- for cosine top-K queries (its stored SQL loses the `WITH (metric = 'cosine')`
+-- clause). At our scale a linear scan of array_cosine_distance is plenty fast
+-- and array_cosine_distance is a core DuckDB function — no VSS extension
+-- required. Drop the index and move on.
+DROP INDEX IF EXISTS idx_embeddings_cosine;

--- a/src/db/sql/15-fts_index.sql
+++ b/src/db/sql/15-fts_index.sql
@@ -1,0 +1,8 @@
+-- Keyword search uses DuckDB's FTS extension for BM25 ranking over
+-- chunk_content and title. The index is a snapshot and must be rebuilt
+-- after any write to the embeddings table. rebuildSearchIndex() in
+-- src/db/embeddings.ts is the single entry point and is called from the
+-- ingest transaction. overwrite = 1 makes this PRAGMA idempotent, which
+-- also gives us a first-run rebuild for users upgrading from a DB that
+-- never had FTS.
+PRAGMA create_fts_index('embeddings', 'id', 'chunk_content', 'title', overwrite = 1);

--- a/src/db/sql/6-vss_index.sql
+++ b/src/db/sql/6-vss_index.sql
@@ -1,1 +1,7 @@
-CREATE INDEX IF NOT EXISTS idx_embeddings_cosine ON embeddings USING HNSW (embedding) WITH (metric = 'cosine');
+-- Historical: this migration used to CREATE an HNSW index on embeddings
+-- via the VSS extension. HNSW has since been removed (see migration 12)
+-- (see migration 14) and the VSS extension is no longer loaded at
+-- connection time, so running `CREATE INDEX ... USING HNSW` here would
+-- fail on fresh DBs. Kept as a no-op to preserve migration numbering
+-- for existing databases that have already recorded id 6 in _migrations.
+SELECT 1;

--- a/src/db/sql/7-drop_embeddings_fk.sql
+++ b/src/db/sql/7-drop_embeddings_fk.sql
@@ -20,5 +20,4 @@ CREATE TABLE embeddings (
   created_at TEXT NOT NULL DEFAULT (current_timestamp::VARCHAR),
   UNIQUE(context_item_id, chunk_index)
 );
-CREATE INDEX IF NOT EXISTS idx_embeddings_cosine ON embeddings USING HNSW (embedding) WITH (metric = 'cosine');
 CHECKPOINT;

--- a/test/db/embeddings.test.ts
+++ b/test/db/embeddings.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { EMBEDDING_DIMENSION } from "../../src/constants.ts";
 import type { DbConnection } from "../../src/db/connection.ts";
 import { createContextItem } from "../../src/db/context.ts";
@@ -6,9 +6,10 @@ import {
   createEmbedding,
   deleteEmbeddingsForItem,
   hybridSearch,
+  rebuildSearchIndex,
   searchEmbeddings,
 } from "../../src/db/embeddings.ts";
-import { setupTestDb } from "../helpers.ts";
+import { fakeEmbed, setupTestDb, setupTestDbFile } from "../helpers.ts";
 
 let conn: DbConnection;
 
@@ -330,11 +331,163 @@ describe("edge cases", () => {
       title: "unique",
       embedding: vec(0),
     });
+    await rebuildSearchIndex(conn);
 
     // Search with keyword that matches AND vector that matches
     const results = await hybridSearch(conn, "unique", vec(0), 10);
     expect(results.length).toBe(1);
     // Score should be boosted by appearing in both keyword and vector results
     expect(results[0]?.score).toBeGreaterThan(0);
+  });
+});
+
+// ── hybridSearch with content-aware embeddings ─────────────
+//
+// These tests use real natural-language content plus a deterministic
+// content-aware fake embedder (vocab → hot dim, unit-normalized) so that
+// cosine similarity actually tracks word overlap. The existing describe
+// blocks above use sparse unit vectors, which produce valid-but-meaningless
+// cosine distances and mask real search bugs.
+
+describe("hybridSearch end-to-end (content-aware)", () => {
+  let fileConn: DbConnection;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    const setup = await setupTestDbFile();
+    fileConn = setup.conn;
+    cleanup = setup.cleanup;
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  async function seedDoc(opts: {
+    title: string;
+    path: string;
+    content: string;
+    embedFrom?: string;
+  }) {
+    const item = await createContextItem(fileConn, {
+      title: opts.title,
+      content: opts.content,
+      drive: "agent",
+      path: opts.path,
+      mimeType: "text/plain",
+      isTextual: true,
+    });
+    await createEmbedding(fileConn, {
+      contextItemId: item.id,
+      chunkIndex: 0,
+      chunkContent: opts.content,
+      title: opts.title,
+      embedding: fakeEmbed(opts.embedFrom ?? opts.content),
+    });
+    return item;
+  }
+
+  async function seedStandardCorpus() {
+    await seedDoc({
+      title: "Evan's Paternity Leave Plan",
+      path: "/paternity",
+      content:
+        "A plan for paternity leave and time off after the newborn arrives.",
+    });
+    await seedDoc({
+      title: "Q3 Revenue Forecast",
+      path: "/revenue",
+      content: "Revenue forecast and quota for Q3.",
+    });
+    await seedDoc({
+      title: "Kubernetes Deployment Guide",
+      path: "/k8s",
+      content: "Kubernetes helm deployment rollout guide.",
+    });
+    await rebuildSearchIndex(fileConn);
+  }
+
+  test("multi-word query recovers doc matching on some tokens", async () => {
+    // Exact reproduction of the user-reported failure: the query contains
+    // five words, none of which appear as a contiguous substring of any
+    // chunk. Naive ILIKE on the whole query finds nothing; BM25 + vector
+    // together must still surface the paternity doc.
+    await seedStandardCorpus();
+    const query = "leave plans time off parental";
+    const results = await hybridSearch(fileConn, query, fakeEmbed(query), 5);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]?.title).toBe("Evan's Paternity Leave Plan");
+  });
+
+  test("vector-only recall: doc retrieved with zero keyword overlap", async () => {
+    // chunk_content has no vocab words so the BM25 path returns nothing;
+    // the embedding was computed from the original sentence so the vector
+    // path can still rescue the doc. Asserts the vector arm carries its
+    // weight on its own.
+    await seedDoc({
+      title: "Redacted Leave Plan",
+      path: "/redacted",
+      content: "A plan for [redacted] and [redacted] away.",
+      embedFrom:
+        "A plan for paternity leave and time off after the newborn arrives.",
+    });
+    await seedDoc({
+      title: "Q3 Revenue Forecast",
+      path: "/revenue",
+      content: "Revenue forecast and quota for Q3.",
+    });
+    await rebuildSearchIndex(fileConn);
+
+    const query = "paternity leave";
+    const results = await hybridSearch(fileConn, query, fakeEmbed(query), 5);
+    expect(results.some((r) => r.title === "Redacted Leave Plan")).toBe(true);
+    expect(results[0]?.title).toBe("Redacted Leave Plan");
+  });
+
+  test("BM25: more matching tokens rank higher than fewer", async () => {
+    // Doc X matches three query tokens (leave, time, off); Doc Y matches
+    // one (leave). BM25 length-normalization + IDF plus the RRF merge
+    // must put X above Y. A naive ILIKE-OR tokenizer cannot distinguish
+    // them reliably — both would appear at arbitrary ranks.
+    await seedDoc({
+      title: "Three Token Doc",
+      path: "/three",
+      content: "Leave time off policy overview.",
+    });
+    await seedDoc({
+      title: "One Token Doc",
+      path: "/one",
+      content: "Leave the building through the south exit.",
+    });
+    await rebuildSearchIndex(fileConn);
+
+    const query = "leave time off";
+    const results = await hybridSearch(fileConn, query, fakeEmbed(query), 5);
+    const threeIdx = results.findIndex((r) => r.title === "Three Token Doc");
+    const oneIdx = results.findIndex((r) => r.title === "One Token Doc");
+    expect(threeIdx).toBeGreaterThanOrEqual(0);
+    expect(oneIdx).toBeGreaterThanOrEqual(0);
+    expect(threeIdx).toBeLessThan(oneIdx);
+  });
+
+  test("unrelated query does not surface the paternity doc", async () => {
+    await seedStandardCorpus();
+    const query = "kubernetes helm rollout";
+    const results = await hybridSearch(fileConn, query, fakeEmbed(query), 5);
+    expect(results[0]?.title).toBe("Kubernetes Deployment Guide");
+    expect(results[0]?.title).not.toBe("Evan's Paternity Leave Plan");
+  });
+
+  test("searchEmbeddings tripwire: returns rows when embeddings exist", async () => {
+    // Catches future vector-path regressions (e.g., a reintroduced HNSW
+    // that silently returns 0 rows on cosine queries). If this assertion
+    // ever goes red, the whole hybrid search is dead regardless of BM25.
+    await seedStandardCorpus();
+    const results = await searchEmbeddings(
+      fileConn,
+      fakeEmbed("paternity leave"),
+      5,
+    );
+    expect(results.length).toBeGreaterThan(0);
   });
 });

--- a/test/db/schema.test.ts
+++ b/test/db/schema.test.ts
@@ -65,7 +65,7 @@ describe("schema migrations", () => {
     )) as {
       count: number;
     };
-    expect(row.count).toBe(13);
+    expect(row.count).toBe(15);
 
     db.close();
   });

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -84,6 +84,45 @@ export const mockEmbed = async (texts: string[]) =>
 export const mockEmbedSingle = async () =>
   new Array(EMBEDDING_DIMENSION).fill(0);
 
+/**
+ * Content-aware deterministic embedder for search-pipeline tests.
+ *
+ * Unlike `mockEmbed` (zero vectors), this produces vectors whose cosine
+ * similarity tracks word overlap: each vocab word maps to a dedicated hot
+ * dimension, the resulting vector is unit-normalized, and two texts sharing
+ * any vocab word produce a positive dot product.
+ *
+ * Use for tests that exercise `searchEmbeddings` / `hybridSearch` — zero
+ * vectors produce valid-but-meaningless cosine distances and mask real bugs.
+ */
+const FAKE_EMBED_VOCAB: Record<string, number> = {
+  paternity: 10,
+  leave: 20,
+  parental: 30,
+  time: 40,
+  off: 50,
+  newborn: 60,
+  plan: 70,
+  childcare: 80,
+  revenue: 100,
+  forecast: 110,
+  quota: 120,
+  kubernetes: 200,
+  helm: 210,
+  deployment: 220,
+  rollout: 230,
+};
+
+export function fakeEmbed(text: string): number[] {
+  const v = new Array(EMBEDDING_DIMENSION).fill(0);
+  const lower = text.toLowerCase();
+  for (const [word, dim] of Object.entries(FAKE_EMBED_VOCAB)) {
+    if (lower.includes(word)) v[dim] = 1;
+  }
+  const mag = Math.sqrt(v.reduce((s, x) => s + x * x, 0));
+  return mag === 0 ? v : v.map((x) => x / mag);
+}
+
 // ---------------------------------------------------------------------------
 // Test config
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Drop HNSW: it hit two distinct corruption modes (duplicate-key WAL replay; silent zero-row top-K from a lost cosine-metric clause) and at our scale a linear `array_cosine_distance` scan is plenty fast and needs no extension.
- Replace ILIKE keyword search with the DuckDB FTS extension's `match_bm25` over `chunk_content` + `title`, so multi-word queries strictly increase recall instead of failing on missing contiguous substrings.
- Add migrations 14 (drop HNSW) and 15 (create FTS index); old VSS migrations are no-op'd to preserve numbering for existing DBs. Ingest now calls `rebuildSearchIndex()` after each write since FTS is a snapshot.
- New content-aware `fakeEmbed()` helper plus end-to-end `hybridSearch` tests covering the original multi-word repro, vector-only recall, BM25 ranking, and a vector-path tripwire.

## Test plan
- [x] `bun run lint`
- [x] `bun test` (710 pass)
- [ ] Verify `bun dev context refresh --all` against a real DB upgraded from a pre-FTS schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)