### PR TITLE
Allow chat agent to call capabilities_refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/chat/agent.ts
+++ b/src/chat/agent.ts
@@ -46,6 +46,7 @@ const CHAT_TOOL_NAMES = new Set([
   "list_schedules",
   "update_beliefs",
   "update_goals",
+  "capabilities_refresh",
   "mcp_list_tools",
   "mcp_search",
   "mcp_info",

--- a/test/chat/agent.test.ts
+++ b/test/chat/agent.test.ts
@@ -46,6 +46,7 @@ describe("getChatTools", () => {
     expect(names).toContain("context_tree");
     expect(names).toContain("update_beliefs");
     expect(names).toContain("update_goals");
+    expect(names).toContain("capabilities_refresh");
     expect(names).toContain("list_schedules");
     expect(names).toContain("create_schedule");
 


### PR DESCRIPTION
## Summary
- Adds `capabilities_refresh` to `CHAT_TOOL_NAMES` in `src/chat/agent.ts` so the chat agent can regenerate `.botholomew/capabilities.md` when its tool inventory feels stale.
- The regenerated file is auto-loaded by `loadPersistentContext` on the next turn, so the agent immediately sees the refreshed summary — no session restart needed.
- Updates the `getChatTools` test to assert the tool is exposed, and bumps `package.json` to 0.9.8 for the auto-release workflow.

## Test plan
- [x] `bun run lint`
- [x] `bun test` (721/721 passing)
- [ ] Manual: open `botholomew chat`, ask it to refresh its capabilities, confirm `.botholomew/capabilities.md` updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)