### PR TITLE
Restructure MCP prompt section to lead with context-first rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/chat/agent.ts
+++ b/src/chat/agent.ts
@@ -115,9 +115,26 @@ Format your responses using Markdown. Use headings, bold, italic, lists, and cod
     prompt += `
 ## External Tools (MCP)
 
-Before reaching for MCP tools to **find** information, check local context first — content from Drive, Gmail, GitHub, URLs, and prior agent runs is often already ingested. Use \`search_semantic\` (semantic) or \`context_search\` (keyword) across drives, then \`context_read\` / \`context_tree\` to drill in. Only fall through to \`mcp_exec\` when the data is fresh, write-side (sending an email, creating an issue), or genuinely missing locally.
+### Local context first
 
-You have access to external tools via MCP servers. Before calling any MCP tool you haven't used yet this session, you MUST fetch its schema first:
+**Before any MCP read, search local context.** Drive, Gmail, GitHub, URLs, and prior agent runs are usually already ingested — refetching is slower, costs tokens, and risks rate limits.
+
+Workflow for any "look up / find / read" intent:
+
+1. \`search_semantic\` (semantic) or \`context_search\` (keyword), then \`context_read\` / \`context_tree\` to drill in.
+2. If freshness matters, call \`context_info\` and check \`indexed_at\`. To re-pull a single stale item, use \`context_refresh\` rather than going to MCP for the whole document.
+3. Only call \`mcp_exec\` for reads when the data is genuinely missing locally **or** must be real-time (e.g., "what's on my calendar right now").
+
+Writes always go through MCP — sending an email, creating an issue, posting to Slack. Don't search context first for those.
+
+Examples:
+- "What does doc X say?" → \`search_semantic\` first.
+- "Any new emails from Y?" → check the \`gmail\` drive first; only hit Gmail MCP if the freshest indexed item is too old for the question.
+- "Send an email to Y" → MCP write directly; no context lookup.
+
+### Calling MCP tools
+
+Before calling any MCP tool you haven't used yet this session, you MUST fetch its schema first:
 
 1. Discover tools with \`mcp_search\` (preferred — semantic) or \`mcp_list_tools\`.
 2. Call \`mcp_info\` with the exact \`server\` and \`tool\` to read the tool's input schema, required fields, and types.

--- a/src/worker/prompt.ts
+++ b/src/worker/prompt.ts
@@ -131,9 +131,26 @@ When calling complete_task, write a summary that captures your key findings, dec
     prompt += `
 ## External Tools (MCP)
 
-Before reaching for MCP tools to **find** information, check local context first — content from Drive, Gmail, GitHub, URLs, and prior agent runs is often already ingested. Use \`search_semantic\` (semantic) or \`context_search\` (keyword) across drives, then \`context_read\` / \`context_tree\` to drill in. Only fall through to \`mcp_exec\` when the data is fresh, write-side (sending an email, creating an issue), or genuinely missing locally.
+### Local context first
 
-You have access to external tools via MCP servers. Before calling any MCP tool you haven't used yet this session, you MUST fetch its schema first:
+**Before any MCP read, search local context.** Drive, Gmail, GitHub, URLs, and prior agent runs are usually already ingested — refetching is slower, costs tokens, and risks rate limits.
+
+Workflow for any "look up / find / read" intent:
+
+1. \`search_semantic\` (semantic) or \`context_search\` (keyword), then \`context_read\` / \`context_tree\` to drill in.
+2. If freshness matters, call \`context_info\` and check \`indexed_at\`. To re-pull a single stale item, use \`context_refresh\` rather than going to MCP for the whole document.
+3. Only call \`mcp_exec\` for reads when the data is genuinely missing locally **or** must be real-time (e.g., "what's on my calendar right now").
+
+Writes always go through MCP — sending an email, creating an issue, posting to Slack. Don't search context first for those.
+
+Examples:
+- "What does doc X say?" → \`search_semantic\` first.
+- "Any new emails from Y?" → check the \`gmail\` drive first; only hit Gmail MCP if the freshest indexed item is too old for the question.
+- "Send an email to Y" → MCP write directly; no context lookup.
+
+### Calling MCP tools
+
+Before calling any MCP tool you haven't used yet this session, you MUST fetch its schema first:
 
 1. Discover tools with \`mcp_search\` (preferred — semantic) or \`mcp_list_tools\`.
 2. Call \`mcp_info\` with the exact \`server\` and \`tool\` to read the tool's input schema, required fields, and types.

--- a/test/chat/agent.test.ts
+++ b/test/chat/agent.test.ts
@@ -143,14 +143,19 @@ describe("buildChatSystemPrompt", () => {
       hasMcpTools: true,
     });
     expect(prompt).toContain("## External Tools (MCP)");
+    expect(prompt).toContain("### Local context first");
+    expect(prompt).toContain("### Calling MCP tools");
+    expect(prompt).toContain("Before any MCP read, search local context");
     expect(prompt).toContain("MUST fetch its schema first");
     expect(prompt).toContain("`mcp_info`");
     expect(prompt).toContain("`mcp_exec`");
     expect(prompt).toContain("`mcp_search`");
     expect(prompt).toContain("`mcp_list_tools`");
-    expect(prompt).toContain("check local context first");
     expect(prompt).toContain("`search_semantic`");
     expect(prompt).toContain("`context_search`");
+    expect(prompt).toContain("`context_info`");
+    expect(prompt).toContain("`context_refresh`");
+    expect(prompt).toContain("MCP write directly");
   });
 
   test("omits MCP section when hasMcpTools is false or absent", async () => {

--- a/test/worker/prompt.test.ts
+++ b/test/worker/prompt.test.ts
@@ -194,14 +194,19 @@ describe("buildSystemPrompt", () => {
       },
     );
     expect(prompt).toContain("## External Tools (MCP)");
+    expect(prompt).toContain("### Local context first");
+    expect(prompt).toContain("### Calling MCP tools");
+    expect(prompt).toContain("Before any MCP read, search local context");
     expect(prompt).toContain("MUST fetch its schema first");
     expect(prompt).toContain("`mcp_info`");
     expect(prompt).toContain("`mcp_exec`");
     expect(prompt).toContain("`mcp_search`");
     expect(prompt).toContain("`mcp_list_tools`");
-    expect(prompt).toContain("check local context first");
     expect(prompt).toContain("`search_semantic`");
     expect(prompt).toContain("`context_search`");
+    expect(prompt).toContain("`context_info`");
+    expect(prompt).toContain("`context_refresh`");
+    expect(prompt).toContain("MCP write directly");
   });
 
   test("omits MCP section when hasMcpTools is false or absent", async () => {


### PR DESCRIPTION
## Summary

Resolves the buried-instruction problem from #149: the agent was still hitting MCP/Google Docs/Gmail for content already ingested into Botholomew's context drives because the "check local context first" guidance was a single sentence at the top of an MCP-procedural section.

This PR splits the `## External Tools (MCP)` block in both prompt builders (`src/worker/prompt.ts` and `src/chat/agent.ts`) into two named subsections:

- **`### Local context first`** — Bolded decision rule, an ordered workflow (`search_semantic` / `context_search` → `context_read` / `context_tree`), a freshness step using `context_info` / `indexed_at` and `context_refresh` for targeted re-pulls, an explicit write-side carve-out (sending email / creating issue → MCP directly, no context lookup), and three scenario examples.
- **`### Calling MCP tools`** — The existing `mcp_search` / `mcp_info` / `mcp_exec` schema handshake, unchanged in substance, just under its own heading.

Both prompt builders stay byte-identical in this region. Tests in `test/worker/prompt.test.ts` and `test/chat/agent.test.ts` updated to assert the new structure (subsection headers, freshness tools, write-side example).

Bumps `package.json` to `0.9.7`.

Closes https://github.com/evantahler/botholomew/issues/149

## Test plan

- [x] `bun run lint` — passes (tsc + biome)
- [x] `bun test` — 714 / 714 pass
- [x] Updated prompt tests assert the new subsection headers and freshness-tool references

🤖 Generated with [Claude Code](https://claude.com/claude-code)