### PR TITLE
Refresh MCP-loaded context items via captured source_url (#145)

### DIFF
--- a/docs/context-and-search.md
+++ b/docs/context-and-search.md
@@ -49,7 +49,9 @@ Each chunk is embedded separately; the `title` and `description` come
 from the parent `context_item` (set at ingestion time), are prepended
 to the chunk's text at embed time (along with a `Source: drive:/path`
 line), and surface in search results as the snippet. If the chunker
-fails, ingestion fails — there is no sliding-window fallback today.
+errors or times out, ingestion falls back to a deterministic
+paragraph/line splitter (`chunkByTextSplit` in `src/context/chunker.ts`)
+— semantic quality suffers, but the item still gets embedded.
 
 ---
 
@@ -276,10 +278,15 @@ botholomew context refresh --all               # every non-agent item
 `refresh` dispatches on the drive:
 
 - `disk` → re-reads from the filesystem.
-- `url` → re-runs the loading agent.
 - `agent` → skipped (no external origin).
-- `google-docs` / `github` → returns a per-item error today (not yet
-  implemented). Re-add from the original URL if you need a fresh copy.
+- Everything else → re-runs the loading agent against
+  `context_items.source_url`, which is captured at ingest time. The
+  built-in `url` drive also accepts its own path as a fallback (the path
+  is the URL). Items without `source_url` — legacy rows created before
+  that column landed, or rows from a drive whose origin isn't a URL —
+  surface a per-item error and the user must re-add from URL. Refresh
+  has no knowledge of any specific remote service; everything goes
+  through `source_url`.
 
 In all cases it compares the new content against what's stored, updates
 only when they differ, and re-embeds only the changed items. Missing

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -871,6 +871,7 @@ async function addUrl(
       drive: target.drive,
       path: target.path,
       isTextual: true,
+      sourceUrl: fetched.sourceUrl,
     };
 
     const item =

--- a/src/context/chunker.ts
+++ b/src/context/chunker.ts
@@ -1,5 +1,6 @@
 import Anthropic from "@anthropic-ai/sdk";
 import type { BotholomewConfig } from "../config/schemas.ts";
+import { logger } from "../utils/logger.ts";
 
 export interface Chunk {
   index: number;
@@ -16,6 +17,10 @@ const DEFAULT_OVERLAP_LINES = 2;
 // 8192-token limit, leaving headroom for the title/description prefix
 // prepended at embed time.
 const MAX_CHUNK_CHARS = 15_000;
+// Target size for deterministic fallback chunks. Smaller than MAX_CHUNK_CHARS
+// so a large doc produces multiple chunks of reasonable granularity when the
+// LLM chunker fails.
+const FALLBACK_TARGET_CHARS = 4_000;
 
 const CHUNKER_TOOL_NAME = "return_chunks";
 const CHUNKER_TOOL = {
@@ -152,6 +157,26 @@ export function addOverlapToChunks(
   });
 }
 
+export type LLMChunkerFn = (
+  content: string,
+  mimeType: string,
+  config: Required<BotholomewConfig>,
+) => Promise<Chunk[]>;
+
+/**
+ * Deterministic fallback that splits content on paragraph / line /
+ * hard-char boundaries. Used when the LLM chunker errors or times out.
+ */
+export function chunkByTextSplit(
+  content: string,
+  targetChars = FALLBACK_TARGET_CHARS,
+): Chunk[] {
+  return splitText(content, targetChars).map((c, i) => ({
+    index: i,
+    content: c,
+  }));
+}
+
 /**
  * LLM-driven chunker that asks Claude to identify semantic boundaries.
  * Uses structured outputs via tool_use with forced tool_choice.
@@ -167,7 +192,7 @@ export async function chunkWithLLM(
   const response = await Promise.race([
     client.messages.create({
       model: config.chunker_model,
-      max_tokens: 1024,
+      max_tokens: 2048,
       tools: [CHUNKER_TOOL],
       tool_choice: { type: "tool", name: CHUNKER_TOOL_NAME },
       messages: [
@@ -209,13 +234,15 @@ ${content}`,
 }
 
 /**
- * Chunk content using the LLM chunker.
+ * Chunk content using the LLM chunker, with a deterministic fallback
+ * when the LLM call fails (timeout, empty boundaries, API error, …).
  * Short content (<200 chars) is returned as a single chunk.
  */
 export async function chunk(
   content: string,
   mimeType: string,
   config: Required<BotholomewConfig>,
+  llmChunker: LLMChunkerFn = chunkWithLLM,
 ): Promise<Chunk[]> {
   if (content.length < SHORT_CONTENT_THRESHOLD) {
     return [{ index: 0, content }];
@@ -227,7 +254,17 @@ export async function chunk(
     );
   }
 
-  const chunks = await chunkWithLLM(content, mimeType, config);
+  let chunks: Chunk[];
+  try {
+    chunks = await llmChunker(content, mimeType, config);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.warn(
+      `chunker: LLM chunking failed (${msg}); falling back to deterministic text split`,
+    );
+    chunks = chunkByTextSplit(content);
+  }
+
   // Enforce a hard size cap before AND after overlap. The first pass handles
   // oversize chunks from the LLM (common for docs with very long lines); the
   // second pass handles the rare case where added overlap pushes a near-limit

--- a/src/context/refresh.ts
+++ b/src/context/refresh.ts
@@ -3,7 +3,7 @@ import type { BotholomewConfig } from "../config/schemas.ts";
 import type { DbConnection } from "../db/connection.ts";
 import { type ContextItem, updateContextItem } from "../db/context.ts";
 import { formatDriveRef } from "./drives.ts";
-import { fetchUrl } from "./fetcher.ts";
+import { type FetchedContent, fetchUrl } from "./fetcher.ts";
 import {
   type PreparedIngestion,
   prepareIngestion,
@@ -40,6 +40,13 @@ export interface RefreshOptions {
 
 type IngestEmbedFn = (texts: string[]) => Promise<number[][]>;
 
+/** Signature compatible with {@link fetchUrl}. Injectable for tests. */
+export type FetchUrlFn = (
+  url: string,
+  config: Required<BotholomewConfig>,
+  mcpxClient: McpxClient | null,
+) => Promise<FetchedContent>;
+
 /**
  * Refresh a batch of context items: re-read from origin, diff, update
  * content, and re-embed only the items that changed.
@@ -47,10 +54,12 @@ type IngestEmbedFn = (texts: string[]) => Promise<number[][]>;
  * Dispatches on `drive`:
  *   disk  → read from filesystem
  *   agent → skip (no external origin)
- *   other → re-fetch as a URL (the path is either a full URL for `url` drive
- *           or an origin-specific identifier that fetchUrl can re-derive via
- *           the MCP agent; for now this only refreshes items stored under
- *           `url:/<full-url>`)
+ *   other → re-fetch via `item.source_url` (captured at ingest time).
+ *           The built-in `url` drive stores the URL as its path so it can
+ *           also refresh directly from `path`. Any other drive with no
+ *           `source_url` surfaces a per-item error — the user must re-add
+ *           from URL. No code here knows anything about the remote
+ *           service behind a drive.
  */
 export async function refreshContextItems(
   conn: DbConnection,
@@ -59,6 +68,7 @@ export async function refreshContextItems(
   mcpxClient: McpxClient | null,
   opts: RefreshOptions = {},
   embedFn?: IngestEmbedFn,
+  fetchFn: FetchUrlFn = fetchUrl,
 ): Promise<RefreshResult> {
   const refreshable = items.filter((i) => i.drive !== "agent");
 
@@ -84,20 +94,20 @@ export async function refreshContextItems(
           continue;
         }
         content = await bunFile.text();
-      } else if (item.drive === "url") {
-        const url = item.path.startsWith("/") ? item.path.slice(1) : item.path;
-        const fetched = await fetchUrl(url, config, mcpxClient);
-        content = fetched.content;
       } else {
-        // Service-specific drives (google-docs, github, etc.) — only
-        // refreshable when the original URL can be reconstructed. For now,
-        // we punt: mark as error so the user knows to re-add from URL.
-        results.push({
-          ...base,
-          status: "error",
-          error: `Refresh not implemented for drive '${item.drive}' — re-add from the original URL.`,
-        });
-        continue;
+        const url =
+          item.source_url ??
+          (item.drive === "url" ? item.path.replace(/^\//, "") : null);
+        if (!url) {
+          results.push({
+            ...base,
+            status: "error",
+            error: `Cannot refresh ${formatDriveRef(item)}: no source_url recorded. Re-add from the original URL.`,
+          });
+          continue;
+        }
+        const fetched = await fetchFn(url, config, mcpxClient);
+        content = fetched.content;
       }
 
       if (content === item.content) {

--- a/src/db/context.ts
+++ b/src/db/context.ts
@@ -17,6 +17,7 @@ export interface ContextItem {
   is_textual: boolean;
   drive: string;
   path: string;
+  source_url: string | null;
   indexed_at: Date | null;
   created_at: Date;
   updated_at: Date;
@@ -38,6 +39,7 @@ interface ContextItemRow {
   is_textual: boolean;
   drive: string;
   path: string;
+  source_url: string | null;
   indexed_at: string | null;
   created_at: string;
   updated_at: string;
@@ -53,6 +55,7 @@ function rowToContextItem(row: ContextItemRow): ContextItem {
     is_textual: !!row.is_textual,
     drive: row.drive,
     path: row.path,
+    source_url: row.source_url,
     indexed_at: row.indexed_at ? new Date(row.indexed_at) : null,
     created_at: new Date(row.created_at),
     updated_at: new Date(row.updated_at),
@@ -84,12 +87,13 @@ export async function createContextItem(
     path: string;
     description?: string;
     isTextual?: boolean;
+    sourceUrl?: string | null;
   },
 ): Promise<ContextItem> {
   const id = uuidv7();
   const row = await db.queryGet<ContextItemRow>(
-    `INSERT INTO context_items (id, title, description, content, mime_type, is_textual, drive, path)
-     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+    `INSERT INTO context_items (id, title, description, content, mime_type, is_textual, drive, path, source_url)
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
      RETURNING *`,
     id,
     params.title,
@@ -99,6 +103,7 @@ export async function createContextItem(
     params.isTextual !== false,
     params.drive,
     params.path,
+    params.sourceUrl ?? null,
   );
   if (!row) throw new Error("INSERT did not return a row");
   return rowToContextItem(row);
@@ -122,6 +127,7 @@ export async function upsertContextItem(
     path: string;
     description?: string;
     isTextual?: boolean;
+    sourceUrl?: string | null;
   },
 ): Promise<ContextItem> {
   const existing = await getContextItem(db, {
@@ -133,6 +139,7 @@ export async function upsertContextItem(
       title: params.title,
       content: params.content,
       mime_type: params.mimeType,
+      source_url: params.sourceUrl,
     });
     if (!updated)
       throw new Error(
@@ -157,6 +164,7 @@ export async function createContextItemStrict(
     path: string;
     description?: string;
     isTextual?: boolean;
+    sourceUrl?: string | null;
   },
 ): Promise<ContextItem> {
   const existing = await getContextItem(db, {
@@ -426,7 +434,10 @@ export async function updateContextItem(
   db: DbConnection,
   id: string,
   updates: Partial<
-    Pick<ContextItem, "title" | "description" | "content" | "mime_type">
+    Pick<
+      ContextItem,
+      "title" | "description" | "content" | "mime_type" | "source_url"
+    >
   >,
 ): Promise<ContextItem | null> {
   const { setClauses, params } = buildSetClauses([
@@ -434,6 +445,7 @@ export async function updateContextItem(
     ["description", updates.description],
     ["content", updates.content],
     ["mime_type", updates.mime_type],
+    ["source_url", updates.source_url],
   ]);
 
   setClauses.push("updated_at = current_timestamp::VARCHAR");
@@ -514,6 +526,7 @@ export async function copyContextItem(
     drive: dst.drive,
     path: dst.path,
     isTextual: source.is_textual,
+    sourceUrl: source.source_url,
   });
 }
 

--- a/src/db/embeddings.ts
+++ b/src/db/embeddings.ts
@@ -153,11 +153,18 @@ export interface HybridSearchResult extends EmbeddingSearchResult {
  * snapshot — it does not update incrementally on INSERT/UPDATE/DELETE, so any
  * batch writer must call this once its transaction commits. Cheap at our
  * scale (hundreds to low thousands of rows).
+ *
+ * The trailing CHECKPOINT is load-bearing: `overwrite = 1` writes a
+ * `DROP SCHEMA fts_main_embeddings` record into the WAL. If the WAL still
+ * contains that drop on the next open, replay fails with "Cannot drop entry
+ * 'fts_main_embeddings' because there are entries that depend on it". Forcing
+ * a checkpoint flushes the WAL so the next open has nothing to replay.
  */
 export async function rebuildSearchIndex(conn: DbConnection): Promise<void> {
   await conn.exec(
     "PRAGMA create_fts_index('embeddings', 'id', 'chunk_content', 'title', overwrite = 1)",
   );
+  await conn.exec("CHECKPOINT");
 }
 
 export async function hybridSearch(

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,5 +1,6 @@
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { logger } from "../utils/logger.ts";
 import type { DbConnection } from "./connection.ts";
 
 interface Migration {
@@ -45,9 +46,16 @@ export async function migrate(db: DbConnection): Promise<void> {
   const applied = new Set(rows.map((row) => row.id));
 
   // Run pending migrations in order
+  const pending = loadMigrations().filter((m) => !applied.has(m.id));
+  if (pending.length > 0) {
+    logger.info(
+      `applying ${pending.length} migration${pending.length === 1 ? "" : "s"}`,
+    );
+  }
+
   let appliedAny = false;
-  for (const migration of loadMigrations()) {
-    if (applied.has(migration.id)) continue;
+  for (const migration of pending) {
+    logger.info(`  ${migration.id}. ${migration.name}`);
 
     // Split on semicolons and run each statement individually
     const statements = migration.sql

--- a/src/db/sql/16-source_url.sql
+++ b/src/db/sql/16-source_url.sql
@@ -1,0 +1,7 @@
+-- Issue #145: preserve the original URL that produced each context item so
+-- `context refresh` can re-fetch loss-lessly for service-specific drives
+-- (google-docs, github, ...). Nullable — local-origin drives (disk, agent,
+-- tool writes) leave it NULL and use their own refresh path. Legacy rows
+-- ingested before this column existed also leave it NULL and surface a
+-- "re-add from URL" error on refresh.
+ALTER TABLE context_items ADD COLUMN source_url TEXT;

--- a/test/context/chunker.test.ts
+++ b/test/context/chunker.test.ts
@@ -21,6 +21,31 @@ describe("chunk", () => {
       "Anthropic API key is required",
     );
   });
+
+  test("falls back to deterministic splitting when LLM chunker throws", async () => {
+    const config = { ...DEFAULT_CONFIG, anthropic_api_key: "test-key" };
+    const paragraph = "abcdefghij".repeat(50); // 500 chars, no newlines
+    const content = Array.from({ length: 12 }, () => paragraph).join("\n\n");
+    expect(content.length).toBeGreaterThan(5_000);
+
+    const throwingChunker = async () => {
+      throw new Error("LLM chunker returned empty boundaries");
+    };
+
+    const chunks = await chunk(content, "text/plain", config, throwingChunker);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const c of chunks) {
+      expect(c.content.length).toBeLessThanOrEqual(15_000);
+    }
+    // Indices are 0..n-1 contiguous.
+    for (const [i, c] of chunks.entries()) {
+      expect(c.index).toBe(i);
+    }
+    // Every paragraph shows up somewhere in the concatenated chunks.
+    const joined = chunks.map((c) => c.content).join("\n");
+    expect(joined).toContain(paragraph);
+  });
 });
 
 describe("addOverlapToChunks", () => {

--- a/test/context/refresh.test.ts
+++ b/test/context/refresh.test.ts
@@ -3,6 +3,8 @@ import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DEFAULT_CONFIG } from "../../src/config/schemas.ts";
+import type { FetchedContent } from "../../src/context/fetcher.ts";
+import type { FetchUrlFn } from "../../src/context/refresh.ts";
 import type { DbConnection } from "../../src/db/connection.ts";
 import { createContextItem, getContextItemById } from "../../src/db/context.ts";
 import { mockEmbed, setupTestDb } from "../helpers.ts";
@@ -12,6 +14,19 @@ const configNoEmbed = { ...DEFAULT_CONFIG };
 
 let conn: DbConnection;
 let tmpBase: string;
+
+/** Build a fake fetcher that records every URL it's called with. */
+function makeFakeFetchFn(reply: (url: string) => FetchedContent): {
+  fn: FetchUrlFn;
+  calls: string[];
+} {
+  const calls: string[] = [];
+  const fn: FetchUrlFn = async (url) => {
+    calls.push(url);
+    return reply(url);
+  };
+  return { fn, calls };
+}
 
 beforeEach(async () => {
   conn = await setupTestDb();
@@ -234,18 +249,63 @@ describe("refreshContextItems — error handling", () => {
     );
   });
 
-  test("errors for service-drive items (refresh not implemented)", async () => {
+  test("errors when drive is unknown and source_url is null", async () => {
+    const { refreshContextItems } = await import(
+      "../../src/context/refresh.ts"
+    );
+    const item = await createContextItem(conn, {
+      title: "unknown service doc",
+      content: "stored",
+      drive: "notion",
+      path: "/abc123",
+      mimeType: "text/markdown",
+      isTextual: true,
+    });
+
+    const { fn, calls } = makeFakeFetchFn(() => {
+      throw new Error("fetchFn should not be called");
+    });
+
+    const result = await refreshContextItems(
+      conn,
+      [item],
+      config,
+      null,
+      {},
+      mockEmbed,
+      fn,
+    );
+
+    expect(result.items[0]?.status).toBe("error");
+    expect(result.items[0]?.error).toMatch(/no source_url/);
+    expect(result.items[0]?.error).toContain("notion:/abc123");
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe("refreshContextItems — service drives", () => {
+  test("google-docs refresh uses source_url when present", async () => {
     const { refreshContextItems } = await import(
       "../../src/context/refresh.ts"
     );
     const gdoc = await createContextItem(conn, {
       title: "some doc",
-      content: "stored",
+      content: "stale",
       drive: "google-docs",
       path: "/abc123",
       mimeType: "text/markdown",
       isTextual: true,
+      sourceUrl: "https://docs.google.com/document/d/abc123/edit",
     });
+
+    const { fn, calls } = makeFakeFetchFn((url) => ({
+      title: "some doc",
+      content: "fresh content",
+      mimeType: "text/markdown",
+      sourceUrl: url,
+      drive: "google-docs",
+      path: "/abc123",
+    }));
 
     const result = await refreshContextItems(
       conn,
@@ -254,9 +314,83 @@ describe("refreshContextItems — error handling", () => {
       null,
       {},
       mockEmbed,
+      fn,
     );
 
+    expect(calls).toEqual(["https://docs.google.com/document/d/abc123/edit"]);
+    expect(result.items[0]?.status).toBe("updated");
+    expect(result.updated).toBe(1);
+    expect(result.reembedded).toBe(1);
+
+    const fresh = await getContextItemById(conn, gdoc.id);
+    expect(fresh?.content).toBe("fresh content");
+  });
+
+  test("service-drive refresh errors when source_url is null (no remote-service reconstruction)", async () => {
+    const { refreshContextItems } = await import(
+      "../../src/context/refresh.ts"
+    );
+    const legacy = await createContextItem(conn, {
+      title: "legacy doc",
+      content: "stale",
+      drive: "google-docs",
+      path: "/legacy-id",
+      mimeType: "text/markdown",
+      isTextual: true,
+    });
+
+    const { fn, calls } = makeFakeFetchFn(() => {
+      throw new Error("fetchFn should not be called without source_url");
+    });
+
+    const result = await refreshContextItems(
+      conn,
+      [legacy],
+      config,
+      null,
+      {},
+      mockEmbed,
+      fn,
+    );
+
+    expect(calls).toHaveLength(0);
     expect(result.items[0]?.status).toBe("error");
-    expect(result.items[0]?.error).toContain("google-docs");
+    expect(result.items[0]?.error).toMatch(/no source_url/);
+  });
+
+  test("url-drive refresh passes the stored URL through fetchFn", async () => {
+    const { refreshContextItems } = await import(
+      "../../src/context/refresh.ts"
+    );
+    const item = await createContextItem(conn, {
+      title: "example",
+      content: "stale",
+      drive: "url",
+      path: "/https://example.com/post",
+      mimeType: "text/markdown",
+      isTextual: true,
+    });
+
+    const { fn, calls } = makeFakeFetchFn((url) => ({
+      title: "example",
+      content: "stale", // unchanged
+      mimeType: "text/markdown",
+      sourceUrl: url,
+      drive: "url",
+      path: "/https://example.com/post",
+    }));
+
+    const result = await refreshContextItems(
+      conn,
+      [item],
+      config,
+      null,
+      {},
+      mockEmbed,
+      fn,
+    );
+
+    expect(calls).toEqual(["https://example.com/post"]);
+    expect(result.items[0]?.status).toBe("unchanged");
   });
 });

--- a/test/db/schema.test.ts
+++ b/test/db/schema.test.ts
@@ -65,7 +65,7 @@ describe("schema migrations", () => {
     )) as {
       count: number;
     };
-    expect(row.count).toBe(15);
+    expect(row.count).toBe(16);
 
     db.close();
   });


### PR DESCRIPTION
## Summary

`context refresh --all` previously punted on service-specific drives (google-docs, github, ...) with *Refresh not implemented for drive 'X' — re-add from the original URL*. Any doc or repo pulled in via MCP became stale-and-stuck.

- Capture `FetchedContent.sourceUrl` into a new nullable `context_items.source_url` column at ingest time.
- `refreshContextItems` routes any drive with a recorded `source_url` through `fetchUrl` exactly like the `url` drive already did. The `url` drive still falls back to its path for back-compat.
- Legacy rows without `source_url` and drives whose origin isn't a URL surface a per-item "re-add from URL" error. Refresh has no knowledge of any specific remote service — everything goes through `source_url`.

Bundled cleanups:
- `chunkByTextSplit` fallback when the LLM chunker errors/times out, so ingestion degrades instead of failing outright.
- `CHECKPOINT` after `rebuildSearchIndex` to flush the FTS index drop out of the WAL, avoiding replay corruption on reopen.
- Log each pending migration as it's applied.

## Test plan

- [x] `bun run lint` passes
- [x] `bun test` — 714 pass, 0 fail
- [x] New refresh tests: google-docs with `source_url` succeeds, legacy google-docs row errors with "no source_url", url-drive still works
- [x] New chunker test: LLM chunker throw triggers deterministic fallback
- [ ] `bun dev context refresh --all` against a real google-docs item that was edited in Google Docs flips to `updated` with a non-zero `reembedded` count

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)