### PR TITLE
Cache embedding model under .botholomew/models

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./test/setup.ts"]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,7 +33,7 @@ schema lives in `src/config/schemas.ts`.
 | `anthropic_api_key` | `""` | Anthropic key. `ANTHROPIC_API_KEY` env var overrides. |
 | `model` | `claude-opus-4-20250514` | Claude model for the main agent loop (workers + chat). |
 | `chunker_model` | `claude-haiku-4-5-20251001` | Smaller/cheaper model used to propose chunk boundaries during ingestion and evaluate schedules. |
-| `embedding_model` | `Xenova/bge-small-en-v1.5` | A local [`@huggingface/transformers`](https://huggingface.co/docs/transformers.js) feature-extraction model. Weights are downloaded on first use and cached under `~/.cache/huggingface/`. Any feature-extraction model in the Xenova/* namespace works — e.g. `Xenova/multilingual-e5-small` (also 384-dim) for non-English content. |
+| `embedding_model` | `Xenova/bge-small-en-v1.5` | A local [`@huggingface/transformers`](https://huggingface.co/docs/transformers.js) feature-extraction model. Weights are downloaded on first use and cached under `.botholomew/models/`. Any feature-extraction model in the Xenova/* namespace works — e.g. `Xenova/multilingual-e5-small` (also 384-dim) for non-English content. |
 | `embedding_dimension` | `384` | Vector dimension. Must match the model. Changing model + dimension requires running `botholomew context reembed` to recompute every stored vector — old and new vectors aren't comparable. |
 | `tick_interval_seconds` | `300` | Seconds a `--persist` worker sleeps between ticks **when there's no work**. It ticks back-to-back while a backlog exists. |
 | `max_tick_duration_seconds` | `120` | Soft cap per tick. Stale-task reset fires at `3×` this value. |

--- a/docs/context-and-search.md
+++ b/docs/context-and-search.md
@@ -305,7 +305,7 @@ Botholomew runs embeddings locally via
 [`@huggingface/transformers`](https://huggingface.co/docs/transformers.js).
 The default model is `Xenova/bge-small-en-v1.5` (384-dim, ~33 MB). Weights
 are downloaded the first time the model is used and cached under
-`~/.cache/huggingface/` — subsequent runs load from disk in milliseconds.
+`.botholomew/models/` — subsequent runs load from disk in milliseconds.
 
 No API key, no per-token cost, no network dependency at query time. The
 model loads lazily on the first embed call, so CLI startup stays fast.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,7 +10,7 @@ processing tasks. For deeper background, see
 - **An Anthropic API key** — Claude is the reasoning model.
 - Embeddings run locally via `@huggingface/transformers` (default
   `Xenova/bge-small-en-v1.5`, 384-dim). The first call downloads ~33 MB
-  of weights to `~/.cache/huggingface/`; no API key is required.
+  of weights to `.botholomew/models/`; no API key is required.
 - Optional: any [MCP servers](./mcpx.md) you want to expose to the agent
   (Gmail, Slack, GitHub, etc.) — managed through
   [MCPX](https://github.com/evantahler/mcpx).

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,4 +1,5 @@
-import { getConfigPath } from "../constants.ts";
+import { mkdirSync } from "node:fs";
+import { getConfigPath, getModelsDir } from "../constants.ts";
 import { setLogLevel } from "../utils/logger.ts";
 import { type BotholomewConfig, DEFAULT_CONFIG } from "./schemas.ts";
 
@@ -21,6 +22,12 @@ export async function loadConfig(
   }
 
   setLogLevel(config.log_level);
+
+  const modelsDir = getModelsDir(projectDir);
+  mkdirSync(modelsDir, { recursive: true });
+  // Dynamic import keeps @huggingface/transformers (heavy, pulls ONNX runtime) out of commands that never embed.
+  const { setEmbeddingCacheDir } = await import("../context/embedder-impl.ts");
+  setEmbeddingCacheDir(modelsDir);
 
   return config;
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,6 +16,7 @@ export const DB_FILENAME = "data.duckdb";
 export const LOGS_DIR = "logs";
 export const CONFIG_FILENAME = "config.json";
 export const MCPX_DIR = "mcpx";
+export const MODELS_DIR = "models";
 export const SKILLS_DIR = "skills";
 export const MCPX_SERVERS_FILENAME = "servers.json";
 export const EMBEDDING_DIMENSION = 384;
@@ -43,6 +44,13 @@ export function getConfigPath(projectDir: string): string {
 
 export function getMcpxDir(projectDir: string): string {
   return join(projectDir, BOTHOLOMEW_DIR, MCPX_DIR);
+}
+
+export function getModelsDir(projectDir: string): string {
+  return (
+    process.env.BOTHOLOMEW_MODELS_DIR_OVERRIDE ??
+    join(projectDir, BOTHOLOMEW_DIR, MODELS_DIR)
+  );
 }
 
 export function getSkillsDir(projectDir: string): string {

--- a/src/context/embedder-impl.ts
+++ b/src/context/embedder-impl.ts
@@ -1,4 +1,7 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 import {
+  env,
   type FeatureExtractionPipeline,
   pipeline,
 } from "@huggingface/transformers";
@@ -15,11 +18,23 @@ type EmbedFn = (
 // ONNX runtime), so we hold one per model for the life of the process.
 const pipelinePromises = new Map<string, Promise<FeatureExtractionPipeline>>();
 
+export function setEmbeddingCacheDir(dir: string): void {
+  // Trailing separator matters: transformers.js builds paths as `${cacheDir}${rel}` (no separator).
+  env.cacheDir = dir.endsWith("/") ? dir : `${dir}/`;
+}
+
+function isModelCached(model: string): boolean {
+  if (!env.cacheDir) return false;
+  return existsSync(join(env.cacheDir, model));
+}
+
 async function getPipeline(model: string): Promise<FeatureExtractionPipeline> {
   let p = pipelinePromises.get(model);
   if (!p) {
     logger.info(
-      `Loading embedding model ${model} (first run downloads weights)`,
+      isModelCached(model)
+        ? `Loading embedding model ${model}`
+        : `Loading embedding model ${model} (first run, downloading weights)`,
     );
     p = pipeline("feature-extraction", model);
     pipelinePromises.set(model, p);

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,33 @@
+import { mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DEFAULT_CONFIG } from "../src/config/schemas.ts";
+
+// All tests share one model cache so each tempdir-init test doesn't re-download
+// the embedding weights (~33 MB). Subprocess tests inherit the env var via
+// Bun.spawn({ env: { ...process.env, ... } }), and loadConfig honors the
+// override before falling back to <projectDir>/.botholomew/models.
+const SHARED_MODELS_DIR = join(tmpdir(), "botholomew-test-models");
+mkdirSync(SHARED_MODELS_DIR, { recursive: true });
+process.env.BOTHOLOMEW_MODELS_DIR_OVERRIDE = SHARED_MODELS_DIR;
+
+const { setEmbeddingCacheDir, embedSingle } = await import(
+  "../src/context/embedder-impl.ts"
+);
+setEmbeddingCacheDir(SHARED_MODELS_DIR);
+
+const PREWARM_TIMEOUT_MS = 60_000;
+await Promise.race([
+  embedSingle("warmup", { ...DEFAULT_CONFIG, anthropic_api_key: "test" }),
+  new Promise((_, reject) =>
+    setTimeout(
+      () =>
+        reject(
+          new Error(
+            `Embedding model prewarm timed out after ${PREWARM_TIMEOUT_MS / 1000}s`,
+          ),
+        ),
+      PREWARM_TIMEOUT_MS,
+    ),
+  ),
+]);


### PR DESCRIPTION
## Summary
- Detect whether the embedding model is on disk before logging — stops every invocation from saying "first run downloads weights" when the cache is warm.
- Move the cache from `@huggingface/transformers`'s internal `.cache/` (blown away on `node_modules` reinstall) to `<project>/.botholomew/models/`, so weights persist with the project. Loader hooks `setEmbeddingCacheDir(getModelsDir(projectDir))` after parsing config; uses dynamic import so commands that never embed don't pull the ONNX runtime.
- Add `bunfig.toml` test preload + `test/setup.ts` that points the embedder at a shared tmpdir cache and warms the model once with a 60s timeout. Subprocess tests inherit the override via env var, so they don't each redownload 33 MB into their tempdir.
- Update docs to reflect the new cache location.

## Test plan
- [x] `bun run lint`
- [x] `bun test` — 793 pass, 0 fail (was 4 fail before the test-preload prewarm)
- [ ] Manually run a CLI command twice; confirm second run logs `Loading embedding model X` without the "first run" parenthetical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)