### PR TITLE
Init: write full default config; default model -> claude-opus-4-6

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,7 +6,7 @@ schema lives in `src/config/schemas.ts`.
 ```json
 {
   "anthropic_api_key": "",
-  "model": "claude-opus-4-20250514",
+  "model": "claude-opus-4-6",
   "chunker_model": "claude-haiku-4-5-20251001",
   "embedding_model": "Xenova/bge-small-en-v1.5",
   "embedding_dimension": 384,
@@ -31,7 +31,7 @@ schema lives in `src/config/schemas.ts`.
 | Key | Default | Purpose |
 |---|---|---|
 | `anthropic_api_key` | `""` | Anthropic key. `ANTHROPIC_API_KEY` env var overrides. |
-| `model` | `claude-opus-4-20250514` | Claude model for the main agent loop (workers + chat). |
+| `model` | `claude-opus-4-6` | Claude model for the main agent loop (workers + chat). |
 | `chunker_model` | `claude-haiku-4-5-20251001` | Smaller/cheaper model used to propose chunk boundaries during ingestion and evaluate schedules. |
 | `embedding_model` | `Xenova/bge-small-en-v1.5` | A local [`@huggingface/transformers`](https://huggingface.co/docs/transformers.js) feature-extraction model. Weights are downloaded on first use and cached under `~/.cache/huggingface/`. Any feature-extraction model in the Xenova/* namespace works — e.g. `Xenova/multilingual-e5-small` (also 384-dim) for non-English content. |
 | `embedding_dimension` | `384` | Vector dimension. Must match the model. Changing model + dimension requires running `botholomew context reembed` to recompute every stored vector — old and new vectors aren't comparable. |

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -19,7 +19,7 @@ export interface BotholomewConfig {
 
 export const DEFAULT_CONFIG: Required<BotholomewConfig> = {
   anthropic_api_key: "",
-  model: "claude-opus-4-20250514",
+  model: "claude-opus-4-6",
   chunker_model: "claude-haiku-4-5-20251001",
   embedding_model: "Xenova/bge-small-en-v1.5",
   embedding_dimension: 384,

--- a/src/init/templates.ts
+++ b/src/init/templates.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_CONFIG as SCHEMA_DEFAULT_CONFIG } from "../config/schemas.ts";
+
 export const SOUL_MD = `---
 loading: always
 agent-modification: false
@@ -85,11 +87,8 @@ and currently in progress) and format a brief standup-style update with:
 `;
 
 export const DEFAULT_CONFIG = {
+  ...SCHEMA_DEFAULT_CONFIG,
   anthropic_api_key: "your-api-key-here",
-  model: "claude-opus-4-20250514",
-  tick_interval_seconds: 300,
-  max_tick_duration_seconds: 120,
-  max_turns: 0,
 };
 
 export const DEFAULT_MCPX_SERVERS = {

--- a/test/init/index.test.ts
+++ b/test/init/index.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { DEFAULT_CONFIG } from "../../src/config/schemas.ts";
 import { initProject } from "../../src/init/index.ts";
 import { parseSkillFile } from "../../src/skills/parser.ts";
 import { parseContextFile } from "../../src/utils/frontmatter.ts";
@@ -94,9 +95,14 @@ describe("initProject", () => {
     const config = JSON.parse(
       await Bun.file(join(tempDir, ".botholomew", "config.json")).text(),
     );
-    expect(config.model).toBe("claude-opus-4-20250514");
+    expect(config.model).toBe("claude-opus-4-6");
     expect(config.tick_interval_seconds).toBe(300);
     expect(config.anthropic_api_key).toBe("your-api-key-here");
+    // Every schema key is present so users can discover and tune all options
+    // without grepping the source.
+    expect(Object.keys(config).sort()).toEqual(
+      Object.keys(DEFAULT_CONFIG).sort(),
+    );
   });
 
   test("throws if already initialized without --force", async () => {


### PR DESCRIPTION
## Summary
- \`botholomew init\` now writes every key from the schema's \`DEFAULT_CONFIG\` (was only 5 of 16). The generated \`config.json\` lists the full surface so users can discover and tune every option without grepping source. The init template just spreads the schema default and overrides the API key with a placeholder, so the two can never drift.
- Bump the default \`model\` from \`claude-opus-4-20250514\` to \`claude-opus-4-6\`.
- New assertion in \`test/init/index.test.ts\` keeps init in sync with the schema as new keys land.
- Doc updates for the new model default.

## Test plan
- [x] \`bun run lint\`
- [x] \`bun test\` — 793 pass
- [ ] \`bun run dev init\` in a scratch dir; confirm the generated \`.botholomew/config.json\` lists all 16 keys and \`"model": "claude-opus-4-6"\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)