### PR TITLE
Bump version to 0.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bumps `package.json` version from 0.10.0 to 0.10.1.

## Test plan
- [ ] Auto-release workflow publishes 0.10.1 binary on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)