### PR TITLE
Show "Preparing tool call" spinner during chat tool input streaming

### DIFF
--- a/docs/tui.md
+++ b/docs/tui.md
@@ -63,7 +63,9 @@ re-layout.
 
 While the agent is streaming, text flushes to the screen on a ~50 ms
 timer (~20 fps) to keep the terminal from flickering. A spinner marks
-in-flight tool calls.
+in-flight tool calls. While the model is assembling a tool-call input
+(streaming a large JSON args block), a `Preparing tool call: <name>...`
+spinner is shown so the UI doesn't appear frozen.
 
 ### 2. Tools
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/chat/agent.ts
+++ b/src/chat/agent.ts
@@ -160,6 +160,7 @@ export interface ToolEndMeta {
 
 export interface ChatTurnCallbacks {
   onToken: (text: string) => void;
+  onToolPreparing?: (id: string, name: string) => void;
   onToolStart: (id: string, name: string, input: string) => void;
   onToolEnd: (
     id: string,
@@ -249,6 +250,18 @@ export async function runChatTurn(input: {
     stream.on("text", (text) => {
       assistantText += text;
       callbacks.onToken(text);
+    });
+
+    stream.on("streamEvent", (event) => {
+      if (
+        event.type === "content_block_start" &&
+        event.content_block.type === "tool_use"
+      ) {
+        callbacks.onToolPreparing?.(
+          event.content_block.id,
+          event.content_block.name,
+        );
+      }
     });
 
     stream.on("contentBlock", (block) => {

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -133,6 +133,10 @@ export function App({
   const [isLoading, setIsLoading] = useState(false);
   const [streamingText, setStreamingText] = useState("");
   const [activeToolCalls, setActiveToolCalls] = useState<ToolCallData[]>([]);
+  const [preparingTool, setPreparingTool] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
   const [ready, setReady] = useState(false);
   const skipSplash = !!(resumeThreadId || initialPrompt);
   const [splashDone, setSplashDone] = useState(skipSplash);
@@ -329,6 +333,7 @@ export function App({
       setIsLoading(true);
       setStreamingText("");
       setActiveToolCalls([]);
+      setPreparingTool(null);
 
       const userMsg: ChatMessage = {
         id: msgId(),
@@ -370,6 +375,9 @@ export function App({
               lastStreamFlush = now;
             }
           },
+          onToolPreparing: (id, name) => {
+            setPreparingTool({ id, name });
+          },
           onToolStart: (id, name, input) => {
             if (currentText) {
               finalizeSegment();
@@ -383,6 +391,7 @@ export function App({
             };
             pendingToolCalls.push(tc);
             setActiveToolCalls([...pendingToolCalls]);
+            setPreparingTool(null);
           },
           onToolEnd: (id, _name, output, isError, meta) => {
             const tc = pendingToolCalls.find((t) => t.id === id);
@@ -410,6 +419,7 @@ export function App({
       } finally {
         setStreamingText("");
         setActiveToolCalls([]);
+        setPreparingTool(null);
       }
     }
 
@@ -700,6 +710,7 @@ export function App({
           streamingText={streamingText}
           isLoading={isLoading}
           activeToolCalls={activeToolCalls}
+          preparingTool={preparingTool}
         />
       </Box>
       <Box

--- a/src/tui/components/MessageList.tsx
+++ b/src/tui/components/MessageList.tsx
@@ -17,6 +17,7 @@ interface MessageListProps {
   streamingText: string;
   isLoading: boolean;
   activeToolCalls: ToolCallData[];
+  preparingTool: { id: string; name: string } | null;
 }
 
 function formatTime(date: Date): string {
@@ -127,6 +128,7 @@ export function MessageList({
   streamingText,
   isLoading,
   activeToolCalls,
+  preparingTool,
 }: MessageListProps) {
   return (
     <>
@@ -160,7 +162,17 @@ export function MessageList({
         </Box>
       )}
 
+      {preparingTool && (
+        <Box marginTop={1}>
+          <Text color={theme.accent}>
+            <Spinner type="dots" />
+          </Text>
+          <Text dimColor> Preparing tool call: {preparingTool.name}...</Text>
+        </Box>
+      )}
+
       {isLoading &&
+        !preparingTool &&
         !streamingText &&
         (activeToolCalls.length === 0 ||
           activeToolCalls.every((tc) => !tc.running)) && (

--- a/src/worker/fake-llm.ts
+++ b/src/worker/fake-llm.ts
@@ -144,9 +144,22 @@ class FakeMessageStream extends EventEmitter {
       if (delay > 0) await new Promise((r) => setTimeout(r, delay));
     }
     const final = buildFinalMessage(text, this.turn.toolCalls);
+    let blockIndex = text ? 1 : 0;
     for (const block of final.content) {
       if ((block as { type: string }).type === "tool_use") {
-        this.emit("contentBlock", block as ToolUseBlock);
+        const toolUse = block as ToolUseBlock;
+        this.emit("streamEvent", {
+          type: "content_block_start",
+          index: blockIndex,
+          content_block: {
+            type: "tool_use",
+            id: toolUse.id,
+            name: toolUse.name,
+            input: {},
+          },
+        });
+        this.emit("contentBlock", toolUse);
+        blockIndex++;
       }
     }
     this.resolveFinal(final);

--- a/test/worker/fake-llm.test.ts
+++ b/test/worker/fake-llm.test.ts
@@ -101,4 +101,63 @@ describe("createFakeAnthropicClient", () => {
     expect(blocks[0]).toMatchObject({ type: "tool_use", name: "list_tasks" });
     expect(final.stop_reason).toBe("tool_use");
   });
+
+  test("emits streamEvent content_block_start for tool_use before contentBlock", async () => {
+    process.env.BOTHOLOMEW_FAKE_LLM_FIXTURE = writeFixture("preparing", {
+      turns: [
+        {
+          text: "",
+          delayMs: 0,
+          toolCalls: [
+            { id: "toolu_abc", name: "create_task", input: { name: "x" } },
+          ],
+        },
+      ],
+    });
+
+    const { createFakeAnthropicClient } = await import(
+      `../../src/worker/fake-llm.ts?cachebust=${Date.now()}`
+    );
+    const client = createFakeAnthropicClient();
+
+    const stream = client.messages.stream({
+      messages: [{ role: "user", content: "go" }],
+    });
+
+    const events: Array<{
+      source: "streamEvent" | "contentBlock";
+      data: unknown;
+    }> = [];
+    // biome-ignore lint/suspicious/noExplicitAny: EventEmitter surface
+    (stream as any).on("streamEvent", (e: unknown) => {
+      events.push({ source: "streamEvent", data: e });
+    });
+    // biome-ignore lint/suspicious/noExplicitAny: EventEmitter surface
+    (stream as any).on("contentBlock", (b: unknown) => {
+      events.push({ source: "contentBlock", data: b });
+    });
+    await stream.finalMessage();
+
+    const startEvents = events.filter(
+      (e) =>
+        e.source === "streamEvent" &&
+        (e.data as { type: string }).type === "content_block_start",
+    );
+    expect(startEvents).toHaveLength(1);
+    expect(startEvents[0]?.data).toMatchObject({
+      type: "content_block_start",
+      content_block: { type: "tool_use", id: "toolu_abc", name: "create_task" },
+    });
+
+    // The streamEvent must arrive before the corresponding contentBlock so
+    // listeners can show a "Preparing tool call" spinner during input
+    // assembly.
+    const firstStartIdx = events.findIndex(
+      (e) =>
+        e.source === "streamEvent" &&
+        (e.data as { type: string }).type === "content_block_start",
+    );
+    const firstBlockIdx = events.findIndex((e) => e.source === "contentBlock");
+    expect(firstStartIdx).toBeLessThan(firstBlockIdx);
+  });
 });


### PR DESCRIPTION
## Summary

- When the chat agent streamed a large `tool_use` input, the TUI appeared frozen: the SDK's `contentBlock` only fires after the JSON is fully assembled, and the existing "Thinking..." spinner is suppressed once any assistant text has flushed.
- Hooked `stream.on("streamEvent", ...)` in `runChatTurn` to detect `content_block_start` for `tool_use` blocks and route it to a new optional `onToolPreparing(id, name)` callback. App state tracks the preparing tool and clears it on `onToolStart`/error/turn-end.
- `MessageList` renders a dedicated `Preparing tool call: <name>...` spinner that takes precedence over `Thinking...` and shows even when streaming text is on screen. Fake LLM now emits the same `streamEvent` shape so tests cover the wire format.

## Test plan

- [x] `bun run lint` passes
- [x] `bun test` passes (749/749)
- [ ] Manual TUI: run `bun run dev chat`, ask the agent to do something with a large tool input (e.g. create a skill with a long body), confirm the "Preparing tool call: \<name\>..." spinner appears during input assembly and disappears when the tool starts executing

🤖 Generated with [Claude Code](https://claude.com/claude-code)