### PR TITLE
Show typed slash command in TUI and support named skill args

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -53,9 +53,18 @@ Please review the file at `$1`. Read it with the available tools, then provide:
 |---|---|
 | `$ARGUMENTS` | The entire argument string as typed |
 | `$1`, `$2`, … | Positional arguments (split on whitespace, quoted strings respected) |
+| `$<name>` | Named placeholder bound to the declared argument with that `name` (same value as the matching positional `$N`) |
 
 Missing optional arguments fall back to their `default`. Missing required
-arguments cause a validation error before the skill is sent.
+arguments cause a validation error before the skill is sent — the TUI
+prints a `Usage:` line and never calls the LLM.
+
+Named and positional placeholders refer to the same underlying value.
+The `arguments[]` order in frontmatter sets each name's slot: the first
+declared argument is `$1` and `$<first-name>`, the second is `$2` and
+`$<second-name>`, and so on. Named placeholders are word-boundary
+matched (so `$start` won't clip `$start_date`), and longer names are
+substituted first when both exist.
 
 Example:
 
@@ -63,8 +72,8 @@ Example:
 > /review src/cli.ts security
 ```
 
-becomes `$1 = "src/cli.ts"`, `$2 = "security"`, `$ARGUMENTS = "src/cli.ts
-security"`.
+becomes `$1 = $file = "src/cli.ts"`, `$2 = $focus = "security"`, and
+`$ARGUMENTS = "src/cli.ts security"`.
 
 ---
 
@@ -111,8 +120,10 @@ name and its description.
 The popup filters as you keep typing, and it disappears once you type
 a space — so a second `Return` submits the message as usual.
 
-A system message ("Running skill: review") is printed to the TUI when a
-skill is invoked, so it's visually distinct from a regular message.
+When a skill runs, the TUI's user bubble shows the literal slash command
+you typed (e.g. `/review src/cli.ts security`), not the rendered prompt
+body — that keeps the chat transcript readable. The agent still receives
+the fully-rendered prompt as its user message.
 
 ---
 
@@ -186,7 +197,10 @@ active session, but won't appear retroactively in history.
 - **Be explicit about what you want.** The model doesn't know the shape
   of the output unless you describe it.
 - **Use positional args, not free-form.** `/review src/cli.ts` is easier
-  to tab-complete than `/review --file=src/cli.ts`.
+  to tab-complete than `/review --file=src/cli.ts`. In the body, you
+  can reference each argument either positionally (`$1`, `$2`) or by
+  the name you gave it (`$file`, `$focus`) — pick whichever reads
+  better.
 - **Reference tools by name.** "Read the file with `context_read`" nudges
   the agent toward the right tool and keeps token counts down.
 - **Keep them short.** A skill is a prompt, not a program. If your skill

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/skills/commands.ts
+++ b/src/skills/commands.ts
@@ -1,5 +1,5 @@
 import type { SkillDefinition } from "./parser.ts";
-import { renderSkill } from "./parser.ts";
+import { renderSkill, validateSkillArgs } from "./parser.ts";
 
 export interface SlashCommand {
   name: string;
@@ -14,12 +14,30 @@ export const BUILTIN_SLASH_COMMANDS: SlashCommand[] = [
   { name: "exit", description: "End the chat session" },
 ];
 
+export interface QueueUserMessageOptions {
+  display?: string;
+}
+
 export interface SlashCommandContext {
   skills: Map<string, SkillDefinition>;
   addSystemMessage: (content: string) => void;
-  queueUserMessage: (content: string) => void;
+  queueUserMessage: (content: string, opts?: QueueUserMessageOptions) => void;
   exit: () => void;
   clearChat?: () => void;
+}
+
+export function formatSkillUsage(skill: SkillDefinition): string {
+  const parts = [`/${skill.name}`];
+  for (const arg of skill.arguments) {
+    if (arg.required && arg.default === undefined) {
+      parts.push(`<${arg.name}>`);
+    } else if (arg.default !== undefined) {
+      parts.push(`[${arg.name}=${arg.default}]`);
+    } else {
+      parts.push(`[${arg.name}]`);
+    }
+  }
+  return parts.join(" ");
 }
 
 /**
@@ -70,9 +88,16 @@ export function handleSlashCommand(
   // Skill dispatch
   const skill = ctx.skills.get(name);
   if (skill) {
+    const { missing } = validateSkillArgs(skill, rawArgs);
+    if (missing.length > 0) {
+      ctx.addSystemMessage(
+        `/${skill.name}: missing required argument(s): ${missing.join(", ")}\n` +
+          `Usage: ${formatSkillUsage(skill)}`,
+      );
+      return true;
+    }
     const rendered = renderSkill(skill, rawArgs);
-    ctx.addSystemMessage(`Running skill: ${skill.name}`);
-    ctx.queueUserMessage(rendered);
+    ctx.queueUserMessage(rendered, { display: input });
     return true;
   }
 

--- a/src/skills/parser.ts
+++ b/src/skills/parser.ts
@@ -55,7 +55,7 @@ export function parseSkillFile(raw: string, filePath: string): SkillDefinition {
  * Split a raw argument string into positional tokens,
  * respecting double-quoted strings.
  */
-function tokenize(raw: string): string[] {
+export function tokenize(raw: string): string[] {
   const tokens: string[] = [];
   let current = "";
   let inQuote = false;
@@ -77,9 +77,29 @@ function tokenize(raw: string): string[] {
   return tokens;
 }
 
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 export function renderSkill(skill: SkillDefinition, rawArgs: string): string {
   const tokens = tokenize(rawArgs);
   let result = skill.body;
+
+  // Replace $<argName> placeholders first, longest names first so a `$start`
+  // arg can't truncate `$start_date`. Word-boundary tail prevents `$end`
+  // from clipping `$endpoint`.
+  const namedArgs = skill.arguments
+    .map((argDef, i) => ({
+      name: argDef.name,
+      value: tokens[i] ?? argDef.default ?? "",
+    }))
+    .filter((a) => /^[A-Za-z_][A-Za-z0-9_]*$/.test(a.name))
+    .sort((a, b) => b.name.length - a.name.length);
+
+  for (const { name, value } of namedArgs) {
+    const re = new RegExp(`\\$${escapeRegex(name)}(?![A-Za-z0-9_])`, "g");
+    result = result.replace(re, value);
+  }
 
   result = result.replaceAll("$ARGUMENTS", rawArgs);
 
@@ -92,4 +112,24 @@ export function renderSkill(skill: SkillDefinition, rawArgs: string): string {
   }
 
   return result;
+}
+
+/**
+ * Identify required arguments that have neither a positional token
+ * nor a declared default. Used by the TUI to reject incomplete
+ * slash-command invocations before sending to the LLM.
+ */
+export function validateSkillArgs(
+  skill: SkillDefinition,
+  rawArgs: string,
+): { missing: string[] } {
+  const tokens = tokenize(rawArgs);
+  const missing: string[] = [];
+  skill.arguments.forEach((argDef, i) => {
+    if (!argDef.required) return;
+    const hasToken = tokens[i] !== undefined;
+    const hasDefault = argDef.default !== undefined;
+    if (!hasToken && !hasDefault) missing.push(argDef.name);
+  });
+  return { missing };
 }

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -145,13 +145,13 @@ export function App({
   const [activeTab, setActiveTab] = useState<TabId>(1);
   const [workerRunning, setWorkerRunning] = useState(false);
   const [chatTitle, setChatTitle] = useState<string | undefined>(undefined);
-  const queueRef = useRef<string[]>([]);
+  const queueRef = useRef<Array<{ display: string; content: string }>>([]);
   const processingRef = useRef(false);
   const [queuedMessages, setQueuedMessages] = useState<string[]>([]);
   const [selectedQueueIndex, setSelectedQueueIndex] = useState(0);
 
   const syncQueue = useCallback(() => {
-    const snapshot = [...queueRef.current];
+    const snapshot = queueRef.current.map((e) => e.display);
     setQueuedMessages(snapshot);
     setSelectedQueueIndex((prev) =>
       snapshot.length === 0 ? 0 : Math.min(prev, snapshot.length - 1),
@@ -297,7 +297,7 @@ export function App({
           );
           syncQueue();
           if (msg) {
-            setInputValue(msg);
+            setInputValue(msg.display);
           }
           return;
         }
@@ -327,9 +327,9 @@ export function App({
     processingRef.current = true;
 
     while (queueRef.current.length > 0) {
-      const trimmed = queueRef.current.shift();
+      const entry = queueRef.current.shift();
       syncQueue();
-      if (!trimmed) break;
+      if (!entry) break;
       setIsLoading(true);
       setStreamingText("");
       setActiveToolCalls([]);
@@ -338,7 +338,7 @@ export function App({
       const userMsg: ChatMessage = {
         id: msgId(),
         role: "user",
-        content: trimmed,
+        content: entry.display,
         timestamp: new Date(),
       };
       setMessages((prev) => [...prev, userMsg]);
@@ -366,7 +366,7 @@ export function App({
 
       let lastStreamFlush = 0;
       try {
-        await sendMessage(sessionRef.current, trimmed, {
+        await sendMessage(sessionRef.current, entry.content, {
           onToken: (token) => {
             currentText += token;
             const now = Date.now();
@@ -432,7 +432,10 @@ export function App({
   useEffect(() => {
     if (ready && initialPrompt && !initialPromptSent.current) {
       initialPromptSent.current = true;
-      queueRef.current.push(initialPrompt);
+      queueRef.current.push({
+        display: initialPrompt,
+        content: initialPrompt,
+      });
       syncQueue();
       setInputHistory((prev) => [...prev, initialPrompt]);
       processQueue();
@@ -570,9 +573,12 @@ export function App({
             };
             setMessages((prev) => [...prev, msg]);
           },
-          queueUserMessage: (content) => {
+          queueUserMessage: (content, opts) => {
             setInputHistory((prev) => [...prev, trimmed]);
-            queueRef.current.push(content);
+            queueRef.current.push({
+              display: opts?.display ?? content,
+              content,
+            });
             syncQueue();
             processQueue();
           },
@@ -618,7 +624,7 @@ export function App({
       }
 
       setInputHistory((prev) => [...prev, trimmed]);
-      queueRef.current.push(trimmed);
+      queueRef.current.push({ display: trimmed, content: trimmed });
       syncQueue();
       processQueue();
     },

--- a/test/skills/commands.test.ts
+++ b/test/skills/commands.test.ts
@@ -5,26 +5,34 @@ import {
 } from "../../src/skills/commands.ts";
 import type { SkillDefinition } from "../../src/skills/parser.ts";
 
+interface QueuedEntry {
+  content: string;
+  display: string;
+}
+
 function makeCtx(
   skills: Map<string, SkillDefinition> = new Map(),
   opts: { withClearChat?: boolean } = {},
 ): SlashCommandContext & {
   systemMessages: string[];
-  queuedMessages: string[];
+  queuedMessages: QueuedEntry[];
   exited: boolean;
   clearCalls: number;
 } {
   const ctx = {
     skills,
     systemMessages: [] as string[],
-    queuedMessages: [] as string[],
+    queuedMessages: [] as QueuedEntry[],
     exited: false,
     clearCalls: 0,
     addSystemMessage: (content: string) => {
       ctx.systemMessages.push(content);
     },
-    queueUserMessage: (content: string) => {
-      ctx.queuedMessages.push(content);
+    queueUserMessage: (content: string, opts?: { display?: string }) => {
+      ctx.queuedMessages.push({
+        content,
+        display: opts?.display ?? content,
+      });
     },
     exit: () => {
       ctx.exited = true;
@@ -89,15 +97,15 @@ describe("handleSlashCommand", () => {
     expect(ctx.systemMessages[0]).toContain("No skills loaded");
   });
 
-  test("dispatches skill and renders template", () => {
+  test("dispatches skill, renders content, displays slash command", () => {
     const skills = makeSkillMap(reviewSkill);
     const ctx = makeCtx(skills);
     const result = handleSlashCommand("/review src/main.ts", ctx);
     expect(result).toBe(true);
-    expect(ctx.systemMessages).toHaveLength(1);
-    expect(ctx.systemMessages[0]).toContain("Running skill: review");
+    expect(ctx.systemMessages).toHaveLength(0);
     expect(ctx.queuedMessages).toHaveLength(1);
-    expect(ctx.queuedMessages[0]).toBe("Please review `src/main.ts`.");
+    expect(ctx.queuedMessages[0]?.content).toBe("Please review `src/main.ts`.");
+    expect(ctx.queuedMessages[0]?.display).toBe("/review src/main.ts");
   });
 
   test("dispatches skill with no arguments", () => {
@@ -105,7 +113,72 @@ describe("handleSlashCommand", () => {
     const ctx = makeCtx(skills);
     const result = handleSlashCommand("/summarize", ctx);
     expect(result).toBe(true);
-    expect(ctx.queuedMessages[0]).toBe("Summarize this conversation.");
+    expect(ctx.queuedMessages[0]?.content).toBe("Summarize this conversation.");
+    expect(ctx.queuedMessages[0]?.display).toBe("/summarize");
+  });
+
+  test("rejects skill invocation missing required args", () => {
+    const skills = makeSkillMap(reviewSkill);
+    const ctx = makeCtx(skills);
+    const result = handleSlashCommand("/review", ctx);
+    expect(result).toBe(true);
+    expect(ctx.queuedMessages).toHaveLength(0);
+    expect(ctx.systemMessages).toHaveLength(1);
+    expect(ctx.systemMessages[0]).toContain("missing required argument(s)");
+    expect(ctx.systemMessages[0]).toContain("file");
+    expect(ctx.systemMessages[0]).toContain("Usage: /review <file>");
+  });
+
+  test("optional arg with default is rendered when omitted", () => {
+    const bizSkill: SkillDefinition = {
+      name: "biz-update",
+      description: "",
+      arguments: [
+        {
+          name: "start_date",
+          description: "",
+          required: false,
+          default: "yesterday",
+        },
+        {
+          name: "end_date",
+          description: "",
+          required: false,
+          default: "today",
+        },
+      ],
+      body: "From $start_date to $end_date.",
+      filePath: "/skills/biz-update.md",
+    };
+    const skills = makeSkillMap(bizSkill);
+    const ctx = makeCtx(skills);
+    const result = handleSlashCommand("/biz-update", ctx);
+    expect(result).toBe(true);
+    expect(ctx.queuedMessages).toHaveLength(1);
+    expect(ctx.queuedMessages[0]?.content).toBe("From yesterday to today.");
+    expect(ctx.queuedMessages[0]?.display).toBe("/biz-update");
+  });
+
+  test("required arg with default counts as satisfied", () => {
+    const skill: SkillDefinition = {
+      name: "thing",
+      description: "",
+      arguments: [
+        {
+          name: "name",
+          description: "",
+          required: true,
+          default: "world",
+        },
+      ],
+      body: "Hello $name",
+      filePath: "/skills/thing.md",
+    };
+    const ctx = makeCtx(makeSkillMap(skill));
+    const result = handleSlashCommand("/thing", ctx);
+    expect(result).toBe(true);
+    expect(ctx.systemMessages).toHaveLength(0);
+    expect(ctx.queuedMessages[0]?.content).toBe("Hello world");
   });
 
   test("unknown command shows error", () => {

--- a/test/skills/parser.test.ts
+++ b/test/skills/parser.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { parseSkillFile, renderSkill } from "../../src/skills/parser.ts";
+import {
+  parseSkillFile,
+  renderSkill,
+  tokenize,
+  validateSkillArgs,
+} from "../../src/skills/parser.ts";
 
 describe("parseSkillFile", () => {
   test("parses valid skill with all frontmatter fields", () => {
@@ -231,5 +236,179 @@ describe("renderSkill", () => {
       filePath: "/test.md",
     };
     expect(renderSkill(skill, "hello")).toBe("Value: hello0");
+  });
+
+  test("substitutes named arg placeholders from positional tokens", () => {
+    const skill = {
+      name: "test",
+      description: "",
+      arguments: [
+        { name: "start_date", description: "", required: false },
+        { name: "end_date", description: "", required: false },
+      ],
+      body: "From $start_date to $end_date.",
+      filePath: "/test.md",
+    };
+    expect(renderSkill(skill, "2026-01-01 2026-01-15")).toBe(
+      "From 2026-01-01 to 2026-01-15.",
+    );
+  });
+
+  test("named args fall back to declared defaults", () => {
+    const skill = {
+      name: "test",
+      description: "",
+      arguments: [
+        {
+          name: "start_date",
+          description: "",
+          required: false,
+          default: "yesterday",
+        },
+        {
+          name: "end_date",
+          description: "",
+          required: false,
+          default: "today",
+        },
+      ],
+      body: "From $start_date to $end_date.",
+      filePath: "/test.md",
+    };
+    expect(renderSkill(skill, "")).toBe("From yesterday to today.");
+  });
+
+  test("named placeholders are word-boundary safe", () => {
+    // $start should NOT clip $start_date when $start is also declared.
+    const skill = {
+      name: "test",
+      description: "",
+      arguments: [
+        { name: "start", description: "", required: false, default: "S" },
+        {
+          name: "start_date",
+          description: "",
+          required: false,
+          default: "SD",
+        },
+      ],
+      body: "$start | $start_date",
+      filePath: "/test.md",
+    };
+    // Positional: $1 = "a" → start, $2 = "b" → start_date
+    expect(renderSkill(skill, "a b")).toBe("a | b");
+  });
+
+  test("mixes $1 and named placeholders in same body", () => {
+    const skill = {
+      name: "test",
+      description: "",
+      arguments: [
+        { name: "file", description: "", required: true },
+        { name: "focus", description: "", required: false, default: "all" },
+      ],
+      body: "Review $1 ($file) focusing on $focus.",
+      filePath: "/test.md",
+    };
+    expect(renderSkill(skill, "src/main.ts perf")).toBe(
+      "Review src/main.ts (src/main.ts) focusing on perf.",
+    );
+  });
+
+  test("$ARGUMENTS still works alongside named placeholders", () => {
+    const skill = {
+      name: "test",
+      description: "",
+      arguments: [{ name: "topic", description: "", required: false }],
+      body: "Topic: $topic | Raw: $ARGUMENTS",
+      filePath: "/test.md",
+    };
+    expect(renderSkill(skill, "auth")).toBe("Topic: auth | Raw: auth");
+  });
+
+  test("ignores named args with non-identifier names", () => {
+    // Defensive: an arg with a weird name shouldn't blow up the regex.
+    const skill = {
+      name: "test",
+      description: "",
+      arguments: [{ name: "1bad", description: "", required: false }],
+      body: "literal $1bad",
+      filePath: "/test.md",
+    };
+    // No named substitution; $1 still expands so "$1bad" becomes "valuebad"
+    expect(renderSkill(skill, "value")).toBe("literal valuebad");
+  });
+});
+
+describe("tokenize", () => {
+  test("splits on whitespace", () => {
+    expect(tokenize("a b c")).toEqual(["a", "b", "c"]);
+  });
+
+  test("respects double-quoted strings", () => {
+    expect(tokenize('"a b" c')).toEqual(["a b", "c"]);
+  });
+
+  test("returns empty array for empty input", () => {
+    expect(tokenize("")).toEqual([]);
+  });
+});
+
+describe("validateSkillArgs", () => {
+  test("returns no missing when no required args", () => {
+    const skill = {
+      name: "test",
+      description: "",
+      arguments: [{ name: "topic", description: "", required: false }],
+      body: "",
+      filePath: "/test.md",
+    };
+    expect(validateSkillArgs(skill, "")).toEqual({ missing: [] });
+  });
+
+  test("flags required args without token or default", () => {
+    const skill = {
+      name: "test",
+      description: "",
+      arguments: [
+        { name: "file", description: "", required: true },
+        { name: "focus", description: "", required: true },
+      ],
+      body: "",
+      filePath: "/test.md",
+    };
+    expect(validateSkillArgs(skill, "a")).toEqual({ missing: ["focus"] });
+  });
+
+  test("required arg with default is satisfied", () => {
+    const skill = {
+      name: "test",
+      description: "",
+      arguments: [
+        {
+          name: "file",
+          description: "",
+          required: true,
+          default: "src/index.ts",
+        },
+      ],
+      body: "",
+      filePath: "/test.md",
+    };
+    expect(validateSkillArgs(skill, "")).toEqual({ missing: [] });
+  });
+
+  test("returns no missing when all required args provided", () => {
+    const skill = {
+      name: "test",
+      description: "",
+      arguments: [
+        { name: "file", description: "", required: true },
+        { name: "focus", description: "", required: false, default: "all" },
+      ],
+      body: "",
+      filePath: "/test.md",
+    };
+    expect(validateSkillArgs(skill, "src/main.ts")).toEqual({ missing: [] });
   });
 });


### PR DESCRIPTION
## Summary
- TUI slash-command invocations now show the literal `/name args` in the user bubble instead of dumping the rendered prompt body into the transcript; the agent still receives the fully-rendered body. Implemented by splitting the chat queue into `{display, content}` entries.
- `renderSkill` now substitutes `$<name>` placeholders bound to declared arguments (in addition to `$1..$9` and `$ARGUMENTS`), with longer names processed first and word-boundary matching so `$start` can't clip `$start_date`.
- New `validateSkillArgs` helper rejects slash commands that omit a required arg (with no default) before reaching the LLM, printing a `Usage: /<name> <args…>` hint in the TUI.
- Drops the now-redundant "Running skill: <name>" system message, updates `docs/skills.md`, and bumps the version to 0.9.10.

## Test plan
- [x] `bun run lint` clean
- [x] `bun test` — 783 pass (50 in `test/skills/`, including new cases for named placeholders, prefix safety, default fallback, missing-required-arg rejection, and `{display, content}` capture)
- [ ] Manual: in `bun run dev chat`, run `/biz-update 2026-01-01 2026-01-15` and confirm the user bubble shows the slash command (not the rendered body), and the agent acts on the substituted dates
- [ ] Manual: run `/biz-update` (defaults) and a skill with a required-no-default arg to confirm the Usage hint and that no LLM call is made

🤖 Generated with [Claude Code](https://claude.com/claude-code)