### PR TITLE
Sync user-facing docs with current code (worker rename, no HNSW/VSS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ through MCP servers wired up via [MCPX](https://github.com/evantahler/mcpx).
   DuckDB. Copy it, share it, check it in (or `.gitignore` it).
 - **Your data, your disk.** Project state — tasks, threads, ingested
   context, embeddings — lives in `.botholomew/`, indexed in DuckDB with
-  HNSW for vector search. Model calls go direct to Anthropic and OpenAI;
-  any further reach is scoped to the MCP servers you add.
+  BM25 keyword search and `array_cosine_distance` vector search. Model
+  calls go direct to Anthropic and OpenAI; any further reach is scoped to
+  the MCP servers you add.
 - **Extensible.** External tools come from MCP servers via
   [MCPX](https://github.com/evantahler/mcpx) — run them locally (Gmail,
   Slack, GitHub) or connect through an MCP gateway like
@@ -115,12 +116,14 @@ my-project/
     soul.md               # always-loaded identity (not agent-editable)
     beliefs.md            # always-loaded, agent-editable priors
     goals.md              # always-loaded, agent-editable goals
+    capabilities.md       # always-loaded, agent-editable tool inventory
     config.json           # models, tick interval, API keys
     data.duckdb           # tasks, schedules, context, embeddings, logs
     mcpx/servers.json     # external MCP servers (Gmail, Slack, …)
-    skills/               # user-defined slash commands
+    skills/               # slash commands (built-ins + user-defined)
       summarize.md
       standup.md
+      capabilities.md
     logs/                 # per-worker log files (one file per spawned worker)
       <worker-id>.log
 ```
@@ -140,12 +143,11 @@ Everything the agent can touch is here. No surprises.
 | `botholomew worker list\|status\|stop\|kill\|reap` | Inspect and manage running workers |
 | `botholomew chat` | Interactive Ink/React TUI |
 | `botholomew task list\|add\|view\|update\|reset\|delete` | Manage the task queue |
-| `botholomew schedule list\|add\|enable\|trigger\|delete` | Recurring work |
-| `botholomew context add\|list\|view\|search\|refresh\|remove` | Ingest & browse knowledge (files, folders, URLs) |
+| `botholomew schedule list\|add\|view\|enable\|disable\|trigger\|delete` | Recurring work |
+| `botholomew context add\|list\|search\|chunks\|refresh\|delete` | Ingest & browse knowledge (files, folders, URLs); also exposes the agent's `read`/`write`/`tree`/`edit`/… tools as subcommands |
 | `botholomew capabilities` | Rescan built-in + MCPX tools and rewrite `.botholomew/capabilities.md` |
-| `botholomew mcpx servers\|add\|remove\|info\|search\|exec\|ping\|auth\|import-global` | Configure external MCP servers |
+| `botholomew mcpx servers\|list\|add\|remove\|info\|search\|exec\|ping\|auth\|deauth\|import-global\|…` | Configure external MCP servers (passthrough to `mcpx`) |
 | `botholomew skill list\|show\|create\|validate` | Manage slash-command skills |
-| `botholomew context ... \| search ...` | Direct access to the agent's virtual filesystem |
 | `botholomew thread list\|view` | Browse the agent's interaction history |
 | `botholomew nuke context\|tasks\|schedules\|threads\|all` | Bulk-erase sections of the database |
 | `botholomew upgrade` | Self-update |
@@ -175,7 +177,7 @@ All `list` subcommands support `-l, --limit <n>` and `-o, --offset <n>` for pagi
                │  ┌───────────┐ ┌──────────────┐    │
                │  │  tasks    │ │ context_items│    │
                │  │ schedules │ │  embeddings  │    │
-               │  │  workers  │ │   (HNSW)     │    │
+               │  │  workers  │ │  (FTS+vector)│    │
                │  │  threads  │ │              │    │
                │  └───────────┘ └──────────────┘    │
                └─────┬───────────────────────────────┘
@@ -203,8 +205,8 @@ Topics worth understanding in detail:
 - **[The virtual filesystem](docs/virtual-filesystem.md)** — why the agent's
   "files" are actually DuckDB rows, and how `context_read`/`context_write` work.
 - **[Context & hybrid search](docs/context-and-search.md)** — LLM-driven
-  chunking, OpenAI embeddings, and DuckDB's HNSW-accelerated keyword +
-  vector search.
+  chunking, OpenAI embeddings, and DuckDB BM25 + linear-scan vector
+  search merged with reciprocal rank fusion.
 - **[Tasks & schedules](docs/tasks-and-schedules.md)** — the claim loop, DAG
   validation, stale-task recovery, and natural-language recurring schedules.
 - **[The Tool class](docs/tools.md)** — one Zod definition, three consumers
@@ -226,9 +228,9 @@ Topics worth understanding in detail:
 ## Tech stack
 
 - **[Bun](https://bun.sh)** + TypeScript
-- **[DuckDB](https://duckdb.org)** via `@duckdb/node-api`, with the
-  **[VSS extension](https://duckdb.org/docs/stable/extensions/vss)** for
-  native vector search
+- **[DuckDB](https://duckdb.org)** via `@duckdb/node-api` —
+  `array_cosine_distance()` (core DuckDB) for vector search, plus the
+  built-in FTS extension for BM25 keyword search
 - **[Anthropic SDK](https://docs.anthropic.com/en/api/client-sdks)** for
   Claude — the reasoning model
 - **OpenAI embeddings API** (`text-embedding-3-small`, 1536-dim) for

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -209,9 +209,10 @@ DuckDB's "don't open the same DB twice" rule; when the last caller in the
 process releases, we close the instance and free the OS-level lock so
 another process can claim it.
 
-The DuckDB VSS extension is loaded at connect time (`INSTALL vss; LOAD
-vss;`) and HNSW persistence is enabled so vector indexes survive
-restarts. See `src/db/connection.ts`.
+Vector search uses `array_cosine_distance()` (core DuckDB, no extension)
+over a linear scan of the `embeddings.embedding` column; the FTS
+extension (`INSTALL fts; LOAD fts;`) is loaded at connect time for BM25
+keyword search. See `src/db/connection.ts`.
 
 ---
 

--- a/docs/captures.md
+++ b/docs/captures.md
@@ -13,7 +13,7 @@ Two pieces:
    GIF, MP4, or PNG.
 2. **Fake LLM mode** — when `BOTHOLOMEW_FAKE_LLM=1` is set, every Anthropic
    client in the codebase is swapped for a scripted stub that streams
-   fixture-defined replies (see `src/daemon/fake-llm.ts`). This makes
+   fixture-defined replies (see `src/worker/fake-llm.ts`). This makes
    captures hermetic: no API key required, no network, and every run produces
    the same output.
 
@@ -74,7 +74,7 @@ bun run capture chat-happy-path
    Output docs/assets/<name>.gif
 
    Sleep 1s
-   Type "botholomew chat --no-daemon"
+   Type "botholomew chat"
    Sleep 600ms
    Enter
    Sleep 4s
@@ -103,7 +103,7 @@ bun run capture chat-happy-path
   (modulo VHS upgrades). `git diff docs/assets/` is meaningful.
 - **Hermetic.** No API key needed, so CI can regenerate captures on merge.
 - **Decoupled.** The TUI itself is unchanged — the fake swap lives at the
-  daemon LLM boundary (`src/daemon/llm-client.ts`), so the same stub can be
+  worker LLM boundary (`src/worker/llm-client.ts`), so the same stub can be
   reused for deterministic agent-loop tests.
 
 ## Known VHS/ttyd limitations

--- a/docs/context-and-search.md
+++ b/docs/context-and-search.md
@@ -312,4 +312,4 @@ an embedding of the query string itself.
 
 If you want a fully-local setup, swap `src/context/embedder.ts` for a
 local model and adjust `EMBEDDING_DIMENSION` in `src/constants.ts` —
-everything downstream (VSS, HNSW, hybrid search) is dimension-agnostic.
+everything downstream (hybrid search) is dimension-agnostic.

--- a/docs/mcpx.md
+++ b/docs/mcpx.md
@@ -7,8 +7,8 @@ GitHub — comes from MCP servers, managed per project via
 
 Think of MCPX as the `package.json` of the agent's tools: a
 project-local manifest (`.botholomew/mcpx/servers.json`) lists the MCP
-servers this project can use, and the daemon connects to them at
-startup.
+servers this project can use, and workers and the chat session connect
+to them at startup.
 
 You have two options for *how* those servers run:
 
@@ -103,8 +103,8 @@ them (e.g. `--args "-y,@scope/pkg"`).
 2. Connects to every server.
 3. Returns an `McpxClient | null` (`null` if no servers are configured).
 
-The daemon holds the client for its entire lifetime and calls
-`client.close()` on SIGTERM/SIGINT. CLI commands like
+Each worker (and the chat session) holds the client for its lifetime
+and calls `client.close()` on SIGTERM/SIGINT. CLI commands like
 `botholomew mcpx exec` open a client, do their work, and close it.
 
 ---

--- a/docs/persistent-context.md
+++ b/docs/persistent-context.md
@@ -40,14 +40,14 @@ prompt, verbatim. Use sparingly. `soul.md`, `beliefs.md`, and `goals.md`
 are always-loaded.
 
 **`loading: contextual`** — the file is included only if its content
-shares keywords with the caller's current intent. The daemon derives
+shares keywords with the caller's current intent. The worker derives
 keywords from the running task's name and description; the chat agent
 derives them from your most recent message. Use this for
 topic-specific notes ("Everything I know about our invoicing system")
 that shouldn't pollute the prompt on unrelated tasks.
 
 See `loadPersistentContext()` and `extractKeywords()` in
-`src/daemon/prompt.ts`.
+`src/worker/prompt.ts`.
 
 ---
 
@@ -134,7 +134,7 @@ agent-modification: true
 
 - Evan prefers bullet-point summaries over paragraphs.
 - The "Q4 planning" doc in /notes is the canonical source for revenue targets.
-- The daemon should escalate to a "waiting" status if a task needs access
+- The worker should escalate to a "waiting" status if a task needs access
   to a tool that isn't configured, instead of failing outright.
 - When summarizing email, strip quoted replies — they add tokens without
   value.
@@ -184,10 +184,10 @@ agent-modification: false
 Tasks mentioning "deploy", "release", or "version" — and chat messages
 mentioning the same — will now include this file in the system prompt
 automatically. You didn't have to register it anywhere. On every tick
-the daemon reads every `.md` file in `.botholomew/`, extracts words
+the worker reads every `.md` file in `.botholomew/`, extracts words
 longer than three characters from the current task's name and
 description, and includes any `loading: contextual` file whose content
 contains at least one of those words. The chat agent does the same on
 every turn, using your most recent message as the keyword source. See
-`loadPersistentContext()` in `src/daemon/prompt.ts` for the exact
+`loadPersistentContext()` in `src/worker/prompt.ts` for the exact
 logic.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -50,7 +50,7 @@ export const completeTaskTool = {
 | `name` | Snake-case identifier; also the CLI subcommand name |
 | `description` | Used for both the LLM tool definition and CLI help text |
 | `group` | Groups tools into CLI namespaces (`task`, `file`, `dir`, …) |
-| `terminal` | If `true`, the daemon ends the agent loop when this tool is called (e.g., `complete_task`, `fail_task`, `wait_task`) |
+| `terminal` | If `true`, the agent loop ends when this tool is called (e.g., `complete_task`, `fail_task`, `wait_task`) |
 | `inputSchema` | Zod schema with `.describe()` per field — becomes JSON Schema for the model and Commander flags for the CLI |
 | `outputSchema` | Zod schema guaranteeing the shape of the response |
 | `execute` | The actual implementation, receiving validated input and a `ToolContext` |
@@ -85,7 +85,7 @@ That means:
   and will be closed immediately after. Use it for ordinary tools that
   do one or two quick queries.
 - `ctx.dbPath` is for tools that run long enough that holding the file
-  lock would block the daemon or CLI (e.g., `context_refresh` re-fetching
+  lock would block the worker or CLI (e.g., `context_refresh` re-fetching
   many URLs). Wrap each DB touch in
   `await withDb(ctx.dbPath, async (conn) => { … })` so the lock is
   released between items.
@@ -126,7 +126,7 @@ tool by name via `getTool(name)`, validates the input against
 `tool_result` block.
 
 Terminal tools (the ones with `terminal: true`) tell the loop to stop.
-For the daemon, those are `complete_task`, `fail_task`, and `wait_task` —
+For workers, those are `complete_task`, `fail_task`, and `wait_task` —
 any of which transitions the task out of `in_progress`.
 
 ---

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -364,9 +364,10 @@ A few choices worth knowing if you're reading or modifying the TUI:
 - **Colors look off / no colors at all.** Your terminal may not be
   reporting `COLORFGBG`. Export it manually (`export COLORFGBG="15;0"`
   for light, `"15;16"` for dark) or rely on the macOS fallback.
-- **"Daemon not running" in the status bar.** Run `botholomew daemon
-  status`; if it's not up, either restart with `botholomew daemon
-  start` or relaunch `chat` without `--no-daemon`.
+- **No workers running.** The TUI does not auto-spawn workers — check
+  `botholomew worker list --status running`. If nothing is alive, start
+  one with `botholomew worker start --persist` or have the chat agent
+  call `spawn_worker`.
 - **Weird layout in tmux / split panes.** Ink needs a stable terminal
   width; if the pane resizes mid-render, large tool-call boxes can
   wrap oddly. A fresh `Ctrl+L` usually sorts it.
@@ -381,7 +382,7 @@ A few choices worth knowing if you're reading or modifying the TUI:
 
 - [Skills (slash commands)](skills.md) — the `/<name>` commands the
   popup surfaces.
-- [Architecture](architecture.md) — how the TUI, daemon, and watchdog
+- [Architecture](architecture.md) — how the TUI, workers, and CLI
   share one DuckDB.
 - [Tasks & schedules](tasks-and-schedules.md) — what the Tasks and
   Schedules tabs are actually managing.

--- a/docs/virtual-filesystem.md
+++ b/docs/virtual-filesystem.md
@@ -66,7 +66,7 @@ for `context_refresh`.
 | File contents       | `context_items.content` (TEXT) or `content_blob` (BLOB) |
 | MIME type           | `context_items.mime_type` |
 | Directory           | A row with `mime_type = 'inode/directory'` |
-| Directory listing   | `SELECT DISTINCT parent(path) WHERE drive = ?` |
+| Directory listing   | Items filtered by `drive` and a path prefix, with intermediate directory segments derived from the matching paths |
 | Binary file         | `is_textual = false`, content in `content_blob` |
 | Ingestion time      | `indexed_at`, `created_at`, `updated_at` |
 
@@ -166,9 +166,11 @@ Every mutation cascades into the embeddings table:
 - `context_move` → no embedding changes (embeddings reference the item id, not the path).
 - `context_delete` → cascade delete embedding rows.
 
-The HNSW index on `embeddings.embedding` stays in sync automatically
-(it is maintained by DuckDB VSS on INSERT/DELETE, and persisted with
-`SET hnsw_enable_experimental_persistence = true`).
+Embeddings are stored as `FLOAT[1536]` and queried by linear scan via
+`array_cosine_distance()` — no HNSW index, no VSS extension. The FTS
+index over `chunk_content` and `title` is rebuilt by
+`rebuildSearchIndex()` after every ingest write. See
+[context-and-search.md](context-and-search.md) for the full pipeline.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Drop stale HNSW/VSS claims from README + architecture + virtual-filesystem + context-and-search; describe `array_cosine_distance` + FTS instead.
- Replace lingering `daemon` references with `worker` / `agent loop` across docs after the M9 rename (persistent-context, captures, mcpx, tools, tui).
- Fix README CLI table (schedule/context/mcpx subcommands), add `capabilities.md` to the project tree, rewrite the obsolete "Daemon not running" TUI troubleshooting bullet, and replace the misleading `SELECT parent(path)` snippet in virtual-filesystem.md.

## Test plan

- [x] \`bun run lint\` (tsc + biome) passes
- [x] \`grep -rn 'daemon' docs/ README.md\` — only legitimate historical mentions remain
- [x] \`grep -rn 'HNSW\\|VSS' docs/ README.md\` — only the rationale paragraph and intentional "no HNSW" wording remain
- [x] CLI table verified against \`bun run dev -- <subcommand> --help\`

## Follow-ups (not in this PR)

- \`docs/tapes/*.tape\` still call \`botholomew chat --no-daemon\`; that flag was removed in M9 so \`bun run capture\` likely needs updating.
- \`CLAUDE.md\` line 28 says "DuckDB with VSS extension" but line 62 in the same file says the opposite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)