### PR TITLE
Add anti-sycophancy style block to agent system prompts

### DIFF
--- a/docs/persistent-context.md
+++ b/docs/persistent-context.md
@@ -51,6 +51,21 @@ See `loadPersistentContext()` and `extractKeywords()` in
 
 ---
 
+## The hardcoded `## Style` block
+
+After the persistent-context files (and after the optional MCP
+section), every system prompt — worker and chat alike — appends a
+short `## Style` block defined as `STYLE_RULES` in
+`src/worker/prompt.ts`. It tells the model to skip sycophantic
+preambles ("You're absolutely right!", "Great question!"), push back
+when the user is wrong, and report failures and uncertainty directly.
+This is hardcoded so it applies to every install without needing to
+re-run `botholomew init`. Anything you put in `soul.md` or
+`beliefs.md` still loads above it and can layer on top — if you'd
+rather have a warm, chatty agent, say so there.
+
+---
+
 ## Agent self-modification
 
 When `agent-modification: true`, the agent can rewrite the file using

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/chat/agent.ts
+++ b/src/chat/agent.ts
@@ -24,6 +24,7 @@ import {
   buildMetaHeader,
   extractKeywords,
   loadPersistentContext,
+  STYLE_RULES,
 } from "../worker/prompt.ts";
 
 registerAllTools();
@@ -150,6 +151,8 @@ Before calling any MCP tool you haven't used yet this session, you MUST fetch it
 Skip step 2 only if you already called \`mcp_info\` for that exact server+tool earlier in this conversation. Do not guess arguments from the tool's description alone — descriptions omit types and required/optional markers.
 `;
   }
+
+  prompt += `\n${STYLE_RULES}`;
 
   return prompt;
 }

--- a/src/init/templates.ts
+++ b/src/init/templates.ts
@@ -8,6 +8,8 @@ agent-modification: false
 You are Botholomew, an AI agent for knowledge work, personified by a wise owl. You help humans manage information, research topics, organize knowledge, and complete intellectual tasks.
 
 You are thoughtful, thorough, and proactive. You work through your task queue methodically, prioritizing appropriately and asking for clarification when needed.
+
+You are direct: lead with the answer, skip preambles, disagree when you have reason to, and never flatter.
 `;
 
 export const BELIEFS_MD = `---

--- a/src/worker/prompt.ts
+++ b/src/worker/prompt.ts
@@ -13,6 +13,14 @@ const pkg = await Bun.file(
   new URL("../../package.json", import.meta.url),
 ).json();
 
+export const STYLE_RULES = `## Style
+- Open with the result, action, or next step. Skip preambles like "Great question", "You're absolutely right", "Let me…", "I'll go ahead and…".
+- Don't flatter the user or their ideas. If a request is wrong, ambiguous, or risky, say so plainly with the reason.
+- Hold your position when you have one. Don't capitulate to pushback that brings no new evidence.
+- Be terse. Don't restate what you just did or are about to do — show it.
+- Report failures and uncertainty directly. Don't paper over gaps with confident prose.
+`;
+
 /**
  * Extract keyword set from free-form text: lowercase, split on whitespace,
  * keep words longer than 3 chars. Used to match `loading: contextual` files
@@ -159,6 +167,8 @@ Before calling any MCP tool you haven't used yet this session, you MUST fetch it
 Skip step 2 only if you already called \`mcp_info\` for that exact server+tool earlier in this conversation. Do not guess arguments from the tool's description alone — descriptions omit types and required/optional markers.
 `;
   }
+
+  prompt += `\n${STYLE_RULES}`;
 
   return prompt;
 }

--- a/test/chat/agent.test.ts
+++ b/test/chat/agent.test.ts
@@ -169,6 +169,36 @@ describe("buildChatSystemPrompt", () => {
     expect(promptFalse).not.toContain("## External Tools (MCP)");
   });
 
+  test("appends the Style block after Instructions", async () => {
+    const prompt = await buildChatSystemPrompt(projectDir);
+    expect(prompt).toContain("## Style");
+    expect(prompt).toContain("preambles");
+    expect(prompt).toContain("Don't flatter");
+    expect(prompt.indexOf("## Style")).toBeGreaterThan(
+      prompt.indexOf("## Instructions"),
+    );
+  });
+
+  test("Style block appears after the MCP block when hasMcpTools is true", async () => {
+    const prompt = await buildChatSystemPrompt(projectDir, {
+      hasMcpTools: true,
+    });
+    expect(prompt).toContain("## Style");
+    expect(prompt.indexOf("## Style")).toBeGreaterThan(
+      prompt.indexOf("## External Tools (MCP)"),
+    );
+  });
+
+  test("Style block is present even with no .botholomew files", async () => {
+    await rm(join(projectDir, ".botholomew"), {
+      recursive: true,
+      force: true,
+    });
+    const prompt = await buildChatSystemPrompt(projectDir);
+    expect(prompt).toContain("## Style");
+    expect(prompt).toContain("Don't flatter");
+  });
+
   test("always-loaded files appear even when keywordSource matches nothing", async () => {
     const always = serializeContextFile(
       { loading: "always", "agent-modification": true },

--- a/test/init/index.test.ts
+++ b/test/init/index.test.ts
@@ -63,6 +63,17 @@ describe("initProject", () => {
     expect(meta["agent-modification"]).toBe(false);
   });
 
+  test("soul.md instructs the agent to be direct and skip flattery", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "botholomew-test-"));
+    await initProject(tempDir);
+
+    const raw = await Bun.file(join(tempDir, ".botholomew", "soul.md")).text();
+    const { content } = parseContextFile(raw);
+
+    expect(content).toContain("lead with the answer");
+    expect(content).toContain("never flatter");
+  });
+
   test("beliefs.md is agent-editable", async () => {
     tempDir = await mkdtemp(join(tmpdir(), "botholomew-test-"));
     await initProject(tempDir);

--- a/test/worker/prompt.test.ts
+++ b/test/worker/prompt.test.ts
@@ -225,6 +225,40 @@ describe("buildSystemPrompt", () => {
     expect(promptFalse).not.toContain("## External Tools (MCP)");
   });
 
+  test("appends the Style block after Instructions", async () => {
+    const prompt = await buildSystemPrompt(projectDir);
+    expect(prompt).toContain("## Style");
+    expect(prompt).toContain("preambles");
+    expect(prompt).toContain("Don't flatter");
+    expect(prompt.indexOf("## Style")).toBeGreaterThan(
+      prompt.indexOf("## Instructions"),
+    );
+  });
+
+  test("Style block appears after the MCP block when hasMcpTools is true", async () => {
+    const prompt = await buildSystemPrompt(
+      projectDir,
+      undefined,
+      undefined,
+      undefined,
+      { hasMcpTools: true },
+    );
+    expect(prompt).toContain("## Style");
+    expect(prompt.indexOf("## Style")).toBeGreaterThan(
+      prompt.indexOf("## External Tools (MCP)"),
+    );
+  });
+
+  test("Style block is present even with no .botholomew files", async () => {
+    await rm(join(projectDir, ".botholomew"), {
+      recursive: true,
+      force: true,
+    });
+    const prompt = await buildSystemPrompt(projectDir);
+    expect(prompt).toContain("## Style");
+    expect(prompt).toContain("Don't flatter");
+  });
+
   test("keyword extraction filters short words", async () => {
     const contextual = serializeContextFile(
       { loading: "contextual", "agent-modification": false },


### PR DESCRIPTION
## Summary

Both the chat agent and the worker agent were opening responses with classic LLM filler — *"You're absolutely right! We need date parameters for flexibility. Let me add those arguments:"* — before doing the actual work. Annoying UX, wasted output tokens, and reads as untrustworthy.

This adds a hardcoded `## Style` block (`STYLE_RULES` in `src/worker/prompt.ts`) appended as the trailing section of both `buildSystemPrompt` (worker) and `buildChatSystemPrompt` (chat). Five short bullets: skip preambles, don't flatter, hold your position, be terse, report failures directly.

Hardcoded in the prompt builder so it applies to every existing install — no `botholomew init` re-run required. User `soul.md` / `beliefs.md` still load above it and can layer on top (a feature: a user who wants warm replies can say so).

The `SOUL_MD` template also gets a one-line tonal alignment ("lead with the answer, skip preambles, disagree when you have reason to, and never flatter") so new installs are consistent. Existing `soul.md` files are NOT migrated — `STYLE_RULES` is the source of truth.

`docs/persistent-context.md` documents the new appended block.

## Test plan

- [x] `bun run lint` clean (tsc + biome)
- [x] `bun test` — 755 pass, 0 fail (8 new assertions across worker, chat, and init suites)
- [ ] `bun run dev chat` in a scratch project: send a leading question (*"don't you think we should rewrite this in Rust?"*) and confirm no "You're absolutely right!" opener
- [ ] Try a clearly-wrong premise (*"Postgres can't handle 10k rows, right?"*) and confirm the agent pushes back with a reason
- [ ] Spawn a worker on a small task and check that the `complete_task` summary leads with substance

🤖 Generated with [Claude Code](https://claude.com/claude-code)