### PR TITLE
Add chat-agent tools to create, edit, and search skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ through MCP servers wired up via [MCPX](https://github.com/evantahler/mcpx).
   Slack, GitHub) or connect through an MCP gateway like
   [Arcade.dev](https://www.arcade.dev/) to reach hundreds of
   authenticated services without managing each server yourself.
-  Reusable workflows are defined as markdown "skills" (slash commands).
+  Reusable workflows are defined as markdown "skills" (slash commands)
+  that the chat agent can also create, edit, and search at runtime.
 - **Safe by default.** The agent has no shell and no direct filesystem
   access. Out of the box, everything it can touch lives in `.botholomew/`;
   every external capability is a MCP server you explicitly add.
@@ -47,7 +48,8 @@ through MCP servers wired up via [MCPX](https://github.com/evantahler/mcpx).
   back into the queue automatically.
 - **Self-modifying.** The agent maintains its own `beliefs.md` and
   `goals.md` — it learns, updates its priors, and revises its goals as it
-  works.
+  works. It can also author its own slash-command skills mid-conversation,
+  turning prompts you keep retyping into durable project assets.
 
 ---
 
@@ -209,7 +211,8 @@ Topics worth understanding in detail:
 - **[Persistent context](docs/persistent-context.md)** — `soul.md`,
   `beliefs.md`, `goals.md`, frontmatter flags, and agent self-modification.
 - **[Skills (slash commands)](docs/skills.md)** — reusable prompt templates
-  with positional arguments and tab completion.
+  with positional arguments and tab completion; the chat agent can also
+  create, edit, and search them at runtime.
 - **[MCPX integration](docs/mcpx.md)** — configuring external servers and
   how MCP tools are merged into the agent's toolset.
 - **[Configuration](docs/configuration.md)** — every key in `config.json`

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -116,6 +116,45 @@ skill is invoked, so it's visually distinct from a regular message.
 
 ---
 
+## Managing skills from chat
+
+Skills aren't write-once-via-CLI: the chat agent can list, read, create,
+edit, and search them on demand. Five tools are exposed to the chat
+agent:
+
+| Tool | What it does |
+|---|---|
+| `skill_list` | List skills (name, description, args, file path) |
+| `skill_read` | Read a skill's raw file contents and parsed fields |
+| `skill_search` | Keyword search across name, description, body, and arg metadata |
+| `skill_write` | Create or overwrite a skill (`on_conflict: 'error' \| 'overwrite'`) |
+| `skill_edit` | Apply git-style line-range patches to an existing skill |
+
+Newly written or edited skills are picked up at the start of the *next*
+user message — `ChatSession.skills` is reloaded from disk in
+`sendMessage`. So a typical flow looks like:
+
+```
+> save this prompt as a skill called daily-log so I can run it tomorrow
+[agent calls skill_write]
+> /daily-log              # works immediately, no chat restart needed
+```
+
+`skill_write` rejects the reserved built-in names (`help`, `skills`,
+`clear`, `exit`) with `error_type: "reserved_name"`. It also normalizes
+names to `[a-z0-9-]`, sets the frontmatter `name` to match the
+filename, and re-parses the generated file before writing — so an
+invalid skill never lands on disk.
+
+`skill_edit` re-parses after applying patches and refuses to write
+if the result fails validation, so you can't break a skill from chat.
+
+**Editing skills outside the chat** (e.g., with your text editor) still
+requires a chat restart — the in-memory cache is only refreshed inside
+`sendMessage`.
+
+---
+
 ## CLI management
 
 ```bash
@@ -132,9 +171,12 @@ non-zero if any file fails to parse, so it fits naturally into a
 pre-commit hook or CI check.
 
 Skills are parsed by `src/skills/parser.ts` and loaded from disk by
-`src/skills/loader.ts` at chat-session start. They're cached on the
-`ChatSession` object, so changes require restarting the chat — but not
-the daemon.
+`src/skills/loader.ts`. The `ChatSession` caches them on session start
+and reloads them at the top of every `sendMessage` — so skills the
+chat agent creates or edits via the `skill_*` tools are usable on the
+next user message. Direct file edits made outside the running chat
+(e.g., from your editor) take effect on the next user message in any
+active session, but won't appear retroactively in history.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/chat/agent.ts
+++ b/src/chat/agent.ts
@@ -52,6 +52,11 @@ const CHAT_TOOL_NAMES = new Set([
   "mcp_exec",
   "read_large_result",
   "spawn_worker",
+  "skill_list",
+  "skill_read",
+  "skill_write",
+  "skill_edit",
+  "skill_search",
 ]);
 
 export function getChatTools() {
@@ -108,6 +113,7 @@ You do NOT execute long-running work directly — enqueue tasks for a background
 Use the available tools to look up tasks, threads, schedules, and context when the user asks about them. Context items live under a drive (disk / url / agent / google-docs / github / …); use \`context_list_drives\` to discover which drives have content, then \`context_tree\`, \`context_info\`, \`context_search\`, or \`context_refresh\` as needed.
 When multiple tool calls are independent of each other (i.e., one does not depend on the result of another), call them all in a single response. They will be executed in parallel, which is faster than calling them one at a time.
 You can update the agent's beliefs and goals files when the user asks you to.
+You can author and refine slash-command skills (reusable prompt templates stored in \`.botholomew/skills/\`) via \`skill_list\`, \`skill_search\`, \`skill_read\`, \`skill_write\`, and \`skill_edit\`. New or edited skills are usable as \`/<name>\` on the user's next message.
 Format your responses using Markdown. Use headings, bold, italic, lists, and code blocks to make your responses clear and well-structured.
 `;
 

--- a/src/chat/session.ts
+++ b/src/chat/session.ts
@@ -104,6 +104,10 @@ export async function sendMessage(
   userMessage: string,
   callbacks: ChatTurnCallbacks,
 ): Promise<void> {
+  // Hot-reload skills so any skill the agent created/edited last turn (or any
+  // out-of-band edit) is visible to slash-command dispatch this turn.
+  session.skills = await loadSkills(session.projectDir);
+
   // Log and append user message
   await withDb(session.dbPath, (conn) =>
     logInteraction(conn, session.threadId, {

--- a/src/skills/writer.ts
+++ b/src/skills/writer.ts
@@ -1,0 +1,63 @@
+import matter from "gray-matter";
+import { BUILTIN_SLASH_COMMANDS } from "./commands.ts";
+import type { SkillArgDef } from "./parser.ts";
+
+export const RESERVED_SKILL_NAMES = new Set(
+  BUILTIN_SLASH_COMMANDS.map((c) => c.name),
+);
+
+const MAX_NAME_LENGTH = 64;
+
+export type ValidateNameResult =
+  | { ok: true; normalized: string }
+  | { ok: false; reason: "empty" | "invalid" | "reserved" | "too_long" };
+
+export function validateSkillName(raw: string): ValidateNameResult {
+  if (typeof raw !== "string" || raw.trim() === "") {
+    return { ok: false, reason: "empty" };
+  }
+
+  const normalized = raw
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  if (normalized === "") return { ok: false, reason: "invalid" };
+  if (normalized.length > MAX_NAME_LENGTH)
+    return { ok: false, reason: "too_long" };
+  if (RESERVED_SKILL_NAMES.has(normalized))
+    return { ok: false, reason: "reserved" };
+
+  return { ok: true, normalized };
+}
+
+export interface SkillFileInput {
+  name: string;
+  description: string;
+  arguments: SkillArgDef[];
+  body: string;
+}
+
+export function buildSkillFileContent(input: SkillFileInput): string {
+  const data: Record<string, unknown> = {
+    name: input.name,
+    description: input.description,
+  };
+
+  if (input.arguments.length > 0) {
+    data.arguments = input.arguments.map((a) => {
+      const out: Record<string, unknown> = {
+        name: a.name,
+        description: a.description,
+        required: a.required,
+      };
+      if (a.default !== undefined) out.default = a.default;
+      return out;
+    });
+  } else {
+    data.arguments = [];
+  }
+
+  return matter.stringify(input.body, data);
+}

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -32,6 +32,12 @@ import { listSchedulesTool } from "./schedule/list.ts";
 // Search tools
 import { searchGrepTool } from "./search/grep.ts";
 import { searchSemanticTool } from "./search/semantic.ts";
+// Skill tools
+import { skillEditTool } from "./skill/edit.ts";
+import { skillListTool } from "./skill/list.ts";
+import { skillReadTool } from "./skill/read.ts";
+import { skillSearchTool } from "./skill/search.ts";
+import { skillWriteTool } from "./skill/write.ts";
 // Task tools
 import { completeTaskTool } from "./task/complete.ts";
 import { createTaskTool } from "./task/create.ts";
@@ -87,6 +93,13 @@ export function registerAllTools(): void {
   // Search
   registerTool(searchGrepTool);
   registerTool(searchSemanticTool);
+
+  // Skill
+  registerTool(skillListTool);
+  registerTool(skillReadTool);
+  registerTool(skillWriteTool);
+  registerTool(skillEditTool);
+  registerTool(skillSearchTool);
 
   // Thread
   registerTool(listThreadsTool);

--- a/src/tools/skill/edit.ts
+++ b/src/tools/skill/edit.ts
@@ -1,0 +1,114 @@
+import { join } from "node:path";
+import { z } from "zod";
+import { getSkillsDir } from "../../constants.ts";
+import { parseSkillFile } from "../../skills/parser.ts";
+import type { ToolDefinition } from "../tool.ts";
+
+const PatchSchema = z.object({
+  start_line: z.number().describe("1-based inclusive start line"),
+  end_line: z
+    .number()
+    .describe("1-based inclusive end line (0 to insert without replacing)"),
+  content: z
+    .string()
+    .describe("Replacement text (empty string to delete lines)"),
+});
+
+const inputSchema = z.object({
+  name: z.string().describe("Skill name (case-insensitive)"),
+  patches: z.array(PatchSchema).describe("Patches to apply"),
+});
+
+const outputSchema = z.object({
+  name: z.string(),
+  path: z.string().nullable(),
+  applied: z.number(),
+  content: z.string(),
+  is_error: z.boolean(),
+  error_type: z.string().optional(),
+  message: z.string().optional(),
+  next_action_hint: z.string().optional(),
+});
+
+function applyPatches(
+  raw: string,
+  patches: Array<{ start_line: number; end_line: number; content: string }>,
+): string {
+  const lines = raw.split("\n");
+  const sorted = [...patches].sort((a, b) => b.start_line - a.start_line);
+
+  for (const patch of sorted) {
+    if (patch.end_line === 0) {
+      const insertLines = patch.content === "" ? [] : patch.content.split("\n");
+      lines.splice(patch.start_line - 1, 0, ...insertLines);
+    } else {
+      const deleteCount = patch.end_line - patch.start_line + 1;
+      const insertLines = patch.content === "" ? [] : patch.content.split("\n");
+      lines.splice(patch.start_line - 1, deleteCount, ...insertLines);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+export const skillEditTool = {
+  name: "skill_edit",
+  description:
+    "[[ bash equivalent command: patch ]] Apply git-style line-range patches to a skill file (user-defined slash command). Operates on the whole file (frontmatter + body). Patches whose result would not parse as a valid skill are rejected without writing. Use skill_read first to inspect current line numbers.",
+  group: "skill",
+  inputSchema,
+  outputSchema,
+  execute: async (input, ctx) => {
+    const normalized = input.name.toLowerCase();
+    const filePath = join(getSkillsDir(ctx.projectDir), `${normalized}.md`);
+
+    const file = Bun.file(filePath);
+    if (!(await file.exists())) {
+      return {
+        name: normalized,
+        path: null,
+        applied: 0,
+        content: "",
+        is_error: true,
+        error_type: "not_found",
+        message: `Skill not found: ${input.name}`,
+        next_action_hint:
+          "Use skill_list to see available skills, or skill_write to create one.",
+      };
+    }
+
+    const original = await file.text();
+    const updated = applyPatches(original, input.patches);
+
+    try {
+      const parsed = parseSkillFile(updated, filePath);
+      if (parsed.name !== normalized) {
+        throw new Error(
+          `frontmatter name '${parsed.name}' no longer matches filename '${normalized}'`,
+        );
+      }
+    } catch (err) {
+      return {
+        name: normalized,
+        path: filePath,
+        applied: 0,
+        content: original,
+        is_error: true,
+        error_type: "invalid_skill",
+        message: `Patched content failed validation: ${err instanceof Error ? err.message : String(err)}`,
+        next_action_hint:
+          "Check that frontmatter YAML stays valid and the file still has a name/description.",
+      };
+    }
+
+    await Bun.write(filePath, updated);
+
+    return {
+      name: normalized,
+      path: filePath,
+      applied: input.patches.length,
+      content: updated,
+      is_error: false,
+    };
+  },
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/skill/list.ts
+++ b/src/tools/skill/list.ts
@@ -1,0 +1,63 @@
+import { basename } from "node:path";
+import { z } from "zod";
+import { loadSkills } from "../../skills/loader.ts";
+import type { ToolDefinition } from "../tool.ts";
+
+const inputSchema = z.object({
+  limit: z
+    .number()
+    .optional()
+    .default(100)
+    .describe("Max number of skills to return (default 100)"),
+  offset: z
+    .number()
+    .optional()
+    .default(0)
+    .describe("Skip the first N skills (default 0)"),
+});
+
+const outputSchema = z.object({
+  skills: z.array(
+    z.object({
+      name: z.string(),
+      description: z.string(),
+      arguments: z.array(z.string()),
+      filename: z.string(),
+      path: z.string(),
+    }),
+  ),
+  total: z.number(),
+  is_error: z.boolean(),
+});
+
+export const skillListTool = {
+  name: "skill_list",
+  description:
+    "[[ bash equivalent command: ls ]] List skills (user-defined slash commands) loaded from .botholomew/skills/. Returns name, description, argument names, and file path for each.",
+  group: "skill",
+  inputSchema,
+  outputSchema,
+  execute: async (input, ctx) => {
+    const skills = await loadSkills(ctx.projectDir);
+    const sorted = [...skills.values()].sort((a, b) =>
+      a.name.localeCompare(b.name),
+    );
+
+    const total = sorted.length;
+    const offset = input.offset ?? 0;
+    const limit = input.limit ?? 100;
+    const page = sorted.slice(offset, offset + limit);
+
+    return {
+      skills: page.map((s) => ({
+        name: s.name,
+        description: s.description,
+        arguments: s.arguments.map((a) => a.name),
+        filename: basename(s.filePath),
+        path: s.filePath,
+      })),
+      total,
+      is_error: false,
+    };
+  },
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/skill/read.ts
+++ b/src/tools/skill/read.ts
@@ -1,0 +1,72 @@
+import { z } from "zod";
+import { loadSkills } from "../../skills/loader.ts";
+import type { ToolDefinition } from "../tool.ts";
+
+const inputSchema = z.object({
+  name: z.string().describe("Skill name (case-insensitive)"),
+});
+
+const ArgSchema = z.object({
+  name: z.string(),
+  description: z.string(),
+  required: z.boolean(),
+  default: z.string().optional(),
+});
+
+const outputSchema = z.object({
+  name: z.string(),
+  path: z.string().nullable(),
+  raw: z.string().nullable(),
+  description: z.string(),
+  arguments: z.array(ArgSchema),
+  body: z.string(),
+  is_error: z.boolean(),
+  error_type: z.string().optional(),
+  message: z.string().optional(),
+  next_action_hint: z.string().optional(),
+});
+
+export const skillReadTool = {
+  name: "skill_read",
+  description:
+    "[[ bash equivalent command: cat ]] Read a skill file (user-defined slash command) by name. Returns the raw file contents plus parsed fields. Returns a not_found error with the list of available names when the skill doesn't exist.",
+  group: "skill",
+  inputSchema,
+  outputSchema,
+  execute: async (input, ctx) => {
+    const skills = await loadSkills(ctx.projectDir);
+    const skill = skills.get(input.name.toLowerCase());
+
+    if (!skill) {
+      const available = [...skills.keys()].sort();
+      const hint =
+        available.length > 0
+          ? `Available: ${available.join(", ")}. Use skill_list to browse.`
+          : "No skills exist yet. Use skill_write to create one.";
+      return {
+        name: input.name,
+        path: null,
+        raw: null,
+        description: "",
+        arguments: [],
+        body: "",
+        is_error: true,
+        error_type: "not_found",
+        message: `Skill not found: ${input.name}`,
+        next_action_hint: hint,
+      };
+    }
+
+    const raw = await Bun.file(skill.filePath).text();
+
+    return {
+      name: skill.name,
+      path: skill.filePath,
+      raw,
+      description: skill.description,
+      arguments: skill.arguments,
+      body: skill.body,
+      is_error: false,
+    };
+  },
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/skill/search.ts
+++ b/src/tools/skill/search.ts
@@ -1,0 +1,165 @@
+import { z } from "zod";
+import { loadSkills } from "../../skills/loader.ts";
+import type { SkillDefinition } from "../../skills/parser.ts";
+import type { ToolDefinition } from "../tool.ts";
+
+const inputSchema = z.object({
+  query: z
+    .string()
+    .describe(
+      "Search query (matched against name, description, body, and arg metadata)",
+    ),
+  top_k: z
+    .number()
+    .optional()
+    .default(10)
+    .describe("Maximum number of results to return (default 10)"),
+});
+
+const outputSchema = z.object({
+  results: z.array(
+    z.object({
+      name: z.string(),
+      description: z.string(),
+      score: z.number(),
+      match_fields: z.array(z.string()),
+      snippet: z.string(),
+    }),
+  ),
+  is_error: z.boolean(),
+  hint: z.string().optional(),
+});
+
+const SNIPPET_RADIUS = 60;
+
+function countOccurrences(haystack: string, needle: string): number {
+  if (needle === "") return 0;
+  let count = 0;
+  let from = 0;
+  while (true) {
+    const idx = haystack.indexOf(needle, from);
+    if (idx === -1) break;
+    count++;
+    from = idx + needle.length;
+  }
+  return count;
+}
+
+function buildSnippet(body: string, term: string): string {
+  const lower = body.toLowerCase();
+  const idx = lower.indexOf(term);
+  if (idx === -1) return body.slice(0, SNIPPET_RADIUS * 2);
+
+  const start = Math.max(0, idx - SNIPPET_RADIUS);
+  const end = Math.min(body.length, idx + term.length + SNIPPET_RADIUS);
+  const prefix = start > 0 ? "…" : "";
+  const suffix = end < body.length ? "…" : "";
+  return prefix + body.slice(start, end) + suffix;
+}
+
+interface ScoreEntry {
+  skill: SkillDefinition;
+  score: number;
+  matchFields: Set<string>;
+  firstBodyTerm: string | null;
+}
+
+function scoreSkill(skill: SkillDefinition, terms: string[]): ScoreEntry {
+  const name = skill.name.toLowerCase();
+  const desc = skill.description.toLowerCase();
+  const body = skill.body.toLowerCase();
+  const matchFields = new Set<string>();
+  let score = 0;
+  let firstBodyTerm: string | null = null;
+
+  for (const term of terms) {
+    if (term === "") continue;
+    if (name.includes(term)) {
+      score += 10;
+      matchFields.add("name");
+    }
+    if (desc.includes(term)) {
+      score += 5;
+      matchFields.add("description");
+    }
+    for (const arg of skill.arguments) {
+      if (arg.name.toLowerCase().includes(term)) {
+        score += 3;
+        matchFields.add("argument_name");
+      }
+      if (arg.description.toLowerCase().includes(term)) {
+        score += 2;
+        matchFields.add("argument_description");
+      }
+    }
+    const bodyHits = Math.min(countOccurrences(body, term), 5);
+    if (bodyHits > 0) {
+      score += bodyHits;
+      matchFields.add("body");
+      if (firstBodyTerm === null) firstBodyTerm = term;
+    }
+  }
+
+  return { skill, score, matchFields, firstBodyTerm };
+}
+
+export const skillSearchTool = {
+  name: "skill_search",
+  description:
+    "Keyword search over skills (user-defined slash commands). Matches against name, description, body, and argument metadata. Returns top-K ranked matches. Use skill_read after finding a match.",
+  group: "skill",
+  inputSchema,
+  outputSchema,
+  execute: async (input, ctx) => {
+    const skills = await loadSkills(ctx.projectDir);
+    const terms = input.query
+      .toLowerCase()
+      .split(/\s+/)
+      .filter((t) => t.length > 0);
+
+    if (skills.size === 0) {
+      return {
+        results: [],
+        is_error: false,
+        hint: "No skills exist yet. Use skill_write to create one.",
+      };
+    }
+
+    if (terms.length === 0) {
+      return {
+        results: [],
+        is_error: false,
+        hint: "Empty query. Provide one or more keywords, or use skill_list to browse.",
+      };
+    }
+
+    const scored = [...skills.values()].map((s) => scoreSkill(s, terms));
+    const matched = scored
+      .filter((e) => e.score > 0)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, input.top_k ?? 10);
+
+    if (matched.length === 0) {
+      return {
+        results: [],
+        is_error: false,
+        hint: "No matches. Try broader terms, or use skill_list to browse.",
+      };
+    }
+
+    const fallbackTerm = terms[0] ?? "";
+    return {
+      results: matched.map((e) => {
+        const snippetTerm = e.firstBodyTerm ?? fallbackTerm;
+        return {
+          name: e.skill.name,
+          description: e.skill.description,
+          score: e.score,
+          match_fields: [...e.matchFields].sort(),
+          snippet: buildSnippet(e.skill.body, snippetTerm),
+        };
+      }),
+      is_error: false,
+    };
+  },
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/skill/write.ts
+++ b/src/tools/skill/write.ts
@@ -1,0 +1,180 @@
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { z } from "zod";
+import { getSkillsDir } from "../../constants.ts";
+import { parseSkillFile } from "../../skills/parser.ts";
+import {
+  buildSkillFileContent,
+  validateSkillName,
+} from "../../skills/writer.ts";
+import type { ToolDefinition } from "../tool.ts";
+
+const ArgInputSchema = z.object({
+  name: z
+    .string()
+    .min(1)
+    .describe("Argument name (referenced as $1, $2, … in the body)"),
+  description: z.string().optional().describe("Argument description"),
+  required: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe("Whether the argument is required"),
+  default: z
+    .string()
+    .optional()
+    .describe("Default value when the argument is omitted"),
+});
+
+const inputSchema = z.object({
+  name: z
+    .string()
+    .describe(
+      "Skill name (slash-command identifier). Will be normalized to lowercase + [a-z0-9-]. Reserved: help, skills, clear, exit.",
+    ),
+  description: z
+    .string()
+    .describe("Short description shown in /skills and /help"),
+  body: z
+    .string()
+    .describe(
+      "Prompt-template body (markdown). Use $ARGUMENTS or $1..$9 for argument substitution.",
+    ),
+  arguments: z
+    .array(ArgInputSchema)
+    .optional()
+    .describe("Argument definitions (positional)"),
+  on_conflict: z
+    .enum(["error", "overwrite"])
+    .optional()
+    .default("error")
+    .describe(
+      "What to do if a skill with this name already exists. Defaults to 'error'.",
+    ),
+});
+
+const outputSchema = z.object({
+  name: z.string().nullable(),
+  path: z.string().nullable(),
+  ref: z.string().nullable(),
+  created: z.boolean(),
+  is_error: z.boolean(),
+  error_type: z.string().optional(),
+  message: z.string().optional(),
+  next_action_hint: z.string().optional(),
+});
+
+export const skillWriteTool = {
+  name: "skill_write",
+  description:
+    "[[ bash equivalent command: tee ]] Create or overwrite a skill file (user-defined slash command) at .botholomew/skills/<name>.md. Fails with path_conflict when the file exists unless on_conflict='overwrite'. Reserved names (help, skills, clear, exit) are rejected. The generated file is parsed to validate before being written.",
+  group: "skill",
+  inputSchema,
+  outputSchema,
+  execute: async (input, ctx) => {
+    const nameCheck = validateSkillName(input.name);
+    if (!nameCheck.ok) {
+      const errorType =
+        nameCheck.reason === "reserved" ? "reserved_name" : "invalid_name";
+      const message =
+        nameCheck.reason === "reserved"
+          ? `'${input.name}' is reserved by a built-in slash command (help, skills, clear, exit).`
+          : nameCheck.reason === "too_long"
+            ? `Skill name too long (max 64 chars after normalization).`
+            : `'${input.name}' is not a valid skill name. After normalization (lowercase, [a-z0-9-], trimmed hyphens) it is empty.`;
+      return {
+        name: null,
+        path: null,
+        ref: null,
+        created: false,
+        is_error: true,
+        error_type: errorType,
+        message,
+        next_action_hint:
+          "Pick a different name made of lowercase letters, digits, and hyphens.",
+      };
+    }
+
+    const normalized = nameCheck.normalized;
+    const body = input.body.trim();
+    if (body === "") {
+      return {
+        name: normalized,
+        path: null,
+        ref: null,
+        created: false,
+        is_error: true,
+        error_type: "empty_body",
+        message: "Skill body is empty.",
+        next_action_hint:
+          "Provide a non-empty prompt template using $ARGUMENTS or $1..$9.",
+      };
+    }
+
+    const args = (input.arguments ?? []).map((a) => ({
+      name: a.name,
+      description: a.description ?? "",
+      required: a.required ?? false,
+      default: a.default,
+    }));
+
+    const skillsDir = getSkillsDir(ctx.projectDir);
+    const filePath = join(skillsDir, `${normalized}.md`);
+
+    const raw = buildSkillFileContent({
+      name: normalized,
+      description: input.description,
+      arguments: args,
+      body,
+    });
+
+    try {
+      const parsed = parseSkillFile(raw, filePath);
+      if (parsed.name !== normalized) {
+        throw new Error(
+          `frontmatter name '${parsed.name}' does not match expected '${normalized}'`,
+        );
+      }
+    } catch (err) {
+      return {
+        name: normalized,
+        path: null,
+        ref: null,
+        created: false,
+        is_error: true,
+        error_type: "invalid_skill",
+        message: `Generated skill content failed validation: ${err instanceof Error ? err.message : String(err)}`,
+        next_action_hint:
+          "Check description and body for unusual characters that break YAML.",
+      };
+    }
+
+    const onConflict = input.on_conflict ?? "error";
+    const existed = await Bun.file(filePath).exists();
+
+    if (existed && onConflict === "error") {
+      return {
+        name: normalized,
+        path: filePath,
+        ref: `skill:${normalized}`,
+        created: false,
+        is_error: true,
+        error_type: "path_conflict",
+        message: `Skill '${normalized}' already exists at ${filePath}.`,
+        next_action_hint:
+          "Retry with on_conflict='overwrite' to replace, or use skill_edit for a partial change.",
+      };
+    }
+
+    await mkdir(skillsDir, { recursive: true });
+    await Bun.write(filePath, raw);
+
+    return {
+      name: normalized,
+      path: filePath,
+      ref: `skill:${normalized}`,
+      created: !existed,
+      is_error: false,
+    };
+  },
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/test/tools/skill.test.ts
+++ b/test/tools/skill.test.ts
@@ -1,0 +1,534 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getSkillsDir } from "../../src/constants.ts";
+import { loadSkills } from "../../src/skills/loader.ts";
+import { skillEditTool } from "../../src/tools/skill/edit.ts";
+import { skillListTool } from "../../src/tools/skill/list.ts";
+import { skillReadTool } from "../../src/tools/skill/read.ts";
+import { skillSearchTool } from "../../src/tools/skill/search.ts";
+import { skillWriteTool } from "../../src/tools/skill/write.ts";
+import type { ToolContext } from "../../src/tools/tool.ts";
+import { setupToolContext } from "../helpers.ts";
+
+let tempDir: string;
+let ctx: ToolContext;
+
+async function seedSkill(
+  projectDir: string,
+  filename: string,
+  content: string,
+): Promise<void> {
+  const dir = getSkillsDir(projectDir);
+  await mkdir(dir, { recursive: true });
+  await Bun.write(join(dir, filename), content);
+}
+
+beforeEach(async () => {
+  ({ ctx } = await setupToolContext());
+  tempDir = await mkdtemp(join(tmpdir(), "both-skill-tool-"));
+  await mkdir(getSkillsDir(tempDir), { recursive: true });
+  ctx.projectDir = tempDir;
+});
+
+afterEach(async () => {
+  if (tempDir) {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+// ── skill_list ─────────────────────────────────────────────────
+
+describe("skill_list", () => {
+  test("returns empty when no skills exist", async () => {
+    const result = await skillListTool.execute({ limit: 100, offset: 0 }, ctx);
+    expect(result.is_error).toBe(false);
+    expect(result.skills).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+
+  test("lists skills sorted by name", async () => {
+    await seedSkill(
+      tempDir,
+      "zeta.md",
+      "---\nname: zeta\ndescription: z\narguments: []\n---\nbody-z\n",
+    );
+    await seedSkill(
+      tempDir,
+      "alpha.md",
+      "---\nname: alpha\ndescription: a\narguments: []\n---\nbody-a\n",
+    );
+    await seedSkill(
+      tempDir,
+      "mid.md",
+      "---\nname: mid\ndescription: m\narguments:\n  - name: x\n    description: an x\n    required: true\n---\nbody-m\n",
+    );
+
+    const result = await skillListTool.execute({ limit: 100, offset: 0 }, ctx);
+    expect(result.total).toBe(3);
+    expect(result.skills.map((s) => s.name)).toEqual(["alpha", "mid", "zeta"]);
+    expect(result.skills[1]?.arguments).toEqual(["x"]);
+    expect(result.skills[1]?.filename).toBe("mid.md");
+  });
+
+  test("respects limit and offset", async () => {
+    for (const n of ["a", "b", "c", "d"]) {
+      await seedSkill(
+        tempDir,
+        `${n}.md`,
+        `---\nname: ${n}\ndescription: ${n}\narguments: []\n---\nbody-${n}\n`,
+      );
+    }
+
+    const result = await skillListTool.execute({ limit: 2, offset: 1 }, ctx);
+    expect(result.total).toBe(4);
+    expect(result.skills.map((s) => s.name)).toEqual(["b", "c"]);
+  });
+});
+
+// ── skill_read ─────────────────────────────────────────────────
+
+describe("skill_read", () => {
+  test("returns parsed fields and raw content", async () => {
+    const raw =
+      "---\nname: review\ndescription: Review code\narguments:\n  - name: file\n    description: file path\n    required: true\n---\nReview $1 thoroughly.\n";
+    await seedSkill(tempDir, "review.md", raw);
+
+    const result = await skillReadTool.execute({ name: "review" }, ctx);
+    expect(result.is_error).toBe(false);
+    expect(result.name).toBe("review");
+    expect(result.description).toBe("Review code");
+    expect(result.body).toBe("Review $1 thoroughly.");
+    expect(result.arguments[0]?.name).toBe("file");
+    expect(result.raw).toBe(raw);
+  });
+
+  test("is case-insensitive", async () => {
+    await seedSkill(
+      tempDir,
+      "lower.md",
+      "---\nname: lower\ndescription: l\narguments: []\n---\nbody\n",
+    );
+
+    const result = await skillReadTool.execute({ name: "LOWER" }, ctx);
+    expect(result.is_error).toBe(false);
+    expect(result.name).toBe("lower");
+  });
+
+  test("returns not_found with available names hint", async () => {
+    await seedSkill(
+      tempDir,
+      "alpha.md",
+      "---\nname: alpha\ndescription: a\narguments: []\n---\nbody\n",
+    );
+    await seedSkill(
+      tempDir,
+      "beta.md",
+      "---\nname: beta\ndescription: b\narguments: []\n---\nbody\n",
+    );
+
+    const result = await skillReadTool.execute({ name: "missing" }, ctx);
+    expect(result.is_error).toBe(true);
+    expect(result.error_type).toBe("not_found");
+    expect(result.next_action_hint).toContain("alpha");
+    expect(result.next_action_hint).toContain("beta");
+  });
+
+  test("returns not_found with create-hint when no skills exist", async () => {
+    const result = await skillReadTool.execute({ name: "anything" }, ctx);
+    expect(result.is_error).toBe(true);
+    expect(result.error_type).toBe("not_found");
+    expect(result.next_action_hint).toContain("skill_write");
+  });
+});
+
+// ── skill_write ────────────────────────────────────────────────
+
+describe("skill_write", () => {
+  test("creates a new skill", async () => {
+    const result = await skillWriteTool.execute(
+      {
+        name: "summarize",
+        description: "Summarize stuff",
+        body: "Summarize $ARGUMENTS in three bullets.",
+        on_conflict: "error",
+      },
+      ctx,
+    );
+
+    expect(result.is_error).toBe(false);
+    expect(result.created).toBe(true);
+    expect(result.name).toBe("summarize");
+    expect(result.path).toBe(join(getSkillsDir(tempDir), "summarize.md"));
+    expect(result.ref).toBe("skill:summarize");
+
+    const skills = await loadSkills(tempDir);
+    const s = skills.get("summarize");
+    expect(s?.description).toBe("Summarize stuff");
+    expect(s?.body).toBe("Summarize $ARGUMENTS in three bullets.");
+  });
+
+  test("normalizes name and aligns frontmatter with filename (anti-drift)", async () => {
+    const result = await skillWriteTool.execute(
+      {
+        name: "My Skill!",
+        description: "d",
+        body: "b",
+        on_conflict: "error",
+      },
+      ctx,
+    );
+
+    expect(result.is_error).toBe(false);
+    expect(result.name).toBe("my-skill");
+    expect(result.path).toBe(join(getSkillsDir(tempDir), "my-skill.md"));
+
+    const skills = await loadSkills(tempDir);
+    expect(skills.get("my-skill")?.name).toBe("my-skill");
+  });
+
+  test("rejects reserved names", async () => {
+    for (const reserved of ["help", "skills", "clear", "exit"]) {
+      const result = await skillWriteTool.execute(
+        {
+          name: reserved,
+          description: "d",
+          body: "b",
+          on_conflict: "error",
+        },
+        ctx,
+      );
+      expect(result.is_error).toBe(true);
+      expect(result.error_type).toBe("reserved_name");
+    }
+  });
+
+  test("rejects names that normalize to empty", async () => {
+    const result = await skillWriteTool.execute(
+      { name: "!!!", description: "d", body: "b", on_conflict: "error" },
+      ctx,
+    );
+    expect(result.is_error).toBe(true);
+    expect(result.error_type).toBe("invalid_name");
+  });
+
+  test("rejects empty body", async () => {
+    const result = await skillWriteTool.execute(
+      {
+        name: "noop",
+        description: "d",
+        body: "   \n  ",
+        on_conflict: "error",
+      },
+      ctx,
+    );
+    expect(result.is_error).toBe(true);
+    expect(result.error_type).toBe("empty_body");
+  });
+
+  test("returns path_conflict when file exists by default", async () => {
+    await seedSkill(
+      tempDir,
+      "dup.md",
+      "---\nname: dup\ndescription: existing\narguments: []\n---\noriginal\n",
+    );
+
+    const result = await skillWriteTool.execute(
+      {
+        name: "dup",
+        description: "new",
+        body: "new body",
+        on_conflict: "error",
+      },
+      ctx,
+    );
+
+    expect(result.is_error).toBe(true);
+    expect(result.error_type).toBe("path_conflict");
+    const skills = await loadSkills(tempDir);
+    expect(skills.get("dup")?.body).toBe("original");
+  });
+
+  test("overwrites with on_conflict='overwrite' and reports created=false", async () => {
+    await seedSkill(
+      tempDir,
+      "dup.md",
+      "---\nname: dup\ndescription: existing\narguments: []\n---\noriginal\n",
+    );
+
+    const result = await skillWriteTool.execute(
+      {
+        name: "dup",
+        description: "updated",
+        body: "new body",
+        on_conflict: "overwrite",
+      },
+      ctx,
+    );
+
+    expect(result.is_error).toBe(false);
+    expect(result.created).toBe(false);
+    const skills = await loadSkills(tempDir);
+    expect(skills.get("dup")?.description).toBe("updated");
+    expect(skills.get("dup")?.body).toBe("new body");
+  });
+
+  test("round-trips arguments shape", async () => {
+    const result = await skillWriteTool.execute(
+      {
+        name: "review",
+        description: "review",
+        body: "Review $1 with focus $2.",
+        arguments: [
+          { name: "file", description: "file path", required: true },
+          {
+            name: "focus",
+            description: "focus area",
+            required: false,
+            default: "general",
+          },
+        ],
+        on_conflict: "error",
+      },
+      ctx,
+    );
+
+    expect(result.is_error).toBe(false);
+    const skills = await loadSkills(tempDir);
+    const s = skills.get("review");
+    expect(s?.arguments).toEqual([
+      { name: "file", description: "file path", required: true },
+      {
+        name: "focus",
+        description: "focus area",
+        required: false,
+        default: "general",
+      },
+    ]);
+  });
+
+  test("handles description with newlines and quotes (YAML-safe)", async () => {
+    const result = await skillWriteTool.execute(
+      {
+        name: "tricky",
+        description: 'has "quotes": and a colon',
+        body: "body",
+        on_conflict: "error",
+      },
+      ctx,
+    );
+
+    expect(result.is_error).toBe(false);
+    const skills = await loadSkills(tempDir);
+    expect(skills.get("tricky")?.description).toBe('has "quotes": and a colon');
+  });
+});
+
+// ── skill_edit ─────────────────────────────────────────────────
+
+describe("skill_edit", () => {
+  test("applies a body replacement", async () => {
+    await seedSkill(
+      tempDir,
+      "doc.md",
+      "---\nname: doc\ndescription: d\narguments: []\n---\noriginal body\n",
+    );
+
+    const original = await Bun.file(
+      join(getSkillsDir(tempDir), "doc.md"),
+    ).text();
+    const lines = original.split("\n");
+    const bodyLineIdx = lines.indexOf("original body") + 1;
+
+    const result = await skillEditTool.execute(
+      {
+        name: "doc",
+        patches: [
+          {
+            start_line: bodyLineIdx,
+            end_line: bodyLineIdx,
+            content: "updated body",
+          },
+        ],
+      },
+      ctx,
+    );
+
+    expect(result.is_error).toBe(false);
+    expect(result.applied).toBe(1);
+    const skills = await loadSkills(tempDir);
+    expect(skills.get("doc")?.body).toBe("updated body");
+  });
+
+  test("rejects edit that breaks frontmatter and leaves file unchanged", async () => {
+    const raw =
+      "---\nname: doc\ndescription: d\narguments: []\n---\noriginal body\n";
+    await seedSkill(tempDir, "doc.md", raw);
+
+    // Replace the description line with malformed YAML (unterminated string).
+    const result = await skillEditTool.execute(
+      {
+        name: "doc",
+        patches: [
+          {
+            start_line: 3,
+            end_line: 3,
+            content: 'description: "unterminated',
+          },
+        ],
+      },
+      ctx,
+    );
+
+    expect(result.is_error).toBe(true);
+    expect(result.error_type).toBe("invalid_skill");
+    const onDisk = await Bun.file(join(getSkillsDir(tempDir), "doc.md")).text();
+    expect(onDisk).toBe(raw);
+  });
+
+  test("rejects edit that changes frontmatter name to mismatch filename", async () => {
+    await seedSkill(
+      tempDir,
+      "doc.md",
+      "---\nname: doc\ndescription: d\narguments: []\n---\nbody\n",
+    );
+
+    const result = await skillEditTool.execute(
+      {
+        name: "doc",
+        patches: [{ start_line: 2, end_line: 2, content: "name: other" }],
+      },
+      ctx,
+    );
+
+    expect(result.is_error).toBe(true);
+    expect(result.error_type).toBe("invalid_skill");
+  });
+
+  test("returns not_found for missing skill", async () => {
+    const result = await skillEditTool.execute(
+      {
+        name: "ghost",
+        patches: [{ start_line: 1, end_line: 1, content: "x" }],
+      },
+      ctx,
+    );
+
+    expect(result.is_error).toBe(true);
+    expect(result.error_type).toBe("not_found");
+  });
+
+  test("applies multiple patches in reverse order without line-shift bugs", async () => {
+    await seedSkill(
+      tempDir,
+      "multi.md",
+      "---\nname: multi\ndescription: d\narguments: []\n---\nA\nB\nC\nD\n",
+    );
+
+    const path = join(getSkillsDir(tempDir), "multi.md");
+    const raw = await Bun.file(path).text();
+    const lines = raw.split("\n");
+    const aIdx = lines.indexOf("A") + 1;
+    const cIdx = lines.indexOf("C") + 1;
+
+    const result = await skillEditTool.execute(
+      {
+        name: "multi",
+        patches: [
+          { start_line: aIdx, end_line: aIdx, content: "A1" },
+          { start_line: cIdx, end_line: cIdx, content: "C1" },
+        ],
+      },
+      ctx,
+    );
+
+    expect(result.is_error).toBe(false);
+    const skills = await loadSkills(tempDir);
+    expect(skills.get("multi")?.body).toBe("A1\nB\nC1\nD");
+  });
+});
+
+// ── skill_search ───────────────────────────────────────────────
+
+describe("skill_search", () => {
+  beforeEach(async () => {
+    await seedSkill(
+      tempDir,
+      "standup.md",
+      "---\nname: standup\ndescription: daily team standup update\narguments: []\n---\nGenerate a standup summary from completed tasks today.\n",
+    );
+    await seedSkill(
+      tempDir,
+      "review.md",
+      "---\nname: review\ndescription: review code for issues\narguments:\n  - name: file\n    description: path to inspect\n    required: true\n---\nRead the file and report bugs and concerns.\n",
+    );
+    await seedSkill(
+      tempDir,
+      "summarize.md",
+      "---\nname: summarize\ndescription: summarize a chat thread\narguments: []\n---\nProduce a concise summary of the conversation.\n",
+    );
+  });
+
+  test("ranks name matches highest", async () => {
+    const result = await skillSearchTool.execute(
+      { query: "standup", top_k: 10 },
+      ctx,
+    );
+    expect(result.is_error).toBe(false);
+    expect(result.results[0]?.name).toBe("standup");
+    expect(result.results[0]?.match_fields).toContain("name");
+  });
+
+  test("matches body content with lower score", async () => {
+    const result = await skillSearchTool.execute(
+      { query: "bugs", top_k: 10 },
+      ctx,
+    );
+    expect(result.is_error).toBe(false);
+    expect(result.results.length).toBeGreaterThan(0);
+    expect(result.results[0]?.name).toBe("review");
+    expect(result.results[0]?.match_fields).toContain("body");
+  });
+
+  test("matches argument metadata", async () => {
+    const result = await skillSearchTool.execute(
+      { query: "inspect", top_k: 10 },
+      ctx,
+    );
+    expect(result.is_error).toBe(false);
+    expect(result.results[0]?.name).toBe("review");
+    expect(result.results[0]?.match_fields).toContain("argument_description");
+  });
+
+  test("respects top_k", async () => {
+    const result = await skillSearchTool.execute(
+      { query: "summary", top_k: 1 },
+      ctx,
+    );
+    expect(result.results.length).toBe(1);
+  });
+
+  test("returns empty results with hint when no matches", async () => {
+    const result = await skillSearchTool.execute(
+      { query: "kubernetes", top_k: 10 },
+      ctx,
+    );
+    expect(result.is_error).toBe(false);
+    expect(result.results).toEqual([]);
+    expect(result.hint).toContain("No matches");
+  });
+
+  test("hints when no skills exist at all", async () => {
+    await rm(getSkillsDir(tempDir), { recursive: true, force: true });
+    await mkdir(getSkillsDir(tempDir), { recursive: true });
+
+    const result = await skillSearchTool.execute(
+      { query: "anything", top_k: 10 },
+      ctx,
+    );
+    expect(result.is_error).toBe(false);
+    expect(result.results).toEqual([]);
+    expect(result.hint).toContain("No skills exist yet");
+  });
+});


### PR DESCRIPTION
## Summary

Five new tools in a `skill` group give the chat agent first-class control over skill files (slash-command prompt templates in `.botholomew/skills/`):

| Tool | Behavior |
|---|---|
| `skill_list` | List skills with name, description, args, file path |
| `skill_read` | Read raw + parsed fields; not_found returns hint with available names |
| `skill_search` | In-memory keyword ranking across name, description, args, body |
| `skill_write` | Create/overwrite with `on_conflict='error'\|'overwrite'`; validates before writing |
| `skill_edit` | git-style line-range patches; re-parses after; rejects invalid results without writing |

`skill_write` rejects reserved names (`help`, `skills`, `clear`, `exit`), normalizes to `[a-z0-9-]`, and aligns frontmatter `name` with filename to prevent drift.

`ChatSession.skills` is now hot-reloaded at the top of `sendMessage`, so a skill the agent creates mid-conversation is invocable as `/<name>` on the very next user message — no chat restart.

## Notable choices
- **Search is keyword-only** (no embeddings). 5–50 skills per project doesn't justify an embeddings pipeline.
- **No `skill_delete`** — out of scope; easy follow-up.
- Patches sorted descending by `start_line` to avoid line-shift bugs (mirrors `applyPatchesToContextItem`).
- Frontmatter is built via `gray-matter`'s `stringify`, never hand-rolled, so YAML special chars in description/body are safe.

## Test plan
- [x] `bun run lint` clean
- [x] `bun test` — 27 new tests in `test/tools/skill.test.ts`; full suite 741 pass
- [ ] Manual: open `bun run dev chat`, ask agent to create a skill, type `/<name>` on next message — verify it resolves

## Docs
- `docs/skills.md` — new "Managing skills from chat" section + updated cache-lifetime note
- `README.md` — Reusable workflows + Self-modifying bullets + skills deep-dive entry now mention runtime authoring
- `package.json` — version bump to 0.9.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)