### PR TITLE
Add delete_task tool so chat agent can clean up tasks

### DIFF
--- a/docs/tasks-and-schedules.md
+++ b/docs/tasks-and-schedules.md
@@ -195,5 +195,8 @@ botholomew schedule trigger <id>
 ```
 
 All of the same operations are available to the chat agent (`create_task`,
-`list_tasks`, `view_task`, `update_task`, `create_schedule`,
+`list_tasks`, `view_task`, `update_task`, `delete_task`, `create_schedule`,
 `list_schedules`) so you can drive the queue conversationally too.
+`delete_task` refuses tasks in `in_progress` — the worker has no
+mid-execution interrupt, so wait for it to finish or run
+`botholomew task reset <id>` from the CLI first.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -35,6 +35,7 @@ import { searchSemanticTool } from "./search/semantic.ts";
 // Task tools
 import { completeTaskTool } from "./task/complete.ts";
 import { createTaskTool } from "./task/create.ts";
+import { deleteTaskTool } from "./task/delete.ts";
 import { failTaskTool } from "./task/fail.ts";
 import { listTasksTool } from "./task/list.ts";
 import { updateTaskTool } from "./task/update.ts";
@@ -54,6 +55,7 @@ export function registerAllTools(): void {
   registerTool(waitTaskTool);
   registerTool(createTaskTool);
   registerTool(updateTaskTool);
+  registerTool(deleteTaskTool);
   registerTool(listTasksTool);
   registerTool(viewTaskTool);
 

--- a/src/tools/task/delete.ts
+++ b/src/tools/task/delete.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+import { deleteTask, getTask } from "../../db/tasks.ts";
+import { logger } from "../../utils/logger.ts";
+import type { ToolDefinition } from "../tool.ts";
+
+const inputSchema = z.object({
+  id: z.string().describe("ID of the task to delete"),
+});
+
+const outputSchema = z.object({
+  deleted_id: z.string().nullable(),
+  message: z.string(),
+  is_error: z.boolean(),
+});
+
+export const deleteTaskTool = {
+  name: "delete_task",
+  description:
+    "[[ bash equivalent command: rm ]] Delete a task permanently. Refuses in_progress tasks; wait for the worker to finish or run `botholomew task reset <id>` first.",
+  group: "task",
+  inputSchema,
+  outputSchema,
+  execute: async (input, ctx) => {
+    const existing = await getTask(ctx.conn, input.id);
+    if (!existing) {
+      return {
+        deleted_id: null,
+        message: `Task ${input.id} not found`,
+        is_error: true,
+      };
+    }
+    if (existing.status === "in_progress") {
+      return {
+        deleted_id: null,
+        message: `Cannot delete task ${input.id}: it is currently in_progress (claimed by ${existing.claimed_by ?? "unknown"}). Wait for the worker to finish, or reset it first via \`botholomew task reset ${input.id}\`.`,
+        is_error: true,
+      };
+    }
+    const ok = await deleteTask(ctx.conn, input.id);
+    if (!ok) {
+      return {
+        deleted_id: null,
+        message: `Failed to delete task ${input.id}`,
+        is_error: true,
+      };
+    }
+    logger.info(`Deleted task: ${existing.name} (${existing.id})`);
+    return {
+      deleted_id: existing.id,
+      message: `Deleted task "${existing.name}" (${existing.id})`,
+      is_error: false,
+    };
+  },
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/test/tools/task.test.ts
+++ b/test/tools/task.test.ts
@@ -1,8 +1,14 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import type { DbConnection } from "../../src/db/connection.ts";
-import { updateTaskStatus } from "../../src/db/tasks.ts";
+import {
+  claimSpecificTask,
+  createTask,
+  getTask,
+  updateTaskStatus,
+} from "../../src/db/tasks.ts";
 import { completeTaskTool } from "../../src/tools/task/complete.ts";
 import { createTaskTool } from "../../src/tools/task/create.ts";
+import { deleteTaskTool } from "../../src/tools/task/delete.ts";
 import { failTaskTool } from "../../src/tools/task/fail.ts";
 import { updateTaskTool } from "../../src/tools/task/update.ts";
 import { waitTaskTool } from "../../src/tools/task/wait.ts";
@@ -127,6 +133,79 @@ describe("update_task", () => {
       id: "abc",
       priority: "urgent",
     });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ── delete_task ────────────────────────────────────────────
+
+describe("delete_task", () => {
+  test("deletes a pending task", async () => {
+    const task = await createTask(conn, { name: "scratch" });
+
+    const result = await deleteTaskTool.execute({ id: task.id }, ctx);
+
+    expect(result.is_error).toBe(false);
+    expect(result.deleted_id).toBe(task.id);
+    expect(result.message).toContain("scratch");
+    expect(await getTask(conn, task.id)).toBeNull();
+  });
+
+  test("deletes a failed task", async () => {
+    const task = await createTask(conn, { name: "broken" });
+    await updateTaskStatus(conn, task.id, "failed", "boom");
+
+    const result = await deleteTaskTool.execute({ id: task.id }, ctx);
+
+    expect(result.is_error).toBe(false);
+    expect(await getTask(conn, task.id)).toBeNull();
+  });
+
+  test("deletes a complete task", async () => {
+    const task = await createTask(conn, { name: "done" });
+    await updateTaskStatus(conn, task.id, "complete", null, "ok");
+
+    const result = await deleteTaskTool.execute({ id: task.id }, ctx);
+
+    expect(result.is_error).toBe(false);
+    expect(await getTask(conn, task.id)).toBeNull();
+  });
+
+  test("deletes a waiting task", async () => {
+    const task = await createTask(conn, { name: "paused" });
+    await updateTaskStatus(conn, task.id, "waiting", "blocked on user");
+
+    const result = await deleteTaskTool.execute({ id: task.id }, ctx);
+
+    expect(result.is_error).toBe(false);
+    expect(await getTask(conn, task.id)).toBeNull();
+  });
+
+  test("refuses to delete an in_progress task and names the worker", async () => {
+    const task = await createTask(conn, { name: "running" });
+    const claimed = await claimSpecificTask(conn, task.id, "worker-1");
+    expect(claimed?.status).toBe("in_progress");
+
+    const result = await deleteTaskTool.execute({ id: task.id }, ctx);
+
+    expect(result.is_error).toBe(true);
+    expect(result.deleted_id).toBeNull();
+    expect(result.message).toContain("in_progress");
+    expect(result.message).toContain("worker-1");
+    expect(result.message).toContain("botholomew task reset");
+    expect(await getTask(conn, task.id)).not.toBeNull();
+  });
+
+  test("returns not-found error for unknown id", async () => {
+    const result = await deleteTaskTool.execute({ id: "nonexistent" }, ctx);
+
+    expect(result.is_error).toBe(true);
+    expect(result.deleted_id).toBeNull();
+    expect(result.message).toContain("not found");
+  });
+
+  test("validates input schema rejects missing id", () => {
+    const result = deleteTaskTool.inputSchema.safeParse({});
     expect(result.success).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Adds `delete_task` to the chat-agent tool registry, mirroring `botholomew task delete <id>` from the CLI.
- Refuses `in_progress` tasks (the worker has no mid-execution interrupt) and surfaces the worker id plus the `botholomew task reset <id>` recovery hint in the error message.
- Allowed states: `pending`, `waiting`, `failed`, `complete`. Built on the existing `deleteTask()` in `src/db/tasks.ts`.
- Tool description prefixed with `[[ bash equivalent command: rm ]]` per the project's tool-naming convention.
- Updates `docs/tasks-and-schedules.md` to list the new tool and document the `in_progress` refusal.
- Bumps `package.json` to `0.9.7` for the auto-release workflow.

## Test plan
- [x] `bun run lint` (tsc + biome)
- [x] `bun test` — 721 pass / 0 fail (7 new cases in `test/tools/task.test.ts` covering pending/failed/complete/waiting deletes, in_progress refusal, not-found, and schema validation)
- [ ] Manual smoke: `botholomew chat` and ask the agent to delete a task in each terminal state

🤖 Generated with [Claude Code](https://claude.com/claude-code)