### PR TITLE
Add skill_delete tool so chat agent can remove skills

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -119,7 +119,7 @@ skill is invoked, so it's visually distinct from a regular message.
 ## Managing skills from chat
 
 Skills aren't write-once-via-CLI: the chat agent can list, read, create,
-edit, and search them on demand. Five tools are exposed to the chat
+edit, search, and delete them on demand. Six tools are exposed to the chat
 agent:
 
 | Tool | What it does |
@@ -129,6 +129,7 @@ agent:
 | `skill_search` | Keyword search across name, description, body, and arg metadata |
 | `skill_write` | Create or overwrite a skill (`on_conflict: 'error' \| 'overwrite'`) |
 | `skill_edit` | Apply git-style line-range patches to an existing skill |
+| `skill_delete` | Delete a skill file by name |
 
 Newly written or edited skills are picked up at the start of the *next*
 user message — `ChatSession.skills` is reloaded from disk in

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/chat/agent.ts
+++ b/src/chat/agent.ts
@@ -58,6 +58,7 @@ const CHAT_TOOL_NAMES = new Set([
   "skill_write",
   "skill_edit",
   "skill_search",
+  "skill_delete",
 ]);
 
 export function getChatTools() {
@@ -114,7 +115,7 @@ You do NOT execute long-running work directly — enqueue tasks for a background
 Use the available tools to look up tasks, threads, schedules, and context when the user asks about them. Context items live under a drive (disk / url / agent / google-docs / github / …); use \`context_list_drives\` to discover which drives have content, then \`context_tree\`, \`context_info\`, \`context_search\`, or \`context_refresh\` as needed.
 When multiple tool calls are independent of each other (i.e., one does not depend on the result of another), call them all in a single response. They will be executed in parallel, which is faster than calling them one at a time.
 You can update the agent's beliefs and goals files when the user asks you to.
-You can author and refine slash-command skills (reusable prompt templates stored in \`.botholomew/skills/\`) via \`skill_list\`, \`skill_search\`, \`skill_read\`, \`skill_write\`, and \`skill_edit\`. New or edited skills are usable as \`/<name>\` on the user's next message.
+You can author and refine slash-command skills (reusable prompt templates stored in \`.botholomew/skills/\`) via \`skill_list\`, \`skill_search\`, \`skill_read\`, \`skill_write\`, \`skill_edit\`, and \`skill_delete\`. New or edited skills are usable as \`/<name>\` on the user's next message.
 Format your responses using Markdown. Use headings, bold, italic, lists, and code blocks to make your responses clear and well-structured.
 `;
 

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -129,6 +129,27 @@ or $1, $2, etc. for positional arguments.
       await Bun.write(filePath, template);
       logger.success(`Created skill: ${filePath}`);
     });
+
+  skill
+    .command("delete <name>")
+    .description("Delete a skill file")
+    .action(async (name: string) => {
+      const dir = program.opts().dir;
+      const skills = await loadSkills(dir);
+      const s = skills.get(name.toLowerCase());
+
+      if (!s) {
+        logger.error(`Skill not found: ${name}`);
+        if (skills.size > 0) {
+          const available = [...skills.keys()].sort().join(", ");
+          console.error(ansis.dim(`Available: ${available}`));
+        }
+        process.exit(1);
+      }
+
+      await Bun.file(s.filePath).delete();
+      logger.success(`Deleted skill: ${s.filePath}`);
+    });
 }
 
 async function validateSingleFile(filePath: string): Promise<void> {

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -33,6 +33,7 @@ import { listSchedulesTool } from "./schedule/list.ts";
 import { searchGrepTool } from "./search/grep.ts";
 import { searchSemanticTool } from "./search/semantic.ts";
 // Skill tools
+import { skillDeleteTool } from "./skill/delete.ts";
 import { skillEditTool } from "./skill/edit.ts";
 import { skillListTool } from "./skill/list.ts";
 import { skillReadTool } from "./skill/read.ts";
@@ -102,6 +103,7 @@ export function registerAllTools(): void {
   registerTool(skillWriteTool);
   registerTool(skillEditTool);
   registerTool(skillSearchTool);
+  registerTool(skillDeleteTool);
 
   // Thread
   registerTool(listThreadsTool);

--- a/src/tools/skill/delete.ts
+++ b/src/tools/skill/delete.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+import { loadSkills } from "../../skills/loader.ts";
+import type { ToolDefinition } from "../tool.ts";
+
+const inputSchema = z.object({
+  name: z.string().describe("Skill name (case-insensitive)"),
+});
+
+const outputSchema = z.object({
+  name: z.string().nullable(),
+  path: z.string().nullable(),
+  deleted: z.boolean(),
+  is_error: z.boolean(),
+  error_type: z.string().optional(),
+  message: z.string().optional(),
+  next_action_hint: z.string().optional(),
+});
+
+export const skillDeleteTool = {
+  name: "skill_delete",
+  description:
+    "[[ bash equivalent command: rm ]] Delete a skill file (user-defined slash command) by name. The file is removed from .botholomew/skills/. Returns a not_found error with the list of available names when the skill doesn't exist.",
+  group: "skill",
+  inputSchema,
+  outputSchema,
+  execute: async (input, ctx) => {
+    const skills = await loadSkills(ctx.projectDir);
+    const skill = skills.get(input.name.toLowerCase());
+
+    if (!skill) {
+      const available = [...skills.keys()].sort();
+      const hint =
+        available.length > 0
+          ? `Available: ${available.join(", ")}. Use skill_list to browse.`
+          : "No skills exist yet. Use skill_write to create one.";
+      return {
+        name: input.name,
+        path: null,
+        deleted: false,
+        is_error: true,
+        error_type: "not_found",
+        message: `Skill not found: ${input.name}`,
+        next_action_hint: hint,
+      };
+    }
+
+    await Bun.file(skill.filePath).delete();
+
+    return {
+      name: skill.name,
+      path: skill.filePath,
+      deleted: true,
+      is_error: false,
+    };
+  },
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/test/tools/skill.test.ts
+++ b/test/tools/skill.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { getSkillsDir } from "../../src/constants.ts";
 import { loadSkills } from "../../src/skills/loader.ts";
+import { skillDeleteTool } from "../../src/tools/skill/delete.ts";
 import { skillEditTool } from "../../src/tools/skill/edit.ts";
 import { skillListTool } from "../../src/tools/skill/list.ts";
 import { skillReadTool } from "../../src/tools/skill/read.ts";
@@ -530,5 +531,75 @@ describe("skill_search", () => {
     expect(result.is_error).toBe(false);
     expect(result.results).toEqual([]);
     expect(result.hint).toContain("No skills exist yet");
+  });
+});
+
+// ── skill_delete ───────────────────────────────────────────────
+
+describe("skill_delete", () => {
+  test("deletes an existing skill", async () => {
+    await seedSkill(
+      tempDir,
+      "doomed.md",
+      "---\nname: doomed\ndescription: bye\narguments: []\n---\nbody\n",
+    );
+
+    const result = await skillDeleteTool.execute({ name: "doomed" }, ctx);
+    expect(result.is_error).toBe(false);
+    expect(result.deleted).toBe(true);
+    expect(result.name).toBe("doomed");
+    expect(result.path).toContain("doomed.md");
+
+    const skills = await loadSkills(tempDir);
+    expect(skills.has("doomed")).toBe(false);
+    expect(
+      await Bun.file(join(getSkillsDir(tempDir), "doomed.md")).exists(),
+    ).toBe(false);
+  });
+
+  test("looks up name case-insensitively", async () => {
+    await seedSkill(
+      tempDir,
+      "review.md",
+      "---\nname: review\ndescription: r\narguments: []\n---\nbody\n",
+    );
+
+    const result = await skillDeleteTool.execute({ name: "REVIEW" }, ctx);
+    expect(result.is_error).toBe(false);
+    expect(result.deleted).toBe(true);
+
+    const skills = await loadSkills(tempDir);
+    expect(skills.has("review")).toBe(false);
+  });
+
+  test("returns not_found with hint when no skills exist", async () => {
+    const result = await skillDeleteTool.execute({ name: "nope" }, ctx);
+    expect(result.is_error).toBe(true);
+    expect(result.error_type).toBe("not_found");
+    expect(result.deleted).toBe(false);
+    expect(result.next_action_hint).toContain("skill_write");
+  });
+
+  test("returns not_found listing available names when other skills exist", async () => {
+    await seedSkill(
+      tempDir,
+      "alpha.md",
+      "---\nname: alpha\ndescription: a\narguments: []\n---\nbody\n",
+    );
+    await seedSkill(
+      tempDir,
+      "beta.md",
+      "---\nname: beta\ndescription: b\narguments: []\n---\nbody\n",
+    );
+
+    const result = await skillDeleteTool.execute({ name: "missing" }, ctx);
+    expect(result.is_error).toBe(true);
+    expect(result.error_type).toBe("not_found");
+    expect(result.next_action_hint).toContain("alpha");
+    expect(result.next_action_hint).toContain("beta");
+
+    const skills = await loadSkills(tempDir);
+    expect(skills.has("alpha")).toBe(true);
+    expect(skills.has("beta")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

PR #152 added `skill_write`, `skill_edit`, and `skill_search` but forgot the symmetric delete — the chat agent could create skills but had no way to remove them. This adds `skill_delete` (plus a matching `skill delete <name>` CLI subcommand) following the same case-insensitive lookup + `not_found` hint pattern as `skill_read`.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun test` — 752 pass / 0 fail (4 new tests for delete success, case-insensitive lookup, and two not_found variants)
- [ ] Manual smoke: `botholomew skill create demo && botholomew skill delete demo && botholomew skill list`
- [ ] Chat smoke: ask the agent to create then delete a skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)