### PR TITLE
Patch mcpx's nested @huggingface/transformers too

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,8 +69,9 @@ An AI agent for knowledge work. See `docs/plans/README.md` for the milestone roa
 ## Embeddings
 
 - Embeddings run via `@huggingface/transformers` in **WASM** (`onnxruntime-web`), not the native `onnxruntime-node` bindings. The native bindings segfault under Bun when DuckDB is also loaded in the same process (see [oven-sh/bun#26081](https://github.com/oven-sh/bun/issues/26081)).
-- The switch is enforced by a `bun patch` at `patches/@huggingface%2Ftransformers@<version>.patch` plus a `wasmPaths` override in `src/context/embedder-impl.ts` that points at the local `onnxruntime-web/dist/` files (no CDN fetch).
-- **Bumping `@huggingface/transformers`**: re-run `bun patch '@huggingface/transformers@<version>'`, reapply the three edits to `src/backends/onnx.js` (kill the static `onnxruntime-node` import; in the `IS_NODE_ENV` branch, set `ONNX = ONNX_WEB` and use `['wasm']` for `supportedDevices`/`defaultDevices`), then `bun patch --commit`. The "coexists with DuckDB native module" test in `test/context/embedder.test.ts` is the regression guard.
+- **Two patches, not one.** Botholomew uses transformers directly (`@huggingface/transformers@4.x`); `@evantahler/mcpx` ships its own nested `@huggingface/transformers@3.x` for `mcp_search`'s semantic tool index. Both copies have to be patched — see `patches/@huggingface%2Ftransformers@*.patch`. Bumping mcpx can bring in a new transformers version, in which case its patch needs to be redone too.
+- The switch is enforced by `bun patch` plus a `wasmPaths` override in `src/context/embedder-impl.ts` that points at the local `onnxruntime-web/dist/` files (no CDN fetch).
+- **Bumping `@huggingface/transformers`** (either the top-level one or the one nested under mcpx): re-run `bun patch '@huggingface/transformers@<version>'`, reapply the two edits to `src/backends/onnx.js` (kill the static `onnxruntime-node` import; in the `IS_NODE_ENV` branch, set `ONNX = ONNX_WEB` and use `['wasm']` for `supportedDevices`/`defaultDevices`), then `bun patch --commit`. The "coexists with DuckDB native module" test in `test/context/embedder.test.ts` is the regression guard for the top-level patch; chat-time crashes inside `mcp_search` are the signal for the mcpx one.
 
 ## Testing
 

--- a/bun.lock
+++ b/bun.lock
@@ -38,6 +38,7 @@
     "protobufjs",
   ],
   "patchedDependencies": {
+    "@huggingface/transformers@3.8.1": "patches/@huggingface%2Ftransformers@3.8.1.patch",
     "@huggingface/transformers@4.2.0": "patches/@huggingface%2Ftransformers@4.2.0.patch",
   },
   "packages": {

--- a/docs/context-and-search.md
+++ b/docs/context-and-search.md
@@ -314,18 +314,26 @@ ONNX Runtime runs in **WASM** mode (`onnxruntime-web`) rather than the
 default native `onnxruntime-node` bindings, because the native bindings
 segfault under Bun when another native module (DuckDB) is loaded in the
 same process — see [oven-sh/bun#26081](https://github.com/oven-sh/bun/issues/26081).
-The switch is implemented as a small `bun patch` against
-`@huggingface/transformers` (see `patches/`) plus a `wasmPaths` override
-in `src/context/embedder-impl.ts` that points the WASM loader at the
-`onnxruntime-web/dist/` files already on disk — no CDN fetch at runtime.
+The switch is implemented as `bun patch` files against every copy of
+`@huggingface/transformers` in `node_modules/` (see `patches/`) plus a
+`wasmPaths` override in `src/context/embedder-impl.ts` that points the
+WASM loader at the `onnxruntime-web/dist/` files already on disk — no
+CDN fetch at runtime.
 
-> **Maintaining the patch.** When bumping `@huggingface/transformers`,
-> re-run `bun patch '@huggingface/transformers@<version>'`, reapply the
-> three edits in `src/backends/onnx.js` (drop the static
+> **Two transformers copies.** Both the top-level `@huggingface/transformers@4.2.0`
+> (used by Botholomew's embedder) and the nested copy under
+> `@evantahler/mcpx/node_modules/@huggingface/transformers@3.8.1` (used by
+> mcpx's `mcp_search` for tool semantic search) need the same patch.
+> Bumping mcpx may bring in a new transformers version — re-apply the
+> patch to that one too.
+
+> **Maintaining a patch.** Run `bun patch '@huggingface/transformers@<version>'`,
+> reapply the two edits in `src/backends/onnx.js` (drop the static
 > `onnxruntime-node` import; route the `IS_NODE_ENV` branch to `ONNX_WEB`
-> with `wasm` defaults), and run `bun patch --commit`. If the patch ever
-> stops applying cleanly, the new `embedder.test.ts` regression case
-> (DuckDB + embedder in the same process) will catch it.
+> with `wasm` defaults), then `bun patch --commit`. If a patch ever stops
+> applying cleanly, the `embedder.test.ts` regression case
+> (DuckDB + embedder in the same process) will catch the top-level one;
+> watch for chat-time crashes inside `mcp_search` to catch the mcpx one.
 
 To use a different model, set `embedding_model` and `embedding_dimension`
 in `.botholomew/config.json`. Any feature-extraction model from the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {
@@ -57,6 +57,7 @@
     "protobufjs"
   ],
   "patchedDependencies": {
-    "@huggingface/transformers@4.2.0": "patches/@huggingface%2Ftransformers@4.2.0.patch"
+    "@huggingface/transformers@4.2.0": "patches/@huggingface%2Ftransformers@4.2.0.patch",
+    "@huggingface/transformers@3.8.1": "patches/@huggingface%2Ftransformers@3.8.1.patch"
   }
 }

--- a/patches/@huggingface%2Ftransformers@3.8.1.patch
+++ b/patches/@huggingface%2Ftransformers@3.8.1.patch
@@ -1,0 +1,52 @@
+diff --git a/src/backends/onnx.js b/src/backends/onnx.js
+index 3e49ece2367ba4286014c4dc6ab65ee75c378451..6e6a66e19c8d158a472160e466775b36e385af2d 100644
+--- a/src/backends/onnx.js
++++ b/src/backends/onnx.js
+@@ -20,7 +20,10 @@ import { env, apis } from '../env.js';
+ 
+ // NOTE: Import order matters here. We need to import `onnxruntime-node` before `onnxruntime-web`.
+ // In either case, we select the default export if it exists, otherwise we use the named export.
+-import * as ONNX_NODE from 'onnxruntime-node';
++// PATCHED (botholomew): the static `import 'onnxruntime-node'` segfaults under Bun
++// (oven-sh/bun#26081). We never want the native bindings — `onnxruntime-web` (WASM) runs
++// fine on Bun + Node + browsers. The IS_NODE_ENV branch below is rerouted to ONNX_WEB.
++const ONNX_NODE = undefined;
+ import * as ONNX_WEB from 'onnxruntime-web';
+ 
+ export { Tensor } from 'onnxruntime-common';
+@@ -61,30 +64,11 @@ if (ORT_SYMBOL in globalThis) {
+     ONNX = globalThis[ORT_SYMBOL];
+ 
+ } else if (apis.IS_NODE_ENV) {
+-    ONNX = ONNX_NODE.default ?? ONNX_NODE;
+-
+-    // Updated as of ONNX Runtime 1.20.1
+-    // The following table lists the supported versions of ONNX Runtime Node.js binding provided with pre-built binaries.
+-    // | EPs/Platforms | Windows x64 | Windows arm64 | Linux x64         | Linux arm64 | MacOS x64 | MacOS arm64 |
+-    // | ------------- | ----------- | ------------- | ----------------- | ----------- | --------- | ----------- |
+-    // | CPU           | ✔️          | ✔️            | ✔️                | ✔️          | ✔️        | ✔️          |
+-    // | DirectML      | ✔️          | ✔️            | ❌                | ❌          | ❌        | ❌          |
+-    // | CUDA          | ❌          | ❌            | ✔️ (CUDA v11.8)   | ❌          | ❌        | ❌          |
+-    switch (process.platform) {
+-        case 'win32': // Windows x64 and Windows arm64
+-            supportedDevices.push('dml');
+-            break;
+-        case 'linux': // Linux x64 and Linux arm64
+-            if (process.arch === 'x64') {
+-                supportedDevices.push('cuda');
+-            }
+-            break;
+-        case 'darwin': // MacOS x64 and MacOS arm64
+-            break;
+-    }
+-
+-    supportedDevices.push('cpu');
+-    defaultDevices = ['cpu'];
++    // PATCHED (botholomew): force the WASM backend in node-like envs to avoid
++    // loading onnxruntime-node native bindings (segfaults under Bun).
++    ONNX = ONNX_WEB;
++    supportedDevices.push('wasm');
++    defaultDevices = ['wasm'];
+ } else {
+     ONNX = ONNX_WEB;
+ 


### PR DESCRIPTION
## Summary
- Follow-up to #171. The top-level `@huggingface/transformers@4.2.0` was patched to use WASM, but `@evantahler/mcpx@0.18.7` ships its **own nested** `@huggingface/transformers@3.8.1` under `node_modules/@evantahler/mcpx/node_modules/` with its own `onnxruntime-node@1.21.0`. Chat lazy-loads that nested copy the first time the agent calls `mcp_search`, and it still segfaulted under Bun.
- Apply the same WASM patch to the nested 3.8.1 copy (drop the static `onnxruntime-node` import; route the IS_NODE_ENV branch to `ONNX_WEB` with `wasm` defaults). Saved to `patches/@huggingface%2Ftransformers@3.8.1.patch`.
- Update docs (`docs/context-and-search.md`, `CLAUDE.md`) to call out the two-patches reality and how to keep both in sync — including: bumping mcpx may bring in a different transformers version that needs the same edits.
- Bump version to `0.11.2`.

## Test plan
- [x] `bun run lint` — clean
- [x] `bun test` — 794 pass, 0 fail
- [x] Smoke test of the exact failure mode: open a DuckDB connection, then exercise mcpx's `generateEmbedding` (the code path `mcp_search` uses) in a single Bun process — completes cleanly with a 384-dim vector, no segfault
- [ ] `bun run dev chat` end-to-end (reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)