### PR TITLE
db doctor: don't block repair on dead-PID workers; quiet child stderr

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -283,7 +283,7 @@ anything else that touches a corrupted row die immediately.
 | Mode | What it does |
 |---|---|
 | `db doctor` (default) | For each user table, spawns a child Bun process that runs a self-update touching the PK index. Reports `ok` / `empty` / `missing` / `corrupt` per table. The child-process isolation is essential — a panic in the probe stays out of the doctor itself. |
-| `db doctor --repair` | Refuses if any worker is registered as `running`. Runs `CHECKPOINT`, `EXPORT DATABASE` to a timestamped directory under `.botholomew/`, renames the original `data.duckdb` (and `.wal`) to `data.duckdb.bak-<timestamp>`, opens a fresh DB at the original path, and `IMPORT DATABASE`s back. Indexes are rebuilt from data, which restores write integrity. |
+| `db doctor --repair` | Refuses if any worker is **actually running** (PID alive). Stale `status='running'` rows whose PIDs are dead — the case that tends to coexist with workers-table corruption — are warned about but do not block repair, because flipping them to `stopped` would just trip the same corruption. Runs `CHECKPOINT`, `EXPORT DATABASE` to a timestamped directory under `.botholomew/`, renames the original `data.duckdb` (and `.wal`) to `data.duckdb.bak-<timestamp>`, opens a fresh DB at the original path, and `IMPORT DATABASE`s back. Indexes are rebuilt from data, which restores write integrity. After repair, `botholomew worker reap` cleans up the stale rows. |
 
 Repair is idempotent and non-destructive: the original DB is preserved
 as a `.bak-<timestamp>` file next to the new one. Delete the backup once

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/commands/db.ts
+++ b/src/commands/db.ts
@@ -3,11 +3,12 @@ import type { Command } from "commander";
 import { getDbPath } from "../constants.ts";
 import { withDb as coreWithDb } from "../db/connection.ts";
 import {
+  isPidAlive,
   type ProbeResult,
   probeAllTables,
   repairDatabase,
 } from "../db/doctor.ts";
-import { listWorkers } from "../db/workers.ts";
+import { listWorkers, type Worker } from "../db/workers.ts";
 import { logger } from "../utils/logger.ts";
 
 function statusBadge(status: ProbeResult["status"]): string {
@@ -78,27 +79,37 @@ async function doctor(program: Command, repair: boolean): Promise<void> {
     process.exit(1);
   }
 
-  // Repair requires exclusive access — refuse if any worker is registered
-  // as running, otherwise the EXPORT would race with the worker's writes.
+  // Repair requires exclusive access — refuse if any worker is actually
+  // running, otherwise the EXPORT would race with the worker's writes.
+  // Stale `status='running'` rows whose PID is dead (the exact case that
+  // tends to coexist with workers-table corruption) are reported but do
+  // not block repair: trying to flip them to `stopped` would just trip
+  // the same corruption we're about to fix.
   const running = await coreWithDb(dbPath, async (conn) => {
     try {
       return await listWorkers(conn, { status: "running" });
     } catch {
-      // If listWorkers itself trips the corruption we're about to fix,
-      // fall through and let repair proceed; the user is on their own
-      // for confirming no live workers, which `worker reap` would also
-      // be unable to do anyway.
-      return [];
+      return [] as Worker[];
     }
   });
-  if (running.length > 0) {
+  const live = running.filter((w) => isPidAlive(w.pid));
+  const stale = running.filter((w) => !isPidAlive(w.pid));
+  if (live.length > 0) {
     logger.error(
-      `${running.length} worker(s) registered as running. Stop them first: botholomew worker stop <id>`,
+      `${live.length} worker(s) actually running. Stop them first: botholomew worker stop <id>`,
     );
-    for (const w of running) {
+    for (const w of live) {
       logger.dim(`  ${w.id} (pid ${w.pid}, mode=${w.mode})`);
     }
     process.exit(1);
+  }
+  if (stale.length > 0) {
+    logger.warn(
+      `${stale.length} worker row(s) marked 'running' but PID is dead — proceeding (rows will be carried through repair, then reapable):`,
+    );
+    for (const w of stale) {
+      logger.dim(`  ${w.id} (pid ${w.pid}, mode=${w.mode})`);
+    }
   }
 
   logger.phase("repair", "EXPORT DATABASE → swap files → IMPORT DATABASE");

--- a/src/db/doctor.ts
+++ b/src/db/doctor.ts
@@ -85,12 +85,15 @@ export async function probeTable(
     }
   `;
 
+  // Discard the child's stderr. When the probe panics, Bun writes a multi-
+  // line crash banner there which would otherwise spill into our table
+  // output via the fallback message. The exit code alone tells us what we
+  // need to know.
   const proc = Bun.spawn(["bun", "-e", script], {
-    stdio: ["ignore", "pipe", "pipe"],
+    stdio: ["ignore", "pipe", "ignore"],
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
+  const [stdout, exitCode] = await Promise.all([
     new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
     proc.exited,
   ]);
 
@@ -103,20 +106,21 @@ export async function probeTable(
     return {
       table,
       status: "missing",
-      message: stdout.slice("MISSING:".length),
+      message: firstLine(stdout.slice("MISSING:".length)),
     };
   }
   if (stdout.startsWith("CORRUPT:")) {
     return {
       table,
       status: "corrupt",
-      message: stdout.slice("CORRUPT:".length),
+      message: firstLine(stdout.slice("CORRUPT:".length)),
     };
   }
-  const reason =
-    stderr.trim() ||
-    `child exited with code ${exitCode} and no verdict (likely native panic)`;
-  return { table, status: "corrupt", message: reason };
+  return {
+    table,
+    status: "corrupt",
+    message: `child exited with code ${exitCode} (likely native panic)`,
+  };
 }
 
 /**
@@ -207,6 +211,30 @@ export async function repairDatabase(dbPath: string): Promise<RepairResult> {
 async function pathExists(p: string): Promise<boolean> {
   try {
     await stat(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function firstLine(s: string): string {
+  const trimmed = s.trim();
+  const nl = trimmed.indexOf("\n");
+  return nl === -1 ? trimmed : trimmed.slice(0, nl);
+}
+
+/**
+ * Send signal 0 to test whether `pid` corresponds to a live process. Returns
+ * false on ESRCH (no such process) and on any other error (including EPERM,
+ * which we conservatively treat as "not ours, not relevant"). Used by the
+ * doctor's safety gate to distinguish workers actually running from rows
+ * that say `status = 'running'` because the worker crashed before flipping
+ * its row to `stopped` or `dead`.
+ */
+export function isPidAlive(pid: number): boolean {
+  if (!pid || pid < 1) return false;
+  try {
+    process.kill(pid, 0);
     return true;
   } catch {
     return false;

--- a/test/db/doctor.test.ts
+++ b/test/db/doctor.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { getConnection } from "../../src/db/connection.ts";
 import {
+  isPidAlive,
   PROBE_TABLES,
   probeAllTables,
   probeTable,
@@ -74,6 +75,23 @@ describe("probeAllTables", () => {
     );
     // Empty DB: no table is corrupt.
     expect(results.every((r) => r.status !== "corrupt")).toBe(true);
+  });
+});
+
+describe("isPidAlive", () => {
+  test("returns true for the current process", () => {
+    expect(isPidAlive(process.pid)).toBe(true);
+  });
+
+  test("returns false for a sentinel non-existent pid", () => {
+    // PID 0 is special on POSIX (process group); reject it explicitly.
+    expect(isPidAlive(0)).toBe(false);
+    expect(isPidAlive(-1)).toBe(false);
+  });
+
+  test("returns false for a pid that was never assigned in this process tree", () => {
+    // 2^31 - 1 is past the typical max PID on macOS/Linux.
+    expect(isPidAlive(2147483647)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Follow-up to #159. First real-world use of \`db doctor --repair\` surfaced two issues:

- The probe child's Bun panic banner was leaking into the per-table message column via our captured stderr, putting "===" and a multi-line crash dump into the table output. Discard child stderr and use the exit code instead; single-line any messages we do show.
- Repair refused with "2 worker(s) registered as running" even though their PIDs were dead and \`worker stop\` itself panicked on the same corrupt index — chicken-and-egg. New \`isPidAlive\` helper (uses \`process.kill(pid, 0)\`) lets the safety gate distinguish actually-running workers from stale rows; stale rows are warned about, carried through the EXPORT/IMPORT, and reaped on the next \`worker reap\`.

Verified end-to-end against a real corrupted DB: doctor repaired in 103ms, follow-up reap cleared the stale row.

## Test plan

- [x] \`bun test\` — 792 pass (3 new for \`isPidAlive\`)
- [x] \`bun run lint\`
- [x] \`bun dev db doctor --repair\` against a corrupt DB with one dead-PID stale "running" worker — repair completed; \`db doctor\` follow-up reports clean; \`worker reap\` cleared the stale row

🤖 Generated with [Claude Code](https://claude.com/claude-code)