### PR TITLE
Replace OpenAI embeddings with local @huggingface/transformers

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ bun run dev -- --help
 # 1. Initialize a project in the current directory
 botholomew init
 
-# 2. Add your API keys to .botholomew/config.json, or export env vars
+# 2. Add your Anthropic key to .botholomew/config.json, or export it
 export ANTHROPIC_API_KEY=sk-ant-...
-export OPENAI_API_KEY=sk-...     # used for embeddings
+# Embeddings run locally — no API key required.
 
 # 3. Queue some work
 botholomew task add "Summarize every markdown file in ~/notes"
@@ -144,7 +144,7 @@ Everything the agent can touch is here. No surprises.
 | `botholomew chat` | Interactive Ink/React TUI |
 | `botholomew task list\|add\|view\|update\|reset\|delete` | Manage the task queue |
 | `botholomew schedule list\|add\|view\|enable\|disable\|trigger\|delete` | Recurring work |
-| `botholomew context add\|list\|search\|chunks\|refresh\|delete` | Ingest & browse knowledge (files, folders, URLs); also exposes the agent's `read`/`write`/`tree`/`edit`/… tools as subcommands |
+| `botholomew context add\|list\|search\|chunks\|refresh\|reembed\|delete` | Ingest & browse knowledge (files, folders, URLs); `reembed` rebuilds every vector after upgrading the embedding model; also exposes the agent's `read`/`write`/`tree`/`edit`/… tools as subcommands |
 | `botholomew capabilities` | Rescan built-in + MCPX tools and rewrite `.botholomew/capabilities.md` |
 | `botholomew mcpx servers\|list\|add\|remove\|info\|search\|exec\|ping\|auth\|deauth\|import-global\|…` | Configure external MCP servers (passthrough to `mcpx`) |
 | `botholomew skill list\|show\|create\|validate` | Manage slash-command skills |
@@ -236,8 +236,9 @@ Topics worth understanding in detail:
   built-in FTS extension for BM25 keyword search
 - **[Anthropic SDK](https://docs.anthropic.com/en/api/client-sdks)** for
   Claude — the reasoning model
-- **OpenAI embeddings API** (`text-embedding-3-small`, 1536-dim) for
-  semantic search
+- **[`@huggingface/transformers`](https://huggingface.co/docs/transformers.js)**
+  for local embeddings (default `Xenova/bge-small-en-v1.5`, 384-dim) —
+  no API key, weights cached on first run
 - **[MCPX](https://github.com/evantahler/mcpx)** for external tools
 - **[Ink 6](https://github.com/vadimdemedes/ink)** + **React 19** for the
   terminal UI

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@anthropic-ai/sdk": "^0.88.0",
         "@duckdb/node-api": "^1.5.2-r.1",
         "@evantahler/mcpx": "0.18.6",
+        "@huggingface/transformers": "^4.2.0",
         "ansis": "^4.2.0",
         "commander": "^14.0.0",
         "gray-matter": "^4.0.3",
@@ -32,6 +33,10 @@
       },
     },
   },
+  "trustedDependencies": [
+    "onnxruntime-node",
+    "protobufjs",
+  ],
   "packages": {
     "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.2.5", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw=="],
 
@@ -177,7 +182,9 @@
 
     "@huggingface/jinja": ["@huggingface/jinja@0.5.6", "", {}, "sha512-MyMWyLnjqo+KRJYSH7oWNbsOn5onuIvfXYPcc0WOGxU0eHUV7oAYUoQTl2BMdu7ml+ea/bu11UM+EshbeHwtIA=="],
 
-    "@huggingface/transformers": ["@huggingface/transformers@3.8.1", "", { "dependencies": { "@huggingface/jinja": "^0.5.3", "onnxruntime-node": "1.21.0", "onnxruntime-web": "1.22.0-dev.20250409-89f8206ba4", "sharp": "^0.34.1" } }, "sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA=="],
+    "@huggingface/tokenizers": ["@huggingface/tokenizers@0.1.3", "", {}, "sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA=="],
+
+    "@huggingface/transformers": ["@huggingface/transformers@4.2.0", "", { "dependencies": { "@huggingface/jinja": "^0.5.6", "@huggingface/tokenizers": "^0.1.3", "onnxruntime-node": "1.24.3", "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c", "sharp": "^0.34.5" } }, "sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ=="],
 
     "@iconify-json/simple-icons": ["@iconify-json/simple-icons@1.2.80", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-iglncJJ6X/dVuzFDU32MrHwwo4RBwivGf108dgyYg+HKS78ifx0h7sTenpDZMVT+UhdS6CSgZcvY/SvRXlIEUg=="],
 
@@ -392,6 +399,8 @@
     "@vueuse/shared": ["@vueuse/shared@12.8.2", "", { "dependencies": { "vue": "^3.5.13" } }, "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "adm-zip": ["adm-zip@0.5.17", "", {}, "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ=="],
 
     "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
@@ -777,11 +786,11 @@
 
     "oniguruma-to-es": ["oniguruma-to-es@3.1.1", "", { "dependencies": { "emoji-regex-xs": "^1.0.0", "regex": "^6.0.1", "regex-recursion": "^6.0.2" } }, "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ=="],
 
-    "onnxruntime-common": ["onnxruntime-common@1.21.0", "", {}, "sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ=="],
+    "onnxruntime-common": ["onnxruntime-common@1.24.3", "", {}, "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA=="],
 
-    "onnxruntime-node": ["onnxruntime-node@1.21.0", "", { "dependencies": { "global-agent": "^3.0.0", "onnxruntime-common": "1.21.0", "tar": "^7.0.1" }, "os": [ "linux", "win32", "darwin", ] }, "sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw=="],
+    "onnxruntime-node": ["onnxruntime-node@1.24.3", "", { "dependencies": { "adm-zip": "^0.5.16", "global-agent": "^3.0.0", "onnxruntime-common": "1.24.3" }, "os": [ "linux", "win32", "darwin", ] }, "sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg=="],
 
-    "onnxruntime-web": ["onnxruntime-web@1.22.0-dev.20250409-89f8206ba4", "", { "dependencies": { "flatbuffers": "^25.1.24", "guid-typescript": "^1.0.9", "long": "^5.2.3", "onnxruntime-common": "1.22.0-dev.20250409-89f8206ba4", "platform": "^1.3.6", "protobufjs": "^7.2.4" } }, "sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ=="],
+    "onnxruntime-web": ["onnxruntime-web@1.26.0-dev.20260416-b7804b056c", "", { "dependencies": { "flatbuffers": "^25.1.24", "guid-typescript": "^1.0.9", "long": "^5.2.3", "onnxruntime-common": "1.24.0-dev.20251116-b39e144322", "platform": "^1.3.6", "protobufjs": "^7.2.4" } }, "sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw=="],
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
@@ -1007,6 +1016,8 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
+    "@evantahler/mcpx/@huggingface/transformers": ["@huggingface/transformers@3.8.1", "", { "dependencies": { "@huggingface/jinja": "^0.5.3", "onnxruntime-node": "1.21.0", "onnxruntime-web": "1.22.0-dev.20250409-89f8206ba4", "sharp": "^0.34.1" } }, "sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA=="],
+
     "@vue/compiler-core/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
@@ -1023,7 +1034,7 @@
 
     "mdast-util-frontmatter/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
-    "onnxruntime-web/onnxruntime-common": ["onnxruntime-common@1.22.0-dev.20250409-89f8206ba4", "", {}, "sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ=="],
+    "onnxruntime-web/onnxruntime-common": ["onnxruntime-common@1.24.0-dev.20251116-b39e144322", "", {}, "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw=="],
 
     "roarr/sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
 
@@ -1034,6 +1045,10 @@
     "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "@evantahler/mcpx/@huggingface/transformers/onnxruntime-node": ["onnxruntime-node@1.21.0", "", { "dependencies": { "global-agent": "^3.0.0", "onnxruntime-common": "1.21.0", "tar": "^7.0.1" }, "os": [ "linux", "win32", "darwin", ] }, "sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw=="],
+
+    "@evantahler/mcpx/@huggingface/transformers/onnxruntime-web": ["onnxruntime-web@1.22.0-dev.20250409-89f8206ba4", "", { "dependencies": { "flatbuffers": "^25.1.24", "guid-typescript": "^1.0.9", "long": "^5.2.3", "onnxruntime-common": "1.22.0-dev.20250409-89f8206ba4", "platform": "^1.3.6", "protobufjs": "^7.2.4" } }, "sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ=="],
 
     "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
@@ -1048,6 +1063,10 @@
     "yargs/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "@evantahler/mcpx/@huggingface/transformers/onnxruntime-node/onnxruntime-common": ["onnxruntime-common@1.21.0", "", {}, "sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ=="],
+
+    "@evantahler/mcpx/@huggingface/transformers/onnxruntime-web/onnxruntime-common": ["onnxruntime-common@1.22.0-dev.20250409-89f8206ba4", "", {}, "sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ=="],
 
     "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
   }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,11 +6,10 @@ schema lives in `src/config/schemas.ts`.
 ```json
 {
   "anthropic_api_key": "",
-  "openai_api_key": "",
   "model": "claude-opus-4-20250514",
   "chunker_model": "claude-haiku-4-5-20251001",
-  "embedding_model": "text-embedding-3-small",
-  "embedding_dimension": 1536,
+  "embedding_model": "Xenova/bge-small-en-v1.5",
+  "embedding_dimension": 384,
   "tick_interval_seconds": 300,
   "max_tick_duration_seconds": 120,
   "system_prompt_override": "",
@@ -32,11 +31,10 @@ schema lives in `src/config/schemas.ts`.
 | Key | Default | Purpose |
 |---|---|---|
 | `anthropic_api_key` | `""` | Anthropic key. `ANTHROPIC_API_KEY` env var overrides. |
-| `openai_api_key` | `""` | OpenAI key for embeddings. `OPENAI_API_KEY` env var overrides. |
 | `model` | `claude-opus-4-20250514` | Claude model for the main agent loop (workers + chat). |
 | `chunker_model` | `claude-haiku-4-5-20251001` | Smaller/cheaper model used to propose chunk boundaries during ingestion and evaluate schedules. |
-| `embedding_model` | `text-embedding-3-small` | OpenAI embedding model. |
-| `embedding_dimension` | `1536` | Vector dimension. Must match the model; changes require re-indexing (migration 5 did this once for the switch from 384-dim local embeddings). |
+| `embedding_model` | `Xenova/bge-small-en-v1.5` | A local [`@huggingface/transformers`](https://huggingface.co/docs/transformers.js) feature-extraction model. Weights are downloaded on first use and cached under `~/.cache/huggingface/`. Any feature-extraction model in the Xenova/* namespace works — e.g. `Xenova/multilingual-e5-small` (also 384-dim) for non-English content. |
+| `embedding_dimension` | `384` | Vector dimension. Must match the model. Changing model + dimension requires running `botholomew context reembed` to recompute every stored vector — old and new vectors aren't comparable. |
 | `tick_interval_seconds` | `300` | Seconds a `--persist` worker sleeps between ticks **when there's no work**. It ticks back-to-back while a backlog exists. |
 | `max_tick_duration_seconds` | `120` | Soft cap per tick. Stale-task reset fires at `3×` this value. |
 | `system_prompt_override` | `""` | Appended to the built-in system prompt. Use this for project-specific instructions that should be always-loaded without editing `soul.md`. |
@@ -56,7 +54,6 @@ schema lives in `src/config/schemas.ts`.
 | Var | Effect |
 |---|---|
 | `ANTHROPIC_API_KEY` | Overrides `anthropic_api_key` in config. |
-| `OPENAI_API_KEY` | Overrides `openai_api_key` in config. |
 | `BOTHOLOMEW_LOG_LEVEL` | Overrides `log_level` in config. One of `silent`, `error`, `warn`, `info`, `debug`. |
 | `BOTHOLOMEW_NO_UPDATE_CHECK` | Disable the background "new version available" check. |
 

--- a/docs/context-and-search.md
+++ b/docs/context-and-search.md
@@ -15,8 +15,8 @@ agent writes via `context_write`), this happens:
 ```
  content ─► create context_item row  (drive, path)
          ─► LLM-driven chunker (claude-haiku-4-5 by default)
-         ─► embedder (OpenAI text-embedding-3-small, 1536-dim)
-         ─► embeddings table (FLOAT[1536])
+         ─► embedder (local @huggingface/transformers, default Xenova/bge-small-en-v1.5, 384-dim)
+         ─► embeddings table (FLOAT[384])
          ─► rebuild FTS index (BM25 over chunk_content + title)
          ─► indexed_at set on the context_item
 ```
@@ -88,7 +88,7 @@ CREATE TABLE embeddings (
   chunk_content    TEXT,
   title            TEXT NOT NULL,
   description      TEXT NOT NULL DEFAULT '',
-  embedding        FLOAT[1536],
+  embedding        FLOAT[384],
   created_at       TEXT NOT NULL DEFAULT (current_timestamp::VARCHAR),
   UNIQUE(context_item_id, chunk_index)
 );
@@ -299,17 +299,28 @@ post-refresh `tree` snapshot.
 
 ---
 
-## Why OpenAI for embeddings?
+## Local embeddings
 
-Earlier milestones used a local `@xenova/transformers` model
-(`bge-small-en-v1.5`, 384-dim). It worked but had drawbacks: ~500 MB of
-model weights, slow CPU inference on first load, and noticeably worse
-quality on mixed-language content. Migration 5
-(`5-reset_embeddings_for_openai.sql`) switched to OpenAI
-`text-embedding-3-small` at 1536 dimensions — faster, better, and only
-"non-local" for the index-time call. Queries at runtime still only need
-an embedding of the query string itself.
+Botholomew runs embeddings locally via
+[`@huggingface/transformers`](https://huggingface.co/docs/transformers.js).
+The default model is `Xenova/bge-small-en-v1.5` (384-dim, ~33 MB). Weights
+are downloaded the first time the model is used and cached under
+`~/.cache/huggingface/` — subsequent runs load from disk in milliseconds.
 
-If you want a fully-local setup, swap `src/context/embedder.ts` for a
-local model and adjust `EMBEDDING_DIMENSION` in `src/constants.ts` —
-everything downstream (hybrid search) is dimension-agnostic.
+No API key, no per-token cost, no network dependency at query time. The
+model loads lazily on the first embed call, so CLI startup stays fast.
+
+To use a different model, set `embedding_model` and `embedding_dimension`
+in `.botholomew/config.json`. Any feature-extraction model from the
+Xenova/* namespace works — for example, `Xenova/multilingual-e5-small`
+(also 384-dim) handles mixed-language content much better than the default.
+
+Changing models means old vectors and new vectors live in different
+embedding spaces and aren't comparable. Run `botholomew context reembed`
+to rebuild every vector with the new model.
+
+History: an older milestone shipped with OpenAI
+`text-embedding-3-small` (1536-dim) for quality reasons. Migration 18
+(`18-reset_embeddings_for_local.sql`) reverts that decision — modern
+small open-source models close the quality gap, and "no API key
+required" is more in line with Botholomew's local-first stance.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,7 +8,9 @@ processing tasks. For deeper background, see
 
 - **[Bun](https://bun.sh) 1.1+** — Botholomew is a Bun-native CLI.
 - **An Anthropic API key** — Claude is the reasoning model.
-- **An OpenAI API key** — used for embeddings (`text-embedding-3-small`).
+- Embeddings run locally via `@huggingface/transformers` (default
+  `Xenova/bge-small-en-v1.5`, 384-dim). The first call downloads ~33 MB
+  of weights to `~/.cache/huggingface/`; no API key is required.
 - Optional: any [MCP servers](./mcpx.md) you want to expose to the agent
   (Gmail, Slack, GitHub, etc.) — managed through
   [MCPX](https://github.com/evantahler/mcpx).
@@ -58,14 +60,13 @@ Everything the agent can touch is here — see
 
 ## Configure API keys
 
-Either export environment variables:
+Either export the environment variable:
 
 ```bash
 export ANTHROPIC_API_KEY=sk-ant-...
-export OPENAI_API_KEY=sk-...
 ```
 
-…or set them in `.botholomew/config.json`. See
+…or set it in `.botholomew/config.json`. See
 [Configuration](./configuration.md) for every key and its default.
 
 ## Queue work and run a worker

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,9 +52,8 @@ bun install -g botholomew
 # 2. Initialize a project
 botholomew init
 
-# 3. Set your API keys
+# 3. Set your Anthropic API key (embeddings run locally — no other key needed)
 export ANTHROPIC_API_KEY=sk-ant-...
-export OPENAI_API_KEY=sk-...   # used for embeddings
 
 # 4. Queue some work and run a worker
 botholomew task add "Summarize every markdown file in ~/notes"

--- a/docs/virtual-filesystem.md
+++ b/docs/virtual-filesystem.md
@@ -166,7 +166,7 @@ Every mutation cascades into the embeddings table:
 - `context_move` → no embedding changes (embeddings reference the item id, not the path).
 - `context_delete` → cascade delete embedding rows.
 
-Embeddings are stored as `FLOAT[1536]` and queried by linear scan via
+Embeddings are stored as `FLOAT[384]` and queried by linear scan via
 `array_cosine_distance()` — no HNSW index, no VSS extension. The FTS
 index over `chunk_content` and `title` is rebuilt by
 `rebuildSearchIndex()` after every ingest write. See

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.9.12",
+  "version": "0.10.0",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {
@@ -29,6 +29,7 @@
     "@anthropic-ai/sdk": "^0.88.0",
     "@duckdb/node-api": "^1.5.2-r.1",
     "@evantahler/mcpx": "0.18.6",
+    "@huggingface/transformers": "^4.2.0",
     "ansis": "^4.2.0",
     "commander": "^14.0.0",
     "gray-matter": "^4.0.3",
@@ -50,5 +51,9 @@
     "vitepress": "^1.5.0",
     "vitepress-plugin-llms": "^1.12.1",
     "vue": "^3.5.0"
-  }
+  },
+  "trustedDependencies": [
+    "onnxruntime-node",
+    "protobufjs"
+  ]
 }

--- a/src/chat/agent.ts
+++ b/src/chat/agent.ts
@@ -86,7 +86,7 @@ export async function buildChatSystemPrompt(
 
   const dbPath = options?.dbPath;
   const config = options?.config;
-  if (dbPath && config?.openai_api_key && keywordSource) {
+  if (dbPath && config && keywordSource) {
     try {
       const queryVec = await embedSingle(keywordSource, config);
       const results = await withDb(dbPath, (conn) =>

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -6,6 +6,7 @@ import { isText } from "istextorbinary";
 import { createSpinner } from "nanospinner";
 import { loadConfig } from "../config/loader.ts";
 import type { BotholomewConfig } from "../config/schemas.ts";
+import { getDbPath } from "../constants.ts";
 import { generateDescription } from "../context/describer.ts";
 import {
   type DriveTarget,
@@ -36,6 +37,7 @@ import {
   upsertContextItem,
 } from "../db/context.ts";
 import { getEmbeddingsForItem, hybridSearch } from "../db/embeddings.ts";
+import { reembedMissingVectors } from "../db/reembed.ts";
 import { createMcpxClient } from "../mcpx/client.ts";
 import { logger } from "../utils/logger.ts";
 import {
@@ -425,10 +427,7 @@ export function registerContextCommand(program: Command) {
 
         skipped.push(...dedupSkipped);
 
-        if (itemIds.length === 0 || !config.openai_api_key) {
-          if (!config.openai_api_key) {
-            logger.dim("Skipping embeddings (no OpenAI API key configured).");
-          }
+        if (itemIds.length === 0) {
           const msg = buildSummary({
             added: itemIds.length,
             refreshed: refreshedCount,
@@ -693,9 +692,20 @@ export function registerContextCommand(program: Command) {
           logger.success(
             `Refreshed ${result.updated} item(s), ${result.chunks} chunk(s) re-indexed.`,
           );
-        } else if (result.embeddings_skipped) {
-          logger.dim("Skipping embeddings (no OpenAI API key configured).");
         }
+      }),
+    );
+
+  ctx
+    .command("reembed")
+    .description(
+      "Recompute every embedding using the configured local model. Run this after upgrading or after changing embedding_model.",
+    )
+    .action(() =>
+      withDb(program, async (_conn, dir) => {
+        const config = await loadConfig(dir);
+        const dbPath = getDbPath(dir);
+        await reembedMissingVectors(dbPath, config, { mode: "all" });
       }),
     );
 

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -12,14 +12,10 @@ export function registerPrepareCommand(program: Command) {
       withDb(program, async (_conn, dir) => {
         logger.info("Preparing Botholomew...");
         const config = await loadConfig(dir);
-        if (!config.openai_api_key) {
-          logger.error(
-            "OpenAI API key not set. Set openai_api_key in config or OPENAI_API_KEY env var.",
-          );
-          process.exit(1);
-        }
         await embedSingle("test", config);
-        logger.success("OpenAI embeddings API is reachable and configured.");
+        logger.success(
+          `Embedding model ${config.embedding_model} is loaded and ready.`,
+        );
       }),
     );
 }

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -19,9 +19,6 @@ export async function loadConfig(
   if (process.env.ANTHROPIC_API_KEY) {
     config.anthropic_api_key = process.env.ANTHROPIC_API_KEY;
   }
-  if (process.env.OPENAI_API_KEY) {
-    config.openai_api_key = process.env.OPENAI_API_KEY;
-  }
 
   setLogLevel(config.log_level);
 

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -1,6 +1,5 @@
 export interface BotholomewConfig {
   anthropic_api_key?: string;
-  openai_api_key?: string;
   model?: string;
   chunker_model?: string;
   embedding_model?: string;
@@ -20,11 +19,10 @@ export interface BotholomewConfig {
 
 export const DEFAULT_CONFIG: Required<BotholomewConfig> = {
   anthropic_api_key: "",
-  openai_api_key: "",
   model: "claude-opus-4-20250514",
   chunker_model: "claude-haiku-4-5-20251001",
-  embedding_model: "text-embedding-3-small",
-  embedding_dimension: 1536,
+  embedding_model: "Xenova/bge-small-en-v1.5",
+  embedding_dimension: 384,
   tick_interval_seconds: 300,
   max_tick_duration_seconds: 120,
   system_prompt_override: "",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,8 +18,8 @@ export const CONFIG_FILENAME = "config.json";
 export const MCPX_DIR = "mcpx";
 export const SKILLS_DIR = "skills";
 export const MCPX_SERVERS_FILENAME = "servers.json";
-export const EMBEDDING_DIMENSION = 1536;
-export const EMBEDDING_MODEL = "text-embedding-3-small";
+export const EMBEDDING_DIMENSION = 384;
+export const EMBEDDING_MODEL = "Xenova/bge-small-en-v1.5";
 
 export function getBotholomewDir(projectDir: string): string {
   return join(projectDir, BOTHOLOMEW_DIR);

--- a/src/context/embedder-impl.ts
+++ b/src/context/embedder-impl.ts
@@ -1,18 +1,36 @@
+import {
+  type FeatureExtractionPipeline,
+  pipeline,
+} from "@huggingface/transformers";
 import type { BotholomewConfig } from "../config/schemas.ts";
+import { logger } from "../utils/logger.ts";
 
 type EmbedFn = (
   texts: string[],
   config: Required<BotholomewConfig>,
 ) => Promise<number[][]>;
 
-interface OpenAIEmbeddingResponse {
-  data: { embedding: number[]; index: number }[];
-  usage: { total_tokens: number };
+// Singleton pipeline keyed by model name. Loading the model is expensive
+// (downloads weights on first run, then ~hundreds of ms to instantiate the
+// ONNX runtime), so we hold one per model for the life of the process.
+const pipelinePromises = new Map<string, Promise<FeatureExtractionPipeline>>();
+
+async function getPipeline(model: string): Promise<FeatureExtractionPipeline> {
+  let p = pipelinePromises.get(model);
+  if (!p) {
+    logger.info(
+      `Loading embedding model ${model} (first run downloads weights)`,
+    );
+    p = pipeline("feature-extraction", model);
+    pipelinePromises.set(model, p);
+  }
+  return p;
 }
 
 /**
- * Embed multiple texts using the OpenAI embeddings API.
- * Returns an array of float vectors with the configured dimension.
+ * Embed multiple texts using a local @huggingface/transformers feature-extraction
+ * pipeline. Returns an array of L2-normalized float vectors with the model's
+ * native dimension (must match `config.embedding_dimension`).
  */
 export async function embed(
   texts: string[],
@@ -20,37 +38,17 @@ export async function embed(
 ): Promise<number[][]> {
   if (texts.length === 0) return [];
 
-  if (!config.openai_api_key) {
+  const extractor = await getPipeline(config.embedding_model);
+  const output = await extractor(texts, { pooling: "mean", normalize: true });
+  const data = output.tolist() as number[][];
+
+  if (data[0] && data[0].length !== config.embedding_dimension) {
     throw new Error(
-      "OpenAI API key is required for embeddings. Set openai_api_key in config or OPENAI_API_KEY env var.",
+      `Embedding model ${config.embedding_model} returned ${data[0].length}-dim vectors, but embedding_dimension is set to ${config.embedding_dimension}. Update embedding_dimension in config and re-embed.`,
     );
   }
 
-  const response = await fetch("https://api.openai.com/v1/embeddings", {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${config.openai_api_key}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      input: texts,
-      model: config.embedding_model,
-      dimensions: config.embedding_dimension,
-    }),
-  });
-
-  if (!response.ok) {
-    const body = await response.text();
-    throw new Error(
-      `OpenAI embeddings API error (${response.status}): ${body}`,
-    );
-  }
-
-  const result = (await response.json()) as OpenAIEmbeddingResponse;
-
-  // Sort by index to ensure order matches input
-  const sorted = result.data.sort((a, b) => a.index - b.index);
-  return sorted.map((d) => d.embedding);
+  return data;
 }
 
 /**

--- a/src/context/ingest.ts
+++ b/src/context/ingest.ts
@@ -44,16 +44,7 @@ export async function prepareIngestion(
     return null;
   }
 
-  // Resolve the embed function before chunking — if we can't embed, skip early
-  const doEmbed =
-    embedFn ??
-    (config.openai_api_key
-      ? (texts: string[]) => defaultEmbed(texts, config)
-      : null);
-  if (!doEmbed) {
-    logger.debug("ingest: skipping embeddings (no OpenAI API key configured)");
-    return null;
-  }
+  const doEmbed = embedFn ?? ((texts: string[]) => defaultEmbed(texts, config));
 
   const chunks = await chunk(item.content, item.mime_type, config);
   if (chunks.length === 0) return null;

--- a/src/context/refresh.ts
+++ b/src/context/refresh.ts
@@ -132,8 +132,7 @@ export async function refreshContextItems(
   const unchanged = results.filter((r) => r.status === "unchanged").length;
   const missing = results.filter((r) => r.status === "missing").length;
 
-  const hasEmbedder = !!embedFn || !!config.openai_api_key;
-  if (toReembed.length === 0 || !hasEmbedder) {
+  if (toReembed.length === 0) {
     return {
       checked: refreshable.length,
       updated,
@@ -141,7 +140,7 @@ export async function refreshContextItems(
       missing,
       reembedded: 0,
       chunks: 0,
-      embeddings_skipped: toReembed.length > 0 && !hasEmbedder,
+      embeddings_skipped: false,
       items: results,
     };
   }

--- a/src/db/reembed.ts
+++ b/src/db/reembed.ts
@@ -1,0 +1,113 @@
+import type { BotholomewConfig } from "../config/schemas.ts";
+import { embed } from "../context/embedder.ts";
+import { logger } from "../utils/logger.ts";
+import { withDb } from "./connection.ts";
+import { rebuildSearchIndex } from "./embeddings.ts";
+
+interface PendingRow {
+  id: string;
+  chunk_content: string | null;
+  title: string;
+  description: string;
+  drive: string | null;
+  path: string | null;
+}
+
+const BATCH_SIZE = 32;
+
+function buildEmbeddingInput(row: PendingRow): string {
+  const parts: string[] = [];
+  if (row.title) parts.push(`Title: ${row.title}`);
+  if (row.description) parts.push(`Description: ${row.description}`);
+  if (row.drive && row.path) parts.push(`Source: ${row.drive}:${row.path}`);
+  if (row.chunk_content) parts.push(row.chunk_content);
+  return parts.join("\n");
+}
+
+interface ReembedOptions {
+  /**
+   * `"missing"` (default) — only re-embed rows where `embedding IS NULL`.
+   * `"all"` — re-embed every row, including ones that already have a vector.
+   *           Use this after changing `embedding_model` so old vectors don't
+   *           sit alongside new ones in a different space.
+   */
+  mode?: "missing" | "all";
+}
+
+/**
+ * Recompute embeddings for rows in the embeddings table.
+ *
+ * Default mode (`"missing"`) only touches NULL rows — the case after migration
+ * 18 leaves existing rows with no vector. The `context reembed` CLI command
+ * passes `mode: "all"` to force a full rebuild after the user changes
+ * `embedding_model`.
+ *
+ * Each batch is its own withDb so the file lock releases between embedding
+ * calls — long sweeps don't block other workers from acquiring the DB.
+ */
+export async function reembedMissingVectors(
+  dbPath: string,
+  config: Required<BotholomewConfig>,
+  options: ReembedOptions = {},
+): Promise<void> {
+  const mode = options.mode ?? "missing";
+  const filter = mode === "all" ? "" : "WHERE embedding IS NULL";
+
+  const total = await withDb(dbPath, async (conn) => {
+    const row = await conn.queryGet<{ count: number }>(
+      `SELECT count(*)::INTEGER AS count FROM embeddings ${filter}`,
+    );
+    return row?.count ?? 0;
+  });
+
+  if (total === 0) {
+    logger.info("No embeddings to recompute.");
+    return;
+  }
+
+  logger.info(
+    `re-embedding ${total} row${total === 1 ? "" : "s"} with model ${config.embedding_model}`,
+  );
+
+  let processed = 0;
+  while (processed < total) {
+    const batch = await withDb(dbPath, async (conn) => {
+      const offsetClause = mode === "all" ? `LIMIT ?1 OFFSET ?2` : `LIMIT ?1`;
+      const sql = `SELECT e.id, e.chunk_content, e.title, e.description, ci.drive, ci.path
+         FROM embeddings e
+         LEFT JOIN context_items ci ON ci.id = e.context_item_id
+         ${filter}
+         ORDER BY e.id
+         ${offsetClause}`;
+      return mode === "all"
+        ? conn.queryAll<PendingRow>(sql, BATCH_SIZE, processed)
+        : conn.queryAll<PendingRow>(sql, BATCH_SIZE);
+    });
+
+    if (batch.length === 0) break;
+
+    const inputs = batch.map(buildEmbeddingInput);
+    const vectors = await embed(inputs, config);
+
+    await withDb(dbPath, async (conn) => {
+      for (let i = 0; i < batch.length; i++) {
+        const row = batch[i];
+        const vec = vectors[i];
+        if (!row || !vec) continue;
+        await conn.queryRun(
+          `UPDATE embeddings
+           SET embedding = ?1::FLOAT[${config.embedding_dimension}]
+           WHERE id = ?2`,
+          vec,
+          row.id,
+        );
+      }
+    });
+
+    processed += batch.length;
+    logger.info(`  re-embedded ${processed}/${total}`);
+  }
+
+  await withDb(dbPath, (conn) => rebuildSearchIndex(conn));
+  logger.success(`re-embed complete (${processed} rows)`);
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -2,6 +2,7 @@ import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { logger } from "../utils/logger.ts";
 import type { DbConnection } from "./connection.ts";
+import { rebuildSearchIndex } from "./embeddings.ts";
 
 interface Migration {
   id: number;
@@ -83,4 +84,10 @@ export async function migrate(db: DbConnection): Promise<void> {
   if (appliedAny) {
     await db.exec("CHECKPOINT");
   }
+
+  // Ensure the FTS index exists. Migration 18 drops it (it can't recreate it
+  // in the same SQL run without DuckDB rejecting the dependency commit), and
+  // fresh DBs need it created at least once. `overwrite = 1` makes this
+  // idempotent for DBs that already have a healthy FTS index.
+  await rebuildSearchIndex(db);
 }

--- a/src/db/sql/18-reset_embeddings_for_local.sql
+++ b/src/db/sql/18-reset_embeddings_for_local.sql
@@ -1,15 +1,21 @@
 -- Switch from OpenAI 1536-dim embeddings to local 384-dim embeddings.
+--
 -- DuckDB encodes array dimension in the column type, so we rebuild the
 -- embeddings table preserving every row's metadata (chunk_content, title,
 -- description, context_item_id, chunk_index, created_at). The vectors
 -- themselves are NULLed and repopulated by `botholomew context reembed`
 -- using the locally-loaded embedding model.
 --
--- The FTS index is dropped before the table rebuild and rebuilt by the
--- re-embed sweep. Without this drop, dropping the underlying table leaves
--- fts_main_embeddings in a broken state.
+-- Idempotency: every destructive step uses IF EXISTS so a partial prior
+-- run can be re-attempted cleanly. The FTS index is dropped here but NOT
+-- recreated — `migrate()` calls rebuildSearchIndex once after all SQL
+-- migrations apply, which avoids a same-migration drop-then-create that
+-- DuckDB rejects with "Could not commit creation of dependency, subject
+-- 'stopwords' has been deleted".
 
-PRAGMA drop_fts_index('embeddings');
+DROP SCHEMA IF EXISTS fts_main_embeddings CASCADE;
+
+DROP TABLE IF EXISTS embeddings_new;
 
 CREATE TABLE embeddings_new (
   id TEXT PRIMARY KEY,
@@ -29,7 +35,5 @@ FROM embeddings;
 
 DROP TABLE embeddings;
 ALTER TABLE embeddings_new RENAME TO embeddings;
-
-PRAGMA create_fts_index('embeddings', 'id', 'chunk_content', 'title', overwrite = 1);
 
 CHECKPOINT;

--- a/src/db/sql/18-reset_embeddings_for_local.sql
+++ b/src/db/sql/18-reset_embeddings_for_local.sql
@@ -1,0 +1,35 @@
+-- Switch from OpenAI 1536-dim embeddings to local 384-dim embeddings.
+-- DuckDB encodes array dimension in the column type, so we rebuild the
+-- embeddings table preserving every row's metadata (chunk_content, title,
+-- description, context_item_id, chunk_index, created_at). The vectors
+-- themselves are NULLed and repopulated by `botholomew context reembed`
+-- using the locally-loaded embedding model.
+--
+-- The FTS index is dropped before the table rebuild and rebuilt by the
+-- re-embed sweep. Without this drop, dropping the underlying table leaves
+-- fts_main_embeddings in a broken state.
+
+PRAGMA drop_fts_index('embeddings');
+
+CREATE TABLE embeddings_new (
+  id TEXT PRIMARY KEY,
+  context_item_id TEXT NOT NULL,
+  chunk_index INTEGER NOT NULL,
+  chunk_content TEXT,
+  title TEXT NOT NULL,
+  description TEXT NOT NULL DEFAULT '',
+  embedding FLOAT[384],
+  created_at TEXT NOT NULL DEFAULT (current_timestamp::VARCHAR),
+  UNIQUE(context_item_id, chunk_index)
+);
+
+INSERT INTO embeddings_new (id, context_item_id, chunk_index, chunk_content, title, description, embedding, created_at)
+SELECT id, context_item_id, chunk_index, chunk_content, title, description, NULL, created_at
+FROM embeddings;
+
+DROP TABLE embeddings;
+ALTER TABLE embeddings_new RENAME TO embeddings;
+
+PRAGMA create_fts_index('embeddings', 'id', 'chunk_content', 'title', overwrite = 1);
+
+CHECKPOINT;

--- a/src/worker/prompt.ts
+++ b/src/worker/prompt.ts
@@ -104,7 +104,7 @@ export async function buildSystemPrompt(
 
   prompt += await loadPersistentContext(projectDir, taskKeywords);
 
-  if (task && dbPath && _config?.openai_api_key) {
+  if (task && dbPath && _config) {
     try {
       const query = `${task.name} ${task.description}`;
       const queryVec = await embedSingle(query, _config);

--- a/test/commands/context-refresh-multi.test.ts
+++ b/test/commands/context-refresh-multi.test.ts
@@ -21,11 +21,10 @@ const CLI = join(import.meta.dir, "..", "..", "src", "cli.ts");
 async function run(
   args: string[],
 ): Promise<{ code: number; stdout: string; stderr: string }> {
-  const { OPENAI_API_KEY: _omit, ...envWithoutKey } = process.env;
   const proc = Bun.spawn(["bun", CLI, "--dir", tempDir, ...args], {
     stdout: "pipe",
     stderr: "pipe",
-    env: { ...envWithoutKey, NO_COLOR: "1", BOTHOLOMEW_LOG_LEVEL: "info" },
+    env: { ...process.env, NO_COLOR: "1", BOTHOLOMEW_LOG_LEVEL: "info" },
   });
   const [stdout, stderr] = await Promise.all([
     new Response(proc.stdout).text(),

--- a/test/config/schemas.test.ts
+++ b/test/config/schemas.test.ts
@@ -4,7 +4,6 @@ import { DEFAULT_CONFIG } from "../../src/config/schemas.ts";
 describe("DEFAULT_CONFIG", () => {
   test("has all expected fields", () => {
     expect(DEFAULT_CONFIG).toHaveProperty("anthropic_api_key");
-    expect(DEFAULT_CONFIG).toHaveProperty("openai_api_key");
     expect(DEFAULT_CONFIG).toHaveProperty("model");
     expect(DEFAULT_CONFIG).toHaveProperty("chunker_model");
     expect(DEFAULT_CONFIG).toHaveProperty("embedding_model");
@@ -36,7 +35,6 @@ describe("DEFAULT_CONFIG", () => {
 
   test("API keys default to empty strings", () => {
     expect(DEFAULT_CONFIG.anthropic_api_key).toBe("");
-    expect(DEFAULT_CONFIG.openai_api_key).toBe("");
   });
 
   test("system_prompt_override defaults to empty string", () => {

--- a/test/constants.test.ts
+++ b/test/constants.test.ts
@@ -31,8 +31,8 @@ describe("constants", () => {
   });
 
   test("embedding constants are defined", () => {
-    expect(EMBEDDING_DIMENSION).toBe(1536);
-    expect(EMBEDDING_MODEL).toBe("text-embedding-3-small");
+    expect(EMBEDDING_DIMENSION).toBe(384);
+    expect(EMBEDDING_MODEL).toBe("Xenova/bge-small-en-v1.5");
   });
 
   test("environment variable keys are defined", () => {

--- a/test/context/embedder.test.ts
+++ b/test/context/embedder.test.ts
@@ -1,17 +1,41 @@
 import { describe, expect, test } from "bun:test";
 import { DEFAULT_CONFIG } from "../../src/config/schemas.ts";
-import { embed } from "../../src/context/embedder-impl.ts";
+import { embed, embedSingle } from "../../src/context/embedder-impl.ts";
 
 const config = { ...DEFAULT_CONFIG };
 
 describe("embed", () => {
   test("returns empty array for empty input without loading the model", async () => {
-    // The empty-input fast path is the only embedder behaviour we can verify
-    // without downloading model weights — exercising the real pipeline in CI
-    // would pull ~30MB of ONNX weights on every run. The actual model wiring
-    // is exercised by `botholomew prepare` and the integration tests under
-    // test/commands/ which use mocked embedders.
     const vectors = await embed([], config);
     expect(vectors).toHaveLength(0);
   });
+
+  // This test exercises the real @huggingface/transformers pipeline. The
+  // first run downloads ~33 MB of model weights to ~/.cache/huggingface/;
+  // subsequent runs load from disk in milliseconds.
+  test("loads the default model and returns L2-normalized 384-dim vectors", async () => {
+    const vectors = await embed(["hello world", "goodbye world"], config);
+    expect(vectors).toHaveLength(2);
+
+    const v0 = vectors[0];
+    const v1 = vectors[1];
+    expect(v0).toHaveLength(384);
+    expect(v1).toHaveLength(384);
+
+    // L2 normalization: unit vectors have magnitude ~1
+    const mag0 = Math.sqrt((v0 ?? []).reduce((s, x) => s + x * x, 0));
+    const mag1 = Math.sqrt((v1 ?? []).reduce((s, x) => s + x * x, 0));
+    expect(mag0).toBeCloseTo(1, 4);
+    expect(mag1).toBeCloseTo(1, 4);
+
+    // Two related sentences should have positive cosine similarity. Since
+    // the vectors are unit-normalized, dot product == cosine similarity.
+    const sim = (v0 ?? []).reduce((s, x, i) => s + x * (v1?.[i] ?? 0), 0);
+    expect(sim).toBeGreaterThan(0);
+  }, 120_000);
+
+  test("embedSingle returns one vector of the configured dimension", async () => {
+    const vec = await embedSingle("test", config);
+    expect(vec).toHaveLength(384);
+  }, 120_000);
 });

--- a/test/context/embedder.test.ts
+++ b/test/context/embedder.test.ts
@@ -1,126 +1,17 @@
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { DEFAULT_CONFIG } from "../../src/config/schemas.ts";
-import { embed, embedSingle } from "../../src/context/embedder-impl.ts";
+import { embed } from "../../src/context/embedder-impl.ts";
 
-const config = {
-  ...DEFAULT_CONFIG,
-  openai_api_key: "test-key",
-  embedding_model: "text-embedding-3-small",
-  embedding_dimension: 1536,
-};
-
-function mockFetchResponse(embeddings: number[][]) {
-  return mock(() =>
-    Promise.resolve(
-      new Response(
-        JSON.stringify({
-          data: embeddings.map((e, i) => ({ embedding: e, index: i })),
-          usage: { total_tokens: 10 },
-        }),
-        { status: 200 },
-      ),
-    ),
-  );
-}
-
-const originalFetchGlobal = globalThis.fetch;
-afterEach(() => {
-  globalThis.fetch = originalFetchGlobal;
-});
+const config = { ...DEFAULT_CONFIG };
 
 describe("embed", () => {
-  test("returns empty array for empty input", async () => {
+  test("returns empty array for empty input without loading the model", async () => {
+    // The empty-input fast path is the only embedder behaviour we can verify
+    // without downloading model weights — exercising the real pipeline in CI
+    // would pull ~30MB of ONNX weights on every run. The actual model wiring
+    // is exercised by `botholomew prepare` and the integration tests under
+    // test/commands/ which use mocked embedders.
     const vectors = await embed([], config);
     expect(vectors).toHaveLength(0);
-  });
-
-  test("throws when API key is missing", async () => {
-    const noKeyConfig = { ...config, openai_api_key: "" };
-    expect(embed(["hello"], noKeyConfig)).rejects.toThrow("OpenAI API key");
-  });
-
-  test("calls OpenAI API and returns vectors", async () => {
-    const fakeVec = new Array(1536).fill(0.1);
-    const originalFetch = globalThis.fetch;
-    const mockFn = mockFetchResponse([fakeVec]);
-    globalThis.fetch = mockFn as unknown as typeof fetch;
-
-    try {
-      const result = await embed(["hello world"], config);
-
-      expect(result).toHaveLength(1);
-      expect(result[0]).toHaveLength(1536);
-      expect(mockFn).toHaveBeenCalledTimes(1);
-
-      const callArgs = mockFn.mock.calls[0] as unknown as [string, RequestInit];
-      expect(callArgs[0]).toBe("https://api.openai.com/v1/embeddings");
-
-      const body = JSON.parse(callArgs[1].body as string);
-      expect(body.model).toBe("text-embedding-3-small");
-      expect(body.dimensions).toBe(1536);
-      expect(body.input).toEqual(["hello world"]);
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("sorts results by index", async () => {
-    const vec0 = new Array(1536).fill(0.1);
-    const vec1 = new Array(1536).fill(0.2);
-    const originalFetch = globalThis.fetch;
-    // Return out of order
-    globalThis.fetch = mock(() =>
-      Promise.resolve(
-        new Response(
-          JSON.stringify({
-            data: [
-              { embedding: vec1, index: 1 },
-              { embedding: vec0, index: 0 },
-            ],
-            usage: { total_tokens: 10 },
-          }),
-          { status: 200 },
-        ),
-      ),
-    ) as unknown as typeof fetch;
-
-    try {
-      const result = await embed(["a", "b"], config);
-      expect(result[0]?.[0]).toBe(0.1);
-      expect(result[1]?.[0]).toBe(0.2);
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("throws on API error", async () => {
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = mock(() =>
-      Promise.resolve(new Response("rate limited", { status: 429 })),
-    ) as unknown as typeof fetch;
-
-    try {
-      expect(embed(["hello"], config)).rejects.toThrow(
-        "OpenAI embeddings API error (429)",
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-});
-
-describe("embedSingle", () => {
-  test("returns a single vector", async () => {
-    const fakeVec = new Array(1536).fill(0.5);
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = mockFetchResponse([fakeVec]) as unknown as typeof fetch;
-
-    try {
-      const vec = await embedSingle("test", config);
-      expect(vec).toHaveLength(1536);
-      expect(vec[0]).toBe(0.5);
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
   });
 });

--- a/test/context/refresh.test.ts
+++ b/test/context/refresh.test.ts
@@ -9,8 +9,7 @@ import type { DbConnection } from "../../src/db/connection.ts";
 import { createContextItem, getContextItemById } from "../../src/db/context.ts";
 import { mockEmbed, setupTestDb } from "../helpers.ts";
 
-const config = { ...DEFAULT_CONFIG, openai_api_key: "test-key" };
-const configNoEmbed = { ...DEFAULT_CONFIG };
+const config = { ...DEFAULT_CONFIG };
 
 let conn: DbConnection;
 let tmpBase: string;
@@ -138,27 +137,6 @@ describe("refreshContextItems — disk drive", () => {
 
     expect(result.missing).toBe(1);
     expect(result.items[0]?.status).toBe("missing");
-  });
-
-  test("skips embeddings and flags embeddings_skipped when no OpenAI key", async () => {
-    const { refreshContextItems } = await import(
-      "../../src/context/refresh.ts"
-    );
-    const filePath = join(tmpBase, "noembed.md");
-    const item = await seedDiskItem({
-      filePath,
-      initialDiskContent: "drifted",
-      storedContent: "original",
-    });
-
-    const result = await refreshContextItems(conn, [item], configNoEmbed, null);
-
-    expect(result.updated).toBe(1);
-    expect(result.reembedded).toBe(0);
-    expect(result.embeddings_skipped).toBe(true);
-
-    const fresh = await getContextItemById(conn, item.id);
-    expect(fresh?.content).toBe("drifted");
   });
 
   test("skips items on drive=agent", async () => {

--- a/test/db/reembed.test.ts
+++ b/test/db/reembed.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { EMBEDDING_DIMENSION } from "../../src/constants.ts";
+
+// Mock the embedder before importing reembed.ts so the import binding picks
+// up the mock. Returning a deterministic non-zero vector lets tests verify
+// that vectors actually flow from embed() into the embeddings table.
+const embedMock = mock(async (texts: string[]) =>
+  texts.map((_, i) => {
+    const v = new Array(EMBEDDING_DIMENSION).fill(0);
+    v[i % EMBEDDING_DIMENSION] = 1;
+    return v;
+  }),
+);
+const embedSingleMock = mock(async () => {
+  const v = new Array(EMBEDDING_DIMENSION).fill(0);
+  v[0] = 1;
+  return v;
+});
+
+mock.module("../../src/context/embedder.ts", () => ({
+  embed: embedMock,
+  embedSingle: embedSingleMock,
+}));
+
+const { TEST_CONFIG, setupTestDbFile } = await import("../helpers.ts");
+const { uuidv7 } = await import("../../src/db/uuid.ts");
+const { withDb } = await import("../../src/db/connection.ts");
+const { reembedMissingVectors } = await import("../../src/db/reembed.ts");
+const { createContextItem } = await import("../../src/db/context.ts");
+
+let dbPath: string;
+let cleanup: () => Promise<void>;
+
+beforeEach(async () => {
+  embedMock.mockClear();
+  embedSingleMock.mockClear();
+  ({ dbPath, cleanup } = await setupTestDbFile());
+});
+
+afterEach(async () => {
+  await cleanup();
+});
+
+async function seedNullEmbedding(
+  itemId: string,
+  chunkIndex: number,
+  chunkContent: string,
+  title: string,
+): Promise<string> {
+  const id = uuidv7();
+  await withDb(dbPath, (conn) =>
+    conn.queryRun(
+      `INSERT INTO embeddings (id, context_item_id, chunk_index, chunk_content, title, description, embedding)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL)`,
+      id,
+      itemId,
+      chunkIndex,
+      chunkContent,
+      title,
+      "",
+    ),
+  );
+  return id;
+}
+
+async function seedItem(title: string, path: string): Promise<string> {
+  return withDb(dbPath, async (conn) => {
+    const item = await createContextItem(conn, {
+      title,
+      content: "",
+      drive: "agent",
+      path,
+      mimeType: "text/plain",
+      isTextual: true,
+    });
+    return item.id;
+  });
+}
+
+describe("reembedMissingVectors", () => {
+  test("populates NULL embeddings and leaves no NULL rows", async () => {
+    const itemId = await seedItem("Doc A", "/a.md");
+    const e1 = await seedNullEmbedding(itemId, 0, "first chunk", "Doc A");
+    const e2 = await seedNullEmbedding(itemId, 1, "second chunk", "Doc A");
+
+    await reembedMissingVectors(dbPath, TEST_CONFIG);
+
+    expect(embedMock).toHaveBeenCalledTimes(1);
+    expect(embedMock.mock.calls[0]?.[0]).toHaveLength(2);
+
+    const rows = await withDb(dbPath, (conn) =>
+      conn.queryAll<{ id: string; embedding: number[] | null }>(
+        "SELECT id, embedding FROM embeddings WHERE id IN (?1, ?2) ORDER BY chunk_index",
+        e1,
+        e2,
+      ),
+    );
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.embedding).not.toBeNull();
+    expect(rows[1]?.embedding).not.toBeNull();
+    expect(rows[0]?.embedding).toHaveLength(EMBEDDING_DIMENSION);
+    expect(rows[1]?.embedding).toHaveLength(EMBEDDING_DIMENSION);
+
+    const remaining = await withDb(dbPath, (conn) =>
+      conn.queryGet<{ count: number }>(
+        "SELECT count(*)::INTEGER AS count FROM embeddings WHERE embedding IS NULL",
+      ),
+    );
+    expect(remaining?.count).toBe(0);
+  });
+
+  test("is a no-op when nothing is NULL", async () => {
+    await reembedMissingVectors(dbPath, TEST_CONFIG);
+    expect(embedMock).not.toHaveBeenCalled();
+  });
+
+  test("includes title, description, and source ref in embed input", async () => {
+    const itemId = await seedItem("My Doc", "/notes/a.md");
+    await seedNullEmbedding(itemId, 0, "chunk content here", "My Doc");
+
+    await reembedMissingVectors(dbPath, TEST_CONFIG);
+
+    const inputs = embedMock.mock.calls[0]?.[0] as string[] | undefined;
+    expect(inputs).toBeDefined();
+    expect(inputs?.[0]).toContain("Title: My Doc");
+    expect(inputs?.[0]).toContain("Source: agent:/notes/a.md");
+    expect(inputs?.[0]).toContain("chunk content here");
+  });
+
+  test("mode: 'all' re-embeds rows that already have vectors", async () => {
+    const itemId = await seedItem("Doc B", "/b.md");
+    const id = uuidv7();
+    const oldVec = new Array(EMBEDDING_DIMENSION).fill(0);
+    oldVec[100] = 1; // distinguishable from the mock's hot dim (index 0)
+    await withDb(dbPath, (conn) =>
+      conn.queryRun(
+        `INSERT INTO embeddings (id, context_item_id, chunk_index, chunk_content, title, description, embedding)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7::FLOAT[${EMBEDDING_DIMENSION}])`,
+        id,
+        itemId,
+        0,
+        "old content",
+        "Doc B",
+        "",
+        oldVec,
+      ),
+    );
+
+    await reembedMissingVectors(dbPath, TEST_CONFIG, { mode: "all" });
+
+    expect(embedMock).toHaveBeenCalledTimes(1);
+    const row = await withDb(dbPath, (conn) =>
+      conn.queryGet<{ embedding: number[] }>(
+        "SELECT embedding FROM embeddings WHERE id = ?1",
+        id,
+      ),
+    );
+    // Mock writes 1 at index 0; old vector had 1 at index 100. If reembed
+    // overwrote, index 0 is now 1 and index 100 is 0.
+    expect(row?.embedding[0]).toBe(1);
+    expect(row?.embedding[100]).toBe(0);
+  });
+
+  test("processes batches larger than the batch size", async () => {
+    const itemId = await seedItem("Big Doc", "/big.md");
+    const N = 50; // > BATCH_SIZE (32)
+    for (let i = 0; i < N; i++) {
+      await seedNullEmbedding(itemId, i, `chunk ${i}`, "Big Doc");
+    }
+
+    await reembedMissingVectors(dbPath, TEST_CONFIG);
+
+    expect(embedMock).toHaveBeenCalledTimes(2); // 32 + 18
+    const remaining = await withDb(dbPath, (conn) =>
+      conn.queryGet<{ count: number }>(
+        "SELECT count(*)::INTEGER AS count FROM embeddings WHERE embedding IS NULL",
+      ),
+    );
+    expect(remaining?.count).toBe(0);
+  });
+});

--- a/test/db/schema.test.ts
+++ b/test/db/schema.test.ts
@@ -65,7 +65,7 @@ describe("schema migrations", () => {
     )) as {
       count: number;
     };
-    expect(row.count).toBe(17);
+    expect(row.count).toBe(18);
 
     db.close();
   });

--- a/test/tools/context-refresh.test.ts
+++ b/test/tools/context-refresh.test.ts
@@ -126,17 +126,6 @@ describe("context_refresh tool", () => {
     expect(result.updated).toBe(2);
   });
 
-  test("message surfaces embeddings_skipped when no OpenAI key", async () => {
-    await seedDiskItem("drift2.md", "new", "old");
-
-    const result = await contextRefreshTool.execute({ all: true }, ctx);
-    expect(result.is_error).toBe(false);
-    expect(result.updated).toBe(1);
-    expect(result.reembedded).toBe(0);
-    expect(result.embeddings_skipped).toBe(true);
-    expect(result.message).toContain("embeddings skipped");
-  });
-
   test("returns a tree snapshot on successful refresh", async () => {
     await seedDiskItem("drift.md", "new disk content", "old stored");
     const result = await contextRefreshTool.execute({ all: true }, ctx);

--- a/test/tools/file.test.ts
+++ b/test/tools/file.test.ts
@@ -638,6 +638,10 @@ describe("context edge cases", () => {
   });
 
   test("write file with very long single line", async () => {
+    // contextWriteTool triggers ingestion which chunks content > the short
+    // threshold via the LLM chunker. That requires anthropic_api_key — the
+    // chunker is the only LLM hop in this code path.
+    ctx.config.anthropic_api_key = "test-key";
     const longLine = "x".repeat(10000);
     await contextWriteTool.execute(
       { drive: D, path: "/long.txt", content: longLine },

--- a/test/tools/search.test.ts
+++ b/test/tools/search.test.ts
@@ -13,7 +13,6 @@ let ctx: ToolContext;
 const originalFetch = globalThis.fetch;
 beforeEach(async () => {
   ({ conn, ctx } = await setupToolContext());
-  ctx.config.openai_api_key = "test-key";
 });
 afterEach(() => {
   globalThis.fetch = originalFetch;


### PR DESCRIPTION
## Summary
- Drops the OpenAI dependency entirely. Embeddings now run in-process via `@huggingface/transformers` (default `Xenova/bge-small-en-v1.5`, 384-dim), loaded lazily on first use — no API key, no network at query time.
- Removes `openai_api_key` from config + the `OPENAI_API_KEY` env var. Migration 18 rebuilds the `embeddings` table at the new dimension and leaves vectors NULL; users repopulate via a new `botholomew context reembed` CLI command (re-embed is intentionally not on the worker/chat hot path).
- Bumps to `0.10.0`. Docs (`README.md`, `docs/configuration.md`, `docs/context-and-search.md`, `docs/getting-started.md`, `docs/virtual-filesystem.md`, `docs/index.md`) updated to match.

## Test plan
- [ ] `bun run lint` passes (tsc + biome)
- [ ] `bun test` — 786/786 pass
- [ ] `bun run docs:build` succeeds
- [ ] On an existing project DB, run worker once → migration 18 applies cleanly; then `botholomew context reembed` repopulates vectors and `botholomew context search "..."` returns expected results
- [ ] On a fresh `botholomew init` + `context add <url>`, first call logs the model download, ingest succeeds, semantic search works

🤖 Generated with [Claude Code](https://claude.com/claude-code)