### PR TITLE
Mirror agent loop conversation to background worker logs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -77,6 +77,20 @@ and grep (`grep '\[\[' .botholomew/logs/<id>.log`). Phases emitted each tick:
 - `[[tick-end]] #N Xs didWork=true|false`
 - `[[sleeping]] Ns` (only when there was no work in a persist worker)
 
+Background workers (spawned without a TTY) also mirror the conversation
+thread to the log between `[[claiming-task]]` and `Task ... -> complete`,
+so a `tail -f` shows what the LLM is actually doing:
+
+- `[[assistant]] <full text response>` — assistant message blocks
+- `[[tool-call]] <tool> <truncated JSON input>` — each tool invocation
+- `[[tool-result]] <tool> ok|err in Ns` — tool outcome and duration
+
+Full content (untruncated input, tool output, tokens) stays in the
+`interactions` table; the log mirrors enough to follow the trace without
+opening the DB. Foreground workers (`worker run`) keep their existing
+streaming UX (per-token output and `▶`/`✓` markers) — these phase lines
+are suppressed there to avoid duplication.
+
 ---
 
 ## Registration, heartbeat, reaping

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/worker/llm.ts
+++ b/src/worker/llm.ts
@@ -11,11 +11,16 @@ import { getTask, type Task } from "../db/tasks.ts";
 import { logInteraction } from "../db/threads.ts";
 import { registerAllTools } from "../tools/registry.ts";
 import { getTool, type ToolContext, toAnthropicTools } from "../tools/tool.ts";
+import { logger } from "../utils/logger.ts";
 import { fitToContextWindow, getMaxInputTokens } from "./context.ts";
 import { clearLargeResults, maybeStoreResult } from "./large-results.ts";
 import { createLlmClient } from "./llm-client.ts";
 
 registerAllTools();
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? `${s.slice(0, max)}…` : s;
+}
 
 export interface WorkerStreamCallbacks {
   onToken: (text: string) => void;
@@ -153,6 +158,9 @@ export async function runAgentLoop(input: {
             tokenCount,
           }),
         );
+        if (!callbacks) {
+          logger.phase("assistant", block.text);
+        }
       }
     }
 
@@ -175,6 +183,12 @@ export async function runAgentLoop(input: {
     for (const toolUse of toolUseBlocks) {
       const toolInput = JSON.stringify(toolUse.input);
       callbacks?.onToolStart(toolUse.name, toolInput);
+      if (!callbacks) {
+        logger.phase(
+          "tool-call",
+          `${toolUse.name} ${truncate(toolInput, 200)}`,
+        );
+      }
       await withDb(dbPath, (conn) =>
         logInteraction(conn, threadId, {
           role: "assistant",
@@ -222,6 +236,11 @@ export async function runAgentLoop(input: {
           durationMs,
         }),
       );
+      if (!callbacks) {
+        const seconds = (durationMs / 1000).toFixed(1);
+        const status = result.isError ? "err" : "ok";
+        logger.phase("tool-result", `${toolUse.name} ${status} in ${seconds}s`);
+      }
 
       if (result.terminal && result.agentResult) {
         return result.agentResult;

--- a/src/worker/tick.ts
+++ b/src/worker/tick.ts
@@ -133,6 +133,9 @@ async function runClaimedTask(opts: {
   const { projectDir, dbPath, config, mcpxClient, callbacks, task } = opts;
 
   logger.info(`Claimed task: ${task.name} (${task.id})`);
+  if (!callbacks && task.description) {
+    logger.dim(task.description);
+  }
   callbacks?.onTaskStart(task);
 
   const threadId = await withDb(dbPath, (conn) =>

--- a/test/worker/llm.test.ts
+++ b/test/worker/llm.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
 import type { DbConnection } from "../../src/db/connection.ts";
 import { createTask } from "../../src/db/tasks.ts";
 import { createThread, getThread } from "../../src/db/threads.ts";
@@ -397,6 +405,65 @@ describe("runAgentLoop", () => {
       (i) => i.kind === "tool_use" && i.tool_name === "context_exists",
     );
     expect(toolUses?.length).toBe(2);
+  });
+
+  test("emits assistant/tool-call/tool-result phases for background workers", async () => {
+    const { logger } = await import("../../src/utils/logger.ts");
+    const phaseSpy = spyOn(logger, "phase").mockImplementation(() => {});
+
+    try {
+      const task = await createTask(conn, {
+        name: "Phase log task",
+        description: "Should emit phase markers",
+      });
+      const threadId = await createThread(conn, "worker_tick", task.id);
+
+      mockCreate.mockImplementation(async () => ({
+        content: [
+          { type: "text", text: "Reasoning step." },
+          {
+            type: "tool_use",
+            id: "tool_1",
+            name: "complete_task",
+            input: { summary: "Wrapped up" },
+          },
+        ],
+        stop_reason: "tool_use",
+        usage: { input_tokens: 100, output_tokens: 50 },
+      }));
+
+      await runAgentLoop({
+        systemPrompt: "You are a test agent.",
+        task,
+        config: testConfig,
+        dbPath,
+        threadId,
+        projectDir: "/tmp/test",
+      });
+
+      const phaseNames = phaseSpy.mock.calls.map(([name]) => name);
+      expect(phaseNames).toContain("assistant");
+      expect(phaseNames).toContain("tool-call");
+      expect(phaseNames).toContain("tool-result");
+
+      const assistantCall = phaseSpy.mock.calls.find(
+        ([name]) => name === "assistant",
+      );
+      expect(assistantCall?.[1]).toBe("Reasoning step.");
+
+      const toolCall = phaseSpy.mock.calls.find(
+        ([name]) => name === "tool-call",
+      );
+      expect(toolCall?.[1]).toContain("complete_task");
+
+      const toolResult = phaseSpy.mock.calls.find(
+        ([name]) => name === "tool-result",
+      );
+      expect(toolResult?.[1]).toContain("complete_task");
+      expect(toolResult?.[1]).toContain("ok");
+    } finally {
+      phaseSpy.mockRestore();
+    }
   });
 
   test("logs all interactions to thread", async () => {


### PR DESCRIPTION
## Summary

- Worker log files between `[[claiming-task]]` and `Task -> complete` were silent because `runAgentLoop` only wrote to the `interactions` table — the streaming path existed only for the foreground TUI's `WorkerStreamCallbacks`.
- Added `[[assistant]] / [[tool-call]] / [[tool-result]]` phase lines inside the agent loop, gated on the absence of callbacks so the foreground UX is unchanged. Tool input is truncated to 200 chars; tool output stays in the DB.
- Also logs the task description below `Claimed task: ...` for background workers, updates `docs/architecture.md`, and bumps the version to 0.9.12.

## Test plan
- [x] `bun run lint`
- [x] `bun test` (793 passing, including a new test that spies on `logger.phase`)
- [ ] `tail -f .botholomew/logs/<worker-id>.log` while a real worker runs a task — confirm assistant text, tool calls, and tool results appear interleaved
- [ ] `bun run dev worker run` — confirm the foreground streaming UX (per-token + ▶/✓ markers) is unchanged with no duplicate phase lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)