### PR TITLE
TUI: don't freeze the worker count when a poll throws

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/tui/components/StatusBar.tsx
+++ b/src/tui/components/StatusBar.tsx
@@ -33,22 +33,30 @@ export function StatusBar({
   useEffect(() => {
     let mounted = true;
 
+    // Errors here (e.g. transient DuckDB lock conflicts while a freshly
+    // spawned worker is migrating) must not freeze the count — the next
+    // interval tick will retry. Swallow silently rather than logging
+    // because logger writes to stdout and would corrupt the Ink render.
     const refresh = async () => {
-      const [pending, inProgress, workers] = await withDb(
-        dbPath,
-        async (conn) => [
-          await listTasks(conn, { status: "pending" }),
-          await listTasks(conn, { status: "in_progress" }),
-          await listWorkers(conn, { status: "running" }),
-        ],
-      );
-      if (mounted) {
-        setStatus({
-          workerCount: workers.length,
-          pendingCount: pending.length,
-          inProgressCount: inProgress.length,
-        });
-        onWorkerStatusChange?.(workers.length > 0);
+      try {
+        const [pending, inProgress, workers] = await withDb(
+          dbPath,
+          async (conn) => [
+            await listTasks(conn, { status: "pending" }),
+            await listTasks(conn, { status: "in_progress" }),
+            await listWorkers(conn, { status: "running" }),
+          ],
+        );
+        if (mounted) {
+          setStatus({
+            workerCount: workers.length,
+            pendingCount: pending.length,
+            inProgressCount: inProgress.length,
+          });
+          onWorkerStatusChange?.(workers.length > 0);
+        }
+      } catch {
+        // Keep prior state; next tick will retry.
       }
     };
 


### PR DESCRIPTION
## Summary

Fix a bug where the TUI status bar shows `no workers` (count stuck at 0) even when `botholomew worker list` confirms a persistent worker is registered with `status=running`.

The status-bar `useEffect` in `src/tui/components/StatusBar.tsx` polled `listWorkers({ status: "running" })` every 5s with no try/catch. A single transient DuckDB lock conflict — common while a freshly spawned persist worker is still installing the FTS extension and running migrations against the same DB — caused the awaited promise to reject, skipping `setStatus`. The interval kept firing but every subsequent attempt was lost the same way, so the initial `workerCount: 0` was effectively permanent.

## Fix

Wrap the refresh body in try/catch and preserve prior state on failure so the next 5s tick recovers naturally.

Silent-swallow matches the existing TUI precedent (`src/tui/components/WorkerPanel.tsx:105-107`); `logger.warn` was rejected here because it writes to stdout via `console.log` and would corrupt the Ink-rendered TUI.

## Test plan

- [x] `bun run lint`
- [x] `bun test` (792 pass, 0 fail)
- [ ] Manual: `bun run dev chat`, ask the agent to spawn a persist worker, confirm `botholomew worker list -s running` shows it, watch status bar — should show `1 worker` within ~5s
- [ ] Manual: `botholomew worker stop <id>` — count drops to 0 within ~5s

🤖 Generated with [Claude Code](https://claude.com/claude-code)