### PR TITLE
Skills: handle multi-word args (single quotes + greedy last positional)

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -52,7 +52,7 @@ Please review the file at `$1`. Read it with the available tools, then provide:
 | Placeholder | Meaning |
 |---|---|
 | `$ARGUMENTS` | The entire argument string as typed |
-| `$1`, `$2`, … | Positional arguments (split on whitespace, quoted strings respected) |
+| `$1`, `$2`, … | Positional arguments (split on whitespace; single- and double-quoted strings are respected; the **last declared positional consumes the rest of the input**) |
 | `$<name>` | Named placeholder bound to the declared argument with that `name` (same value as the matching positional `$N`) |
 
 Missing optional arguments fall back to their `default`. Missing required
@@ -74,6 +74,37 @@ Example:
 
 becomes `$1 = $file = "src/cli.ts"`, `$2 = $focus = "security"`, and
 `$ARGUMENTS = "src/cli.ts security"`.
+
+### Multi-word arguments
+
+The last declared positional argument is **greedy** — it captures the
+entire remainder of the input verbatim. So a single-arg skill just
+works without quoting:
+
+```
+> /summarize-topic why are avocados good?
+```
+
+→ `$1 = "why are avocados good?"` (one slot, full sentence).
+
+For skills with two or more declared arguments, an unquoted multi-word
+input is **ambiguous** — Botholomew can't know which words belong to
+which slot. The TUI rejects the invocation, prints a parse breakdown,
+and shows quoting suggestions instead of silently truncating:
+
+```
+> /write-as-evan why are avocados good?
+/write-as-evan: ambiguous input. Parsed as:
+  topic  = "why"
+  format = "are avocados good?"
+
+Quote the multi-word argument to confirm, e.g.:
+  /write-as-evan "why are avocados good?"
+  /write-as-evan 'why' 'are avocados good?'
+```
+
+Either single or double quotes work; the surrounding pair is stripped
+when the entire remainder is one quoted run.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/skills/commands.ts
+++ b/src/skills/commands.ts
@@ -1,5 +1,5 @@
 import type { SkillDefinition } from "./parser.ts";
-import { renderSkill, validateSkillArgs } from "./parser.ts";
+import { renderSkill, tokenizeForSkill, validateSkillArgs } from "./parser.ts";
 
 export interface SlashCommand {
   name: string;
@@ -38,6 +38,58 @@ export function formatSkillUsage(skill: SkillDefinition): string {
     }
   }
   return parts.join(" ");
+}
+
+/**
+ * Detect when a multi-arg skill received unquoted whitespace-separated
+ * input that the greedy-last splitter has packed into the final slot.
+ * The user almost certainly intended one of the words to belong to a
+ * different slot (or the whole thing to be a single argument), so we
+ * surface a parse breakdown instead of silently committing to one
+ * interpretation.
+ *
+ * Returns null when the input is unambiguous and may proceed.
+ */
+export function detectAmbiguousSplit(
+  skill: SkillDefinition,
+  rawArgs: string,
+): { tokens: string[] } | null {
+  if (skill.arguments.length < 2) return null;
+  if (rawArgs.includes('"') || rawArgs.includes("'")) return null;
+  const tokens = tokenizeForSkill(rawArgs, skill);
+  const last = tokens[tokens.length - 1];
+  if (!last || !/\s/.test(last)) return null;
+  return { tokens };
+}
+
+function formatAmbiguityHint(skill: SkillDefinition, tokens: string[]): string {
+  const slots: string[] = [];
+  const nameWidth = skill.arguments.reduce(
+    (m, a) => Math.max(m, a.name.length),
+    0,
+  );
+  skill.arguments.forEach((argDef, i) => {
+    const value =
+      tokens[i] !== undefined
+        ? `"${tokens[i]}"`
+        : argDef.default !== undefined
+          ? `"${argDef.default}" (default)`
+          : "(unset)";
+    slots.push(`  ${argDef.name.padEnd(nameWidth)} = ${value}`);
+  });
+
+  const firstWord = tokens[0] ?? "";
+  const restPreview = tokens.slice(1).join(" ");
+  const fullPreview = [firstWord, restPreview].filter(Boolean).join(" ");
+
+  return [
+    `/${skill.name}: ambiguous input. Parsed as:`,
+    ...slots,
+    "",
+    "Quote the multi-word argument to confirm, e.g.:",
+    `  /${skill.name} "${fullPreview}"`,
+    `  /${skill.name} '${firstWord}' '${restPreview}'`,
+  ].join("\n");
 }
 
 /**
@@ -94,6 +146,11 @@ export function handleSlashCommand(
         `/${skill.name}: missing required argument(s): ${missing.join(", ")}\n` +
           `Usage: ${formatSkillUsage(skill)}`,
       );
+      return true;
+    }
+    const ambiguous = detectAmbiguousSplit(skill, rawArgs);
+    if (ambiguous) {
+      ctx.addSystemMessage(formatAmbiguityHint(skill, ambiguous.tokens));
       return true;
     }
     const rendered = renderSkill(skill, rawArgs);

--- a/src/skills/parser.ts
+++ b/src/skills/parser.ts
@@ -52,18 +52,22 @@ export function parseSkillFile(raw: string, filePath: string): SkillDefinition {
 }
 
 /**
- * Split a raw argument string into positional tokens,
- * respecting double-quoted strings.
+ * Split a raw argument string into positional tokens, respecting both
+ * single- and double-quoted strings. A closing quote must match the
+ * opening quote; the other quote character is treated as a literal
+ * inside the run.
  */
 export function tokenize(raw: string): string[] {
   const tokens: string[] = [];
   let current = "";
-  let inQuote = false;
+  let quoteChar: '"' | "'" | null = null;
 
   for (const ch of raw) {
-    if (ch === '"') {
-      inQuote = !inQuote;
-    } else if (!inQuote && /\s/.test(ch)) {
+    if (quoteChar === null && (ch === '"' || ch === "'")) {
+      quoteChar = ch;
+    } else if (quoteChar !== null && ch === quoteChar) {
+      quoteChar = null;
+    } else if (quoteChar === null && /\s/.test(ch)) {
       if (current) {
         tokens.push(current);
         current = "";
@@ -77,12 +81,75 @@ export function tokenize(raw: string): string[] {
   return tokens;
 }
 
+/**
+ * Schema-aware tokenizer used by skill rendering. When a skill declares
+ * N >= 1 positional arguments, the first N - 1 tokens are split with
+ * `tokenize()` and the **last** token captures the entire remaining
+ * input verbatim (with surrounding whitespace trimmed and a single
+ * surrounding pair of matched quotes stripped). This makes the common
+ * case of an unquoted multi-word final argument "just work" — e.g.
+ * `/write-as-evan why are avocados good?` for a single-arg skill puts
+ * the whole sentence into `$1`.
+ *
+ * When N === 0 (no declared arguments), behaves exactly like
+ * `tokenize()`.
+ */
+export function tokenizeForSkill(
+  raw: string,
+  skill: SkillDefinition,
+): string[] {
+  const n = skill.arguments.length;
+  if (n === 0) return tokenize(raw);
+
+  const tokens: string[] = [];
+  let current = "";
+  let quoteChar: '"' | "'" | null = null;
+  let i = 0;
+
+  for (; i < raw.length && tokens.length < n - 1; i++) {
+    const ch = raw[i] as string;
+    if (quoteChar === null && (ch === '"' || ch === "'")) {
+      quoteChar = ch;
+    } else if (quoteChar !== null && ch === quoteChar) {
+      quoteChar = null;
+    } else if (quoteChar === null && /\s/.test(ch)) {
+      if (current) {
+        tokens.push(current);
+        current = "";
+      }
+    } else {
+      current += ch;
+    }
+  }
+
+  // Flush any in-progress token if we hit the N-1 cap mid-run.
+  if (current) {
+    tokens.push(current);
+    current = "";
+  }
+
+  let remainder = raw.slice(i).trim();
+  if (remainder.length >= 2) {
+    const first = remainder[0];
+    const last = remainder[remainder.length - 1];
+    if ((first === '"' || first === "'") && first === last) {
+      // Strip surrounding quotes only when the entire remainder is a
+      // single quoted string with no interior unescaped same-quote.
+      const inner = remainder.slice(1, -1);
+      if (!inner.includes(first)) remainder = inner;
+    }
+  }
+  if (remainder.length > 0) tokens.push(remainder);
+
+  return tokens;
+}
+
 function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 export function renderSkill(skill: SkillDefinition, rawArgs: string): string {
-  const tokens = tokenize(rawArgs);
+  const tokens = tokenizeForSkill(rawArgs, skill);
   let result = skill.body;
 
   // Replace $<argName> placeholders first, longest names first so a `$start`
@@ -123,7 +190,7 @@ export function validateSkillArgs(
   skill: SkillDefinition,
   rawArgs: string,
 ): { missing: string[] } {
-  const tokens = tokenize(rawArgs);
+  const tokens = tokenizeForSkill(rawArgs, skill);
   const missing: string[] = [];
   skill.arguments.forEach((argDef, i) => {
     if (!argDef.required) return;

--- a/test/skills/commands.test.ts
+++ b/test/skills/commands.test.ts
@@ -212,4 +212,105 @@ describe("handleSlashCommand", () => {
     expect(ctx.clearCalls).toBe(0);
     expect(ctx.systemMessages[0]).toContain("only available in the chat TUI");
   });
+
+  test("1-arg skill: unquoted multi-word input is rendered into $1", () => {
+    const writeSkill: SkillDefinition = {
+      name: "write",
+      description: "",
+      arguments: [{ name: "topic", description: "", required: true }],
+      body: "Topic: $1",
+      filePath: "/skills/write.md",
+    };
+    const ctx = makeCtx(makeSkillMap(writeSkill));
+    const result = handleSlashCommand("/write why are avocados good?", ctx);
+    expect(result).toBe(true);
+    expect(ctx.systemMessages).toHaveLength(0);
+    expect(ctx.queuedMessages).toHaveLength(1);
+    expect(ctx.queuedMessages[0]?.content).toBe(
+      "Topic: why are avocados good?",
+    );
+  });
+
+  test("2-arg skill: unquoted multi-word input is blocked with hint", () => {
+    const writeAsEvan: SkillDefinition = {
+      name: "write-as-evan",
+      description: "",
+      arguments: [
+        { name: "topic", description: "", required: true },
+        {
+          name: "format",
+          description: "",
+          required: false,
+          default: "blog-post",
+        },
+      ],
+      body: "About `$1` (**$2**)",
+      filePath: "/skills/write-as-evan.md",
+    };
+    const ctx = makeCtx(makeSkillMap(writeAsEvan));
+    const result = handleSlashCommand(
+      "/write-as-evan why are avocados good?",
+      ctx,
+    );
+    expect(result).toBe(true);
+    expect(ctx.queuedMessages).toHaveLength(0);
+    expect(ctx.systemMessages).toHaveLength(1);
+    const hint = ctx.systemMessages[0] ?? "";
+    expect(hint).toContain("ambiguous input");
+    expect(hint).toContain("topic");
+    expect(hint).toContain("format");
+    expect(hint).toContain("why");
+    expect(hint).toContain("are avocados good?");
+    expect(hint).toContain('"why are avocados good?"');
+  });
+
+  test("2-arg skill: quoted multi-word input proceeds normally", () => {
+    const writeAsEvan: SkillDefinition = {
+      name: "write-as-evan",
+      description: "",
+      arguments: [
+        { name: "topic", description: "", required: true },
+        {
+          name: "format",
+          description: "",
+          required: false,
+          default: "blog-post",
+        },
+      ],
+      body: "About `$1` (**$2**)",
+      filePath: "/skills/write-as-evan.md",
+    };
+    const ctx = makeCtx(makeSkillMap(writeAsEvan));
+    const result = handleSlashCommand(
+      "/write-as-evan 'why are avocados good?'",
+      ctx,
+    );
+    expect(result).toBe(true);
+    expect(ctx.systemMessages).toHaveLength(0);
+    expect(ctx.queuedMessages).toHaveLength(1);
+    expect(ctx.queuedMessages[0]?.content).toBe(
+      "About `why are avocados good?` (**blog-post**)",
+    );
+  });
+
+  test("2-arg skill: clean two-word input proceeds normally", () => {
+    const skill: SkillDefinition = {
+      name: "review",
+      description: "",
+      arguments: [
+        { name: "file", description: "", required: true },
+        { name: "focus", description: "", required: false, default: "all" },
+      ],
+      body: "Review $1 focusing on $2.",
+      filePath: "/skills/review.md",
+    };
+    const ctx = makeCtx(makeSkillMap(skill));
+    const result = handleSlashCommand("/review src/cli.ts security", ctx);
+    expect(result).toBe(true);
+    expect(ctx.systemMessages).toHaveLength(0);
+    expect(ctx.queuedMessages).toHaveLength(1);
+    expect(ctx.queuedMessages[0]?.content).toBe(
+      "Review src/cli.ts focusing on security.",
+    );
+  });
 });

--- a/test/skills/parser.test.ts
+++ b/test/skills/parser.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from "bun:test";
 import {
   parseSkillFile,
   renderSkill,
+  type SkillDefinition,
   tokenize,
+  tokenizeForSkill,
   validateSkillArgs,
 } from "../../src/skills/parser.ts";
 
@@ -173,6 +175,40 @@ describe("renderSkill", () => {
     };
     expect(renderSkill(skill, '"src/my file.ts" performance')).toBe(
       "File: src/my file.ts, Focus: performance",
+    );
+  });
+
+  test("1-arg skill renders multi-word unquoted input into $1", () => {
+    const skill = {
+      name: "test",
+      description: "",
+      arguments: [{ name: "topic", description: "", required: true }],
+      body: "Topic: $1",
+      filePath: "/test.md",
+    };
+    expect(renderSkill(skill, "why are avocados good?")).toBe(
+      "Topic: why are avocados good?",
+    );
+  });
+
+  test("2-arg skill (write-as-evan shape) with quoted multi-word topic", () => {
+    const skill = {
+      name: "write-as-evan",
+      description: "",
+      arguments: [
+        { name: "topic", description: "", required: true },
+        {
+          name: "format",
+          description: "",
+          required: false,
+          default: "blog-post",
+        },
+      ],
+      body: "About `$1` in format **$2**.",
+      filePath: "/test.md",
+    };
+    expect(renderSkill(skill, "'why are avocados good?'")).toBe(
+      "About `why are avocados good?` in format **blog-post**.",
     );
   });
 
@@ -349,8 +385,101 @@ describe("tokenize", () => {
     expect(tokenize('"a b" c')).toEqual(["a b", "c"]);
   });
 
+  test("respects single-quoted strings", () => {
+    expect(tokenize("'a b' c")).toEqual(["a b", "c"]);
+  });
+
+  test("treats single quotes inside double quotes as literal", () => {
+    expect(tokenize('"can\'t stop" now')).toEqual(["can't stop", "now"]);
+  });
+
+  test("treats double quotes inside single quotes as literal", () => {
+    expect(tokenize(`'he said "hi"'`)).toEqual([`he said "hi"`]);
+  });
+
   test("returns empty array for empty input", () => {
     expect(tokenize("")).toEqual([]);
+  });
+});
+
+describe("tokenizeForSkill", () => {
+  function skillWithArgs(n: number): SkillDefinition {
+    return {
+      name: "t",
+      description: "",
+      arguments: Array.from({ length: n }, (_, i) => ({
+        name: `arg${i + 1}`,
+        description: "",
+        required: false,
+      })),
+      body: "",
+      filePath: "/t.md",
+    };
+  }
+
+  test("falls back to tokenize() when no args declared", () => {
+    expect(tokenizeForSkill("a b c", skillWithArgs(0))).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+  });
+
+  test("1-arg skill: unquoted multi-word input becomes one token", () => {
+    expect(
+      tokenizeForSkill("why are avocados good?", skillWithArgs(1)),
+    ).toEqual(["why are avocados good?"]);
+  });
+
+  test("1-arg skill: surrounding single quotes are stripped", () => {
+    expect(
+      tokenizeForSkill("'why are avocados good?'", skillWithArgs(1)),
+    ).toEqual(["why are avocados good?"]);
+  });
+
+  test("1-arg skill: surrounding double quotes are stripped", () => {
+    expect(
+      tokenizeForSkill('"why are avocados good?"', skillWithArgs(1)),
+    ).toEqual(["why are avocados good?"]);
+  });
+
+  test("2-arg skill: first quoted token then remainder", () => {
+    expect(tokenizeForSkill('"a b c" d', skillWithArgs(2))).toEqual([
+      "a b c",
+      "d",
+    ]);
+  });
+
+  test("2-arg skill: greedy last consumes the rest unquoted", () => {
+    expect(tokenizeForSkill("a b c d", skillWithArgs(2))).toEqual([
+      "a",
+      "b c d",
+    ]);
+  });
+
+  test("2-arg skill: single token leaves last slot undefined", () => {
+    expect(tokenizeForSkill("a", skillWithArgs(2))).toEqual(["a"]);
+  });
+
+  test("empty input returns empty array", () => {
+    expect(tokenizeForSkill("", skillWithArgs(2))).toEqual([]);
+  });
+
+  test("strips surrounding quotes from remainder only when matched", () => {
+    // Mismatched: leading single, trailing double → no strip.
+    expect(tokenizeForSkill("a 'foo bar\"", skillWithArgs(2))).toEqual([
+      "a",
+      "'foo bar\"",
+    ]);
+  });
+
+  test("does not strip when remainder contains the same quote inside", () => {
+    // 'a'b' — surrounding quotes match but inner has same quote, so the
+    // remainder is treated as a literal multi-word string.
+    expect(tokenizeForSkill("x 'a'b'", skillWithArgs(2))).toEqual([
+      "x",
+      "'a'b'",
+    ]);
   });
 });
 
@@ -410,5 +539,18 @@ describe("validateSkillArgs", () => {
       filePath: "/test.md",
     };
     expect(validateSkillArgs(skill, "src/main.ts")).toEqual({ missing: [] });
+  });
+
+  test("1 required arg + multi-word input passes (greedy last)", () => {
+    const skill = {
+      name: "test",
+      description: "",
+      arguments: [{ name: "topic", description: "", required: true }],
+      body: "",
+      filePath: "/test.md",
+    };
+    expect(validateSkillArgs(skill, "why are avocados good?")).toEqual({
+      missing: [],
+    });
   });
 });


### PR DESCRIPTION
## Summary

- `tokenize()` accepts both `'...'` and `"..."` strings; before, only double quotes were honored, so `/skill 'a b'` tokenized as `["'a", "b'"]`.
- New `tokenizeForSkill()` makes the **last declared positional argument greedy** — it consumes the entire trailing remainder verbatim. A single-arg skill like `/summarize-topic why are avocados good?` now puts the full sentence in `\$1` without requiring quotes.
- For skills with two or more declared args, unquoted multi-word input is rejected before the LLM is called. The TUI prints a parse breakdown plus quoting suggestions instead of silently dropping words. Quoted (single or double) input proceeds normally.
- Docs in `docs/skills.md` updated; version bumped to 0.11.5.

### Before

```
> /write-as-evan why are avocados good?
[silently dropped to topic="why"; agent writes generic post]
> /write-as-evan 'why are avocados good?'
[topic literally became "'why" — leading apostrophe]
```

### After

```
> /summarize-topic why are avocados good?
\$1 = "why are avocados good?"   # 1-arg skill: greedy works without quotes

> /write-as-evan 'why are avocados good?'
topic = "why are avocados good?", format = default

> /write-as-evan why are avocados good?
/write-as-evan: ambiguous input. Parsed as:
  topic  = "why"
  format = "are avocados good?"

Quote the multi-word argument to confirm, e.g.:
  /write-as-evan "why are avocados good?"
  /write-as-evan 'why' 'are avocados good?'
```

## Test plan

- [x] \`bun run lint\` passes
- [x] \`bun test\` passes (814 tests, 70 in \`test/skills/\`)
- [ ] Manual smoke in \`botholomew chat\` against \`~/.botholomew/skills/write-as-evan.md\`:
  - [ ] \`/write-as-evan 'why are avocados good?'\` — full topic, default format
  - [ ] \`/write-as-evan "why are avocados good?" tutorial\` — full topic, format=tutorial
  - [ ] \`/write-as-evan why are avocados good?\` — TUI shows the ambiguity hint, no LLM call

🤖 Generated with [Claude Code](https://claude.com/claude-code)