### PR TITLE
Tail a worker's log from the Workers TUI panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ my-project/
     skills/               # user-defined slash commands
       summarize.md
       standup.md
-    worker.log            # stdout/stderr from spawned workers
+    logs/                 # per-worker log files (one file per spawned worker)
+      <worker-id>.log
 ```
 
 Everything the agent can touch is here. No surprises.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,10 +67,9 @@ See `src/worker/tick.ts`.
 
 ### Log format
 
-Worker logs (both foreground stdout and `.botholomew/worker.log`) prefix
-every line with a local `HH:MM:SS` timestamp. Lifecycle phases render as
-`[[phase-name]]` in bold magenta so they're easy to scan and grep
-(`grep '\[\[' worker.log`). Phases emitted each tick:
+Worker logs prefix every line with a local `HH:MM:SS` timestamp. Lifecycle
+phases render as `[[phase-name]]` in bold magenta so they're easy to scan
+and grep (`grep '\[\[' .botholomew/logs/<id>.log`). Phases emitted each tick:
 
 - `[[tick-start]] #N`
 - `[[evaluating-schedules]]` (only when any are enabled)
@@ -84,9 +83,16 @@ every line with a local `HH:MM:SS` timestamp. Lifecycle phases render as
 
 Every worker writes a row into the `workers` table on start
 (`registerWorker` in `src/db/workers.ts`) with its id (uuidv7), pid,
-hostname, mode, optional pinned task id, and `status='running'`. From
-that moment, a non-blocking `setInterval` in `src/worker/heartbeat.ts`
-bumps `last_heartbeat_at` every
+hostname, mode, optional pinned task id, optional `log_path`, and
+`status='running'`. Detached workers (spawned via `worker start` or
+`spawn_worker`) get a per-worker log file at
+`.botholomew/logs/<worker-id>.log` — the spawn parent generates the id
+and opens that file before launching the child, so the path is recorded
+on the row from registration onward. Foreground workers (`worker run`)
+have `log_path = null` and write to stdout instead.
+
+From that moment, a non-blocking `setInterval` in
+`src/worker/heartbeat.ts` bumps `last_heartbeat_at` every
 `worker_heartbeat_interval_seconds` (default 15s) — independent of the
 tick loop, so a worker mid-LLM-call still heartbeats reliably.
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -130,7 +130,15 @@ Live view of every worker registered against this project (status
 filter cycles with `f`: all → running → stopped → dead → all). Each row
 shows status, short id, mode, and heartbeat age. The detail pane has
 full id, pid, hostname, started time, heartbeat time, stopped time (if
-any), and pinned task id (if any).
+any), pinned task id (if any), and the per-worker log path.
+
+Press `l` to swap the detail pane into a **log view** that tails the
+selected worker's log file (`.botholomew/logs/<id>.log`). The log
+auto-refreshes every ~1.5 s and follows the bottom by default — scroll
+up with `Shift+↑`, `k`, or `K` to pause following; `G` (or scrolling
+back to the bottom) resumes it. Press `l` again to return to the
+detail view. Foreground workers (`worker run`) have no log file, so
+the log view shows an empty-state message instead.
 
 The panel polls the DB every ~3s. Workers heartbeat every
 `worker_heartbeat_interval_seconds` (default 15s); ones older than
@@ -282,6 +290,18 @@ just shows the summary to keep the chat view compact.
 | `r` | Refresh from DB |
 | `d` | Delete with confirmation (Threads, Schedules, Context) |
 | `e` | Toggle enable/disable (Schedules only) |
+
+### Workers tab
+
+| Key | Action |
+|---|---|
+| `↑` / `↓` | Select worker |
+| `f` | Cycle status filter (all → running → stopped → dead) |
+| `l` | Toggle between detail and log-tail view |
+| `Shift+↑` / `Shift+↓` | Scroll log up/down (log view) |
+| `j` / `k` | Scroll log down/up by one line (log view) |
+| `J` / `K` | Page scroll the log (log view) |
+| `g` / `G` | Jump to top / bottom of log (log view, `G` resumes follow) |
 
 ### Context tab
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,14 +13,13 @@ export const DEFAULTS = {
   UPDATE_CHECK_TIMEOUT_MS: 5_000,
 } as const;
 export const DB_FILENAME = "data.duckdb";
-export const LOG_FILENAME = "worker.log";
+export const LOGS_DIR = "logs";
 export const CONFIG_FILENAME = "config.json";
 export const MCPX_DIR = "mcpx";
 export const SKILLS_DIR = "skills";
 export const MCPX_SERVERS_FILENAME = "servers.json";
 export const EMBEDDING_DIMENSION = 1536;
 export const EMBEDDING_MODEL = "text-embedding-3-small";
-export const LOG_MAX_BYTES = 10 * 1024 * 1024; // 10 MB
 
 export function getBotholomewDir(projectDir: string): string {
   return join(projectDir, BOTHOLOMEW_DIR);
@@ -30,8 +29,12 @@ export function getDbPath(projectDir: string): string {
   return join(projectDir, BOTHOLOMEW_DIR, DB_FILENAME);
 }
 
-export function getLogPath(projectDir: string): string {
-  return join(projectDir, BOTHOLOMEW_DIR, LOG_FILENAME);
+export function getWorkerLogsDir(projectDir: string): string {
+  return join(projectDir, BOTHOLOMEW_DIR, LOGS_DIR);
+}
+
+export function getWorkerLogPath(projectDir: string, workerId: string): string {
+  return join(projectDir, BOTHOLOMEW_DIR, LOGS_DIR, `${workerId}.log`);
 }
 
 export function getConfigPath(projectDir: string): string {

--- a/src/db/sql/17-worker_log_path.sql
+++ b/src/db/sql/17-worker_log_path.sql
@@ -1,0 +1,3 @@
+-- Per-worker log file path. NULL for foreground / in-process workers that
+-- write to stdout instead of a dedicated file.
+ALTER TABLE workers ADD COLUMN log_path TEXT;

--- a/src/db/workers.ts
+++ b/src/db/workers.ts
@@ -14,6 +14,7 @@ export interface Worker {
   started_at: Date;
   last_heartbeat_at: Date;
   stopped_at: Date | null;
+  log_path: string | null;
 }
 
 interface WorkerRow {
@@ -26,6 +27,7 @@ interface WorkerRow {
   started_at: string;
   last_heartbeat_at: string;
   stopped_at: string | null;
+  log_path: string | null;
 }
 
 function rowToWorker(row: WorkerRow): Worker {
@@ -39,6 +41,7 @@ function rowToWorker(row: WorkerRow): Worker {
     started_at: new Date(row.started_at),
     last_heartbeat_at: new Date(row.last_heartbeat_at),
     stopped_at: row.stopped_at ? new Date(row.stopped_at) : null,
+    log_path: row.log_path,
   };
 }
 
@@ -50,17 +53,19 @@ export async function registerWorker(
     hostname: string;
     mode: Worker["mode"];
     taskId?: string | null;
+    logPath?: string | null;
   },
 ): Promise<Worker> {
   const row = await db.queryGet<WorkerRow>(
-    `INSERT INTO workers (id, pid, hostname, mode, task_id, status)
-     VALUES (?1, ?2, ?3, ?4, ?5, 'running')
+    `INSERT INTO workers (id, pid, hostname, mode, task_id, status, log_path)
+     VALUES (?1, ?2, ?3, ?4, ?5, 'running', ?6)
      RETURNING *`,
     params.id,
     params.pid,
     params.hostname,
     params.mode,
     params.taskId ?? null,
+    params.logPath ?? null,
   );
   if (!row) throw new Error("INSERT did not return a row");
   return rowToWorker(row);

--- a/src/tui/components/WorkerPanel.tsx
+++ b/src/tui/components/WorkerPanel.tsx
@@ -1,7 +1,8 @@
 import { Box, Text, useInput, useStdout } from "ink";
-import { memo, useEffect, useState } from "react";
+import { memo, useEffect, useMemo, useState } from "react";
 import { withDb } from "../../db/connection.ts";
 import { listWorkers, type Worker } from "../../db/workers.ts";
+import { readLogTail } from "../../worker/log-reader.ts";
 
 interface WorkerPanelProps {
   dbPath: string;
@@ -14,6 +15,9 @@ const STATUS_FILTERS: readonly (Worker["status"] | null)[] = [
   "stopped",
   "dead",
 ];
+
+const PAGE_SCROLL_LINES = 10;
+const LOG_POLL_MS = 1500;
 
 function statusColor(status: Worker["status"]): string {
   switch (status) {
@@ -36,6 +40,12 @@ function formatAge(from: Date, now: Date): string {
   return `${Math.floor(hours / 24)}d`;
 }
 
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n}B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)}KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)}MB`;
+}
+
 export const WorkerPanel = memo(function WorkerPanel({
   dbPath,
   isActive,
@@ -46,6 +56,12 @@ export const WorkerPanel = memo(function WorkerPanel({
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [filterIdx, setFilterIdx] = useState(0);
   const [now, setNow] = useState(() => new Date());
+  const [viewMode, setViewMode] = useState<"detail" | "log">("detail");
+  const [logContent, setLogContent] = useState("");
+  const [logSize, setLogSize] = useState(0);
+  const [logTruncated, setLogTruncated] = useState(false);
+  const [logScroll, setLogScroll] = useState(0);
+  const [logFollow, setLogFollow] = useState(true);
 
   useEffect(() => {
     let mounted = true;
@@ -72,17 +88,135 @@ export const WorkerPanel = memo(function WorkerPanel({
     };
   }, [dbPath, filterIdx]);
 
+  const selected = workers[selectedIndex];
+  const selectedLogPath = selected?.log_path ?? null;
+
+  useEffect(() => {
+    if (viewMode !== "log" || !selectedLogPath) return;
+    let mounted = true;
+
+    const refresh = async () => {
+      try {
+        const tail = await readLogTail(selectedLogPath);
+        if (!mounted) return;
+        setLogContent(tail.content);
+        setLogSize(tail.size);
+        setLogTruncated(tail.truncated);
+      } catch {
+        // Ignore transient read errors; next tick will retry.
+      }
+    };
+
+    refresh();
+    const interval = setInterval(refresh, LOG_POLL_MS);
+    return () => {
+      mounted = false;
+      clearInterval(interval);
+    };
+  }, [viewMode, selectedLogPath]);
+
+  // Reset log scroll + content when the selection or view mode changes.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional reset triggers
+  useEffect(() => {
+    setLogScroll(0);
+    setLogFollow(true);
+    setLogContent("");
+    setLogSize(0);
+    setLogTruncated(false);
+  }, [selected?.id, viewMode]);
+
+  const logLines = useMemo(() => {
+    if (logContent.length === 0) return [];
+    // Trim a single trailing newline so the rendered list doesn't end with a
+    // blank row, but preserve internal blank lines.
+    const trimmed = logContent.endsWith("\n")
+      ? logContent.slice(0, -1)
+      : logContent;
+    return trimmed.split("\n");
+  }, [logContent]);
+
+  const visibleRows = Math.max(4, termRows - 8);
+  const maxLogScroll = Math.max(0, logLines.length - visibleRows);
+
+  // When following, snap scroll to the bottom whenever new log content
+  // arrives. The user can break follow mode by scrolling up; pressing G or
+  // running off the end via j/J resumes it.
+  useEffect(() => {
+    if (viewMode === "log" && logFollow) {
+      setLogScroll(maxLogScroll);
+    }
+  }, [viewMode, logFollow, maxLogScroll]);
+
   useInput(
     (input, key) => {
       if (!isActive) return;
+
+      if (input === "l") {
+        setViewMode((m) => (m === "log" ? "detail" : "log"));
+        return;
+      }
+
       if (key.upArrow) {
+        if (viewMode === "log" && key.shift) {
+          setLogFollow(false);
+          setLogScroll((s) => Math.max(0, s - 1));
+          return;
+        }
         setSelectedIndex((i) => Math.max(0, i - 1));
         return;
       }
       if (key.downArrow) {
+        if (viewMode === "log" && key.shift) {
+          setLogScroll((s) => {
+            const next = Math.min(maxLogScroll, s + 1);
+            if (next >= maxLogScroll) setLogFollow(true);
+            return next;
+          });
+          return;
+        }
         setSelectedIndex((i) => Math.min(workers.length - 1, i + 1));
         return;
       }
+
+      if (viewMode === "log") {
+        if (input === "j") {
+          setLogScroll((s) => {
+            const next = Math.min(maxLogScroll, s + 1);
+            if (next >= maxLogScroll) setLogFollow(true);
+            return next;
+          });
+          return;
+        }
+        if (input === "k") {
+          setLogFollow(false);
+          setLogScroll((s) => Math.max(0, s - 1));
+          return;
+        }
+        if (input === "J") {
+          setLogScroll((s) => {
+            const next = Math.min(maxLogScroll, s + PAGE_SCROLL_LINES);
+            if (next >= maxLogScroll) setLogFollow(true);
+            return next;
+          });
+          return;
+        }
+        if (input === "K") {
+          setLogFollow(false);
+          setLogScroll((s) => Math.max(0, s - PAGE_SCROLL_LINES));
+          return;
+        }
+        if (input === "g") {
+          setLogFollow(false);
+          setLogScroll(0);
+          return;
+        }
+        if (input === "G") {
+          setLogFollow(true);
+          setLogScroll(maxLogScroll);
+          return;
+        }
+      }
+
       if (input === "f") {
         setFilterIdx((i) => (i + 1) % STATUS_FILTERS.length);
         return;
@@ -91,9 +225,8 @@ export const WorkerPanel = memo(function WorkerPanel({
     { isActive },
   );
 
-  const selected = workers[selectedIndex];
   const filterLabel = STATUS_FILTERS[filterIdx] ?? "all";
-  const visibleRows = Math.max(4, termRows - 10);
+  const visibleSidebarRows = Math.max(4, termRows - 10);
 
   return (
     <Box flexDirection="column" flexGrow={1} paddingX={1}>
@@ -103,7 +236,11 @@ export const WorkerPanel = memo(function WorkerPanel({
         </Text>
         <Text dimColor> · filter: </Text>
         <Text color="yellow">{filterLabel}</Text>
-        <Text dimColor>{" · [f] cycle filter  [↑↓] select"}</Text>
+        <Text dimColor>
+          {viewMode === "log"
+            ? "  · [l] back  [↑↓] select  [j/k] scroll  [g/G] top/bot  [f] filter"
+            : "  · [l] view log  [f] cycle filter  [↑↓] select"}
+        </Text>
       </Box>
 
       {workers.length === 0 ? (
@@ -121,7 +258,7 @@ export const WorkerPanel = memo(function WorkerPanel({
             marginRight={2}
             overflow="hidden"
           >
-            {workers.slice(0, visibleRows).map((w, i) => {
+            {workers.slice(0, visibleSidebarRows).map((w, i) => {
               const active = i === selectedIndex;
               const short = w.id.slice(0, 8);
               return (
@@ -148,7 +285,21 @@ export const WorkerPanel = memo(function WorkerPanel({
             })}
           </Box>
           <Box flexDirection="column" flexGrow={1}>
-            {selected ? <WorkerDetail worker={selected} now={now} /> : null}
+            {selected ? (
+              viewMode === "log" ? (
+                <WorkerLogView
+                  worker={selected}
+                  lines={logLines}
+                  scroll={logScroll}
+                  visibleRows={visibleRows}
+                  truncated={logTruncated}
+                  size={logSize}
+                  follow={logFollow}
+                />
+              ) : (
+                <WorkerDetail worker={selected} now={now} />
+              )
+            ) : null}
           </Box>
         </Box>
       )}
@@ -201,6 +352,89 @@ function WorkerDetail({ worker, now }: { worker: Worker; now: Date }) {
             {worker.task_id}
           </Text>
         )}
+        {worker.log_path && (
+          <Text>
+            <Text dimColor>Log </Text>
+            <Text dimColor>{worker.log_path}</Text>
+          </Text>
+        )}
+      </Box>
+    </Box>
+  );
+}
+
+function WorkerLogView({
+  worker,
+  lines,
+  scroll,
+  visibleRows,
+  truncated,
+  size,
+  follow,
+}: {
+  worker: Worker;
+  lines: string[];
+  scroll: number;
+  visibleRows: number;
+  truncated: boolean;
+  size: number;
+  follow: boolean;
+}) {
+  if (!worker.log_path) {
+    return (
+      <Box flexDirection="column">
+        <Text bold color="blue">
+          {worker.id}
+        </Text>
+        <Box marginTop={1}>
+          <Text dimColor>
+            No log file (worker is running in foreground or was started before
+            per-worker logs existed).
+          </Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  if (lines.length === 0) {
+    return (
+      <Box flexDirection="column">
+        <Text bold color="blue">
+          {worker.id}
+        </Text>
+        <Box marginTop={1}>
+          <Text dimColor>Log empty.</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  const visible = lines.slice(scroll, scroll + visibleRows);
+  const lastLine = Math.min(scroll + visibleRows, lines.length);
+
+  return (
+    <Box flexDirection="column" flexGrow={1}>
+      <Box>
+        <Text bold color="blue">
+          {worker.id.slice(0, 8)}
+        </Text>
+        <Text dimColor>
+          {" "}
+          · {formatBytes(size)}
+          {truncated ? " (tail only)" : ""} ·{" "}
+        </Text>
+        <Text color={follow ? "green" : "yellow"}>
+          {follow ? "following" : "paused"}
+        </Text>
+        <Text dimColor>
+          {"  "}[{scroll + 1}–{lastLine} of {lines.length}]
+        </Text>
+      </Box>
+      <Box flexDirection="column" marginTop={1}>
+        {visible.map((line, i) => {
+          const lineNum = scroll + i;
+          return <Text key={lineNum}>{line || " "}</Text>;
+        })}
       </Box>
     </Box>
   );

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -25,6 +25,19 @@ export interface StartWorkerOptions {
    */
   taskId?: string;
   /**
+   * Pre-allocated worker id from the spawn parent. When provided, the parent
+   * has already opened a per-worker log file at this id and we record both on
+   * the workers row. Foreground/in-process callers may omit this and a fresh
+   * id will be generated.
+   */
+  workerId?: string;
+  /**
+   * Path to the per-worker log file (set by the spawn parent when launching
+   * a detached worker). Stored on the workers row so the TUI can tail it.
+   * Null/undefined for foreground workers writing to stdout.
+   */
+  logPath?: string;
+  /**
    * Whether to evaluate schedules as part of this run.
    * Defaults to `true` for one-shot workers without a taskId and for persist
    * workers; `false` when a taskId is supplied (targeted work shouldn't fan
@@ -86,7 +99,7 @@ export async function startWorker(
     logger.info("MCPX client initialized with external tools");
   }
 
-  const workerId = uuidv7();
+  const workerId = options.workerId ?? uuidv7();
   await withDb(dbPath, (conn) =>
     registerWorker(conn, {
       id: workerId,
@@ -94,6 +107,7 @@ export async function startWorker(
       hostname: hostname(),
       mode,
       taskId: taskId ?? null,
+      logPath: options.logPath ?? null,
     }),
   );
 

--- a/src/worker/log-reader.ts
+++ b/src/worker/log-reader.ts
@@ -1,0 +1,35 @@
+export const DEFAULT_LOG_TAIL_BYTES = 128 * 1024;
+
+export interface LogTail {
+  content: string;
+  truncated: boolean;
+  size: number;
+}
+
+/**
+ * Read the tail of a worker log file. Returns at most `maxBytes` from the end
+ * of the file; sets `truncated` when the file is larger than that.
+ *
+ * If the file doesn't exist (worker hasn't written anything yet), returns
+ * empty content rather than throwing — the caller renders an empty-state
+ * message instead of an error.
+ */
+export async function readLogTail(
+  logPath: string,
+  maxBytes = DEFAULT_LOG_TAIL_BYTES,
+): Promise<LogTail> {
+  const file = Bun.file(logPath);
+  if (!(await file.exists())) {
+    return { content: "", truncated: false, size: 0 };
+  }
+  const size = file.size;
+  if (size === 0) {
+    return { content: "", truncated: false, size: 0 };
+  }
+  if (size <= maxBytes) {
+    return { content: await file.text(), truncated: false, size };
+  }
+  const start = size - maxBytes;
+  const content = await file.slice(start, size).text();
+  return { content, truncated: true, size };
+}

--- a/src/worker/run.ts
+++ b/src/worker/run.ts
@@ -1,14 +1,14 @@
 #!/usr/bin/env bun
 
 // Standalone entry point for a worker when spawned as a detached process.
-// Usage: bun run src/worker/run.ts <projectDir> [--persist] [--task-id=<uuid>] [--no-eval-schedules]
+// Usage: bun run src/worker/run.ts <projectDir> [--worker-id=<uuid>] [--log-path=<path>] [--persist] [--task-id=<uuid>] [--no-eval-schedules]
 
 import { startWorker } from "./index.ts";
 
 const projectDir = process.argv[2];
 if (!projectDir) {
   console.error(
-    "Usage: bun run src/worker/run.ts <projectDir> [--persist] [--task-id=<uuid>] [--no-eval-schedules]",
+    "Usage: bun run src/worker/run.ts <projectDir> [--worker-id=<uuid>] [--log-path=<path>] [--persist] [--task-id=<uuid>] [--no-eval-schedules]",
   );
   process.exit(1);
 }
@@ -18,9 +18,17 @@ const persist = args.includes("--persist");
 const noEvalSchedules = args.includes("--no-eval-schedules");
 const taskIdArg = args.find((a) => a.startsWith("--task-id="));
 const taskId = taskIdArg ? taskIdArg.slice("--task-id=".length) : undefined;
+const workerIdArg = args.find((a) => a.startsWith("--worker-id="));
+const workerId = workerIdArg
+  ? workerIdArg.slice("--worker-id=".length)
+  : undefined;
+const logPathArg = args.find((a) => a.startsWith("--log-path="));
+const logPath = logPathArg ? logPathArg.slice("--log-path=".length) : undefined;
 
 await startWorker(projectDir, {
   mode: persist ? "persist" : "once",
   taskId,
+  workerId,
+  logPath,
   evalSchedules: noEvalSchedules ? false : undefined,
 });

--- a/src/worker/spawn.ts
+++ b/src/worker/spawn.ts
@@ -1,5 +1,11 @@
+import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
-import { getBotholomewDir, getLogPath } from "../constants.ts";
+import {
+  getBotholomewDir,
+  getWorkerLogPath,
+  getWorkerLogsDir,
+} from "../constants.ts";
+import { uuidv7 } from "../db/uuid.ts";
 import { logger } from "../utils/logger.ts";
 import type { WorkerMode } from "./index.ts";
 
@@ -12,11 +18,14 @@ export interface SpawnWorkerOptions {
  * Spawn a worker as a detached background process. Unlike the old daemon
  * model, multiple workers per project are allowed and expected — this just
  * launches a new one.
+ *
+ * The parent generates the worker id and opens a per-worker log file before
+ * spawning so that the TUI / CLI can later tail just this worker's output.
  */
 export async function spawnWorker(
   projectDir: string,
   options: SpawnWorkerOptions = {},
-): Promise<{ pid: number }> {
+): Promise<{ pid: number; workerId: string; logPath: string }> {
   const dotDir = getBotholomewDir(projectDir);
   const dirExists = await Bun.file(join(dotDir, "config.json")).exists();
   if (!dirExists) {
@@ -24,11 +33,20 @@ export async function spawnWorker(
     process.exit(1);
   }
 
-  const logPath = getLogPath(projectDir);
+  const workerId = uuidv7();
+  await mkdir(getWorkerLogsDir(projectDir), { recursive: true });
+  const logPath = getWorkerLogPath(projectDir, workerId);
   const logFile = Bun.file(logPath);
 
   const workerScript = new URL("./run.ts", import.meta.url).pathname;
-  const args = ["bun", "run", workerScript, projectDir];
+  const args = [
+    "bun",
+    "run",
+    workerScript,
+    projectDir,
+    `--worker-id=${workerId}`,
+    `--log-path=${logPath}`,
+  ];
   if (options.mode === "persist") args.push("--persist");
   if (options.taskId) args.push(`--task-id=${options.taskId}`);
 
@@ -44,5 +62,5 @@ export async function spawnWorker(
   );
   logger.dim(`  Log: ${logPath}`);
 
-  return { pid: proc.pid ?? 0 };
+  return { pid: proc.pid ?? 0, workerId, logPath };
 }

--- a/test/constants.test.ts
+++ b/test/constants.test.ts
@@ -11,9 +11,10 @@ import {
   getBotholomewDir,
   getConfigPath,
   getDbPath,
-  getLogPath,
   getMcpxDir,
-  LOG_FILENAME,
+  getWorkerLogPath,
+  getWorkerLogsDir,
+  LOGS_DIR,
   MCPX_DIR,
 } from "../src/constants.ts";
 
@@ -24,7 +25,7 @@ describe("constants", () => {
 
   test("file name constants are defined", () => {
     expect(DB_FILENAME).toBe("data.duckdb");
-    expect(LOG_FILENAME).toBe("worker.log");
+    expect(LOGS_DIR).toBe("logs");
     expect(CONFIG_FILENAME).toBe("config.json");
     expect(MCPX_DIR).toBe("mcpx");
   });
@@ -57,9 +58,15 @@ describe("path helpers", () => {
     );
   });
 
-  test("getLogPath returns project/.botholomew/worker.log", () => {
-    expect(getLogPath(projectDir)).toBe(
-      join(projectDir, ".botholomew", "worker.log"),
+  test("getWorkerLogsDir returns project/.botholomew/logs", () => {
+    expect(getWorkerLogsDir(projectDir)).toBe(
+      join(projectDir, ".botholomew", "logs"),
+    );
+  });
+
+  test("getWorkerLogPath returns project/.botholomew/logs/<id>.log", () => {
+    expect(getWorkerLogPath(projectDir, "abc123")).toBe(
+      join(projectDir, ".botholomew", "logs", "abc123.log"),
     );
   });
 

--- a/test/db/schema.test.ts
+++ b/test/db/schema.test.ts
@@ -65,7 +65,7 @@ describe("schema migrations", () => {
     )) as {
       count: number;
     };
-    expect(row.count).toBe(16);
+    expect(row.count).toBe(17);
 
     db.close();
   });

--- a/test/db/workers.test.ts
+++ b/test/db/workers.test.ts
@@ -49,6 +49,34 @@ describe("worker registration", () => {
     expect(w.task_id).toBe("task-42");
   });
 
+  test("stores logPath and round-trips through getWorker / listWorkers", async () => {
+    const w = await registerWorker(conn, {
+      id: "w-log-1",
+      pid: 1,
+      hostname: "h",
+      mode: "persist",
+      logPath: "/tmp/proj/.botholomew/logs/w-log-1.log",
+    });
+    expect(w.log_path).toBe("/tmp/proj/.botholomew/logs/w-log-1.log");
+
+    const fetched = await getWorker(conn, "w-log-1");
+    expect(fetched?.log_path).toBe("/tmp/proj/.botholomew/logs/w-log-1.log");
+
+    const listed = await listWorkers(conn, { status: "running" });
+    const found = listed.find((row) => row.id === "w-log-1");
+    expect(found?.log_path).toBe("/tmp/proj/.botholomew/logs/w-log-1.log");
+  });
+
+  test("log_path defaults to null when omitted", async () => {
+    const w = await registerWorker(conn, {
+      id: "w-log-2",
+      pid: 1,
+      hostname: "h",
+      mode: "once",
+    });
+    expect(w.log_path).toBeNull();
+  });
+
   test("heartbeat advances last_heartbeat_at", async () => {
     await registerWorker(conn, {
       id: "w-3",

--- a/test/worker/log-reader.test.ts
+++ b/test/worker/log-reader.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readLogTail } from "../../src/worker/log-reader.ts";
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "log-reader-"));
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+describe("readLogTail", () => {
+  test("returns empty + size 0 when the file does not exist", async () => {
+    const tail = await readLogTail(join(dir, "missing.log"));
+    expect(tail).toEqual({ content: "", truncated: false, size: 0 });
+  });
+
+  test("returns the full content for a small file", async () => {
+    const path = join(dir, "small.log");
+    const body = "line 1\nline 2\nline 3\n";
+    await writeFile(path, body);
+
+    const tail = await readLogTail(path);
+    expect(tail.content).toBe(body);
+    expect(tail.truncated).toBe(false);
+    expect(tail.size).toBe(Buffer.byteLength(body));
+  });
+
+  test("truncates to the last maxBytes when the file is larger", async () => {
+    const path = join(dir, "big.log");
+    const body = "x".repeat(2048);
+    await writeFile(path, body);
+
+    const tail = await readLogTail(path, 512);
+    expect(tail.size).toBe(2048);
+    expect(tail.truncated).toBe(true);
+    expect(tail.content.length).toBe(512);
+    // Tail should be the END of the file
+    expect(tail.content).toBe("x".repeat(512));
+  });
+
+  test("uses 128KB as the default tail size", async () => {
+    const path = join(dir, "default.log");
+    const body = "y".repeat(200 * 1024);
+    await writeFile(path, body);
+
+    const tail = await readLogTail(path);
+    expect(tail.truncated).toBe(true);
+    expect(tail.content.length).toBe(128 * 1024);
+  });
+});


### PR DESCRIPTION
## Summary
- Switches from a single shared `.botholomew/worker.log` to per-worker files at `.botholomew/logs/<id>.log`, recorded as `log_path` on the `workers` row, so each worker's output is independently addressable.
- Adds a log-tail view to the Workers tab: press `l` to swap the right pane between metadata and a live tail; `Shift+↑/↓`, `j/k`, `J/K`, `g/G` scroll, and `G` (or scrolling to the bottom) resumes follow.
- Spawn parent now generates the worker id and opens the per-worker log file before launching the child, passing both via `--worker-id` / `--log-path`; foreground workers leave `log_path` null.
- Updates `docs/tui.md`, `docs/architecture.md`, and the `README.md` project layout to describe the new model and key bindings.

## Test plan
- [x] `bun run lint` (tsc + biome) clean
- [x] `bun test` — 755 pass, 0 fail (covers `registerWorker({ logPath })` round-trip, `readLogTail` truncation/empty-file behavior, and the new migration count)
- [ ] Manual: `botholomew worker start --persist`, open `botholomew chat`, switch to tab 7, press `l`, confirm tick output streams in and scroll keys behave like TaskPanel