### PR TITLE
Expose context_read/write/edit to the chat agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/chat/agent.ts
+++ b/src/chat/agent.ts
@@ -29,7 +29,7 @@ import {
 
 registerAllTools();
 
-/** Tools available in chat mode — no worker terminal tools, no destructive file tools */
+/** Tools available in chat mode — no worker terminal tools (complete/fail/wait), no bulk-destructive file tools (delete, copy/move, dir ops) */
 const CHAT_TOOL_NAMES = new Set([
   "create_task",
   "list_tasks",
@@ -39,6 +39,9 @@ const CHAT_TOOL_NAMES = new Set([
   "context_refresh",
   "context_tree",
   "context_list_drives",
+  "context_read",
+  "context_write",
+  "context_edit",
   "search_grep",
   "search_semantic",
   "list_threads",

--- a/test/chat/agent.test.ts
+++ b/test/chat/agent.test.ts
@@ -44,6 +44,10 @@ describe("getChatTools", () => {
     expect(names).toContain("context_info");
     expect(names).toContain("context_refresh");
     expect(names).toContain("context_tree");
+    expect(names).toContain("context_list_drives");
+    expect(names).toContain("context_read");
+    expect(names).toContain("context_write");
+    expect(names).toContain("context_edit");
     expect(names).toContain("update_beliefs");
     expect(names).toContain("update_goals");
     expect(names).toContain("capabilities_refresh");
@@ -55,10 +59,8 @@ describe("getChatTools", () => {
     expect(names).not.toContain("fail_task");
     expect(names).not.toContain("wait_task");
 
-    // Should NOT include destructive file tools
-    expect(names).not.toContain("context_write");
+    // Should NOT include bulk-destructive file tools
     expect(names).not.toContain("context_delete");
-    expect(names).not.toContain("context_edit");
   });
 
   test("returns valid Anthropic tool format", () => {


### PR DESCRIPTION
## Summary

- The chat system prompt at `src/chat/agent.ts:133` told the agent to use `context_read` to drill in after search, but `context_read` was not in `CHAT_TOOL_NAMES` — the agent was told to call a tool it didn't have.
- `docs/context-and-search.md:13` says "agent writes via `context_write`", but `context_write` was also excluded.
- The "destructive file tools" exclusion comment was inconsistent: `update_beliefs`, `update_goals`, `skill_write`, `skill_edit`, `skill_delete` are all already permitted, and `context_write` defaults to `drive: "agent"` (the agent's own scratch).

Fix: add `context_read`, `context_write`, `context_edit` to the chat allowlist. Keep `context_delete`, `context_copy`, `context_move`, and dir ops worker-only — chat should `spawn_worker` for those.

## Test plan

- [x] `bun run lint` (tsc + biome) clean
- [x] `bun test test/chat/agent.test.ts` — updated assertions pass (14/14)
- [x] `bun test` — full suite (794/794) green
- [ ] Manual smoke via chat TUI: ask the agent to summarize a thread and save to `agent:/notes/recap.md`; confirm `context_write` succeeds and `context_read` round-trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)