### PR TITLE
Add pipe_to_context meta-tool for piping large tool output into context

### DIFF
--- a/docs/context-and-search.md
+++ b/docs/context-and-search.md
@@ -266,6 +266,21 @@ On success, `context_write` also returns a `tree` field — a
 `context_tree` snapshot of the current drive — so the agent can see
 what else is nearby without a follow-up call.
 
+### Piping a tool's output straight into context
+
+When the agent wants a *large* tool output to be searchable for later but
+does not need to read the bytes itself, `pipe_to_context` is the
+recommended path. It dispatches another tool (e.g. `search_grep`,
+`mcp_exec`, `context_refresh`), captures the stringified result, and
+feeds it into the same `upsertContextItem` + `ingestByPath` pipeline
+`context_write` uses — chunked, embedded, and indexed for hybrid search.
+The model only sees a small ack (id, drive, path, byte count, 200-char
+preview), so a multi-megabyte payload doesn't burn the conversation
+budget. Terminal tools and `pipe_to_context` itself are rejected; if the
+inner tool errors, nothing is written. See
+[tools.md](tools.md#pipe_to_context--pipe-a-tools-output-straight-into-context)
+for the full contract.
+
 ### Refreshing stale content
 
 ```bash

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -163,6 +163,46 @@ command to wire. The Zod schema is the source of truth.
 
 ---
 
+## `pipe_to_context` — pipe a tool's output straight into context
+
+Sometimes the agent wants a tool's full output to be searchable later but
+doesn't actually need to *read* it. A web fetch, an `mcp_exec` that returns a
+big JSON dump, a `search_grep` over a wide pattern — all of these can blow
+through the conversation budget if the bytes round-trip through the LLM.
+
+`pipe_to_context` is a meta-tool: you give it the *name and arguments* of
+another tool, plus a destination `(drive, path)`, and it dispatches the inner
+tool, captures the stringified result, and writes it directly to a context
+item via the same ingest pipeline `context_write` uses (chunked + embedded +
+indexed). The model only ever sees a small acknowledgment — id, drive, path,
+byte count, and a 200-char preview — never the raw bytes.
+
+```text
+agent → pipe_to_context(tool_name="search_grep",
+                         tool_input={...},
+                         drive="agent",
+                         path="/research/grep-results.txt")
+        → { id, ref: "agent:/research/grep-results.txt",
+            bytes_written: 184321, preview: "…" }
+agent → context_search("the thing I actually wanted to know")
+```
+
+Two guards apply at the dispatch site:
+
+- Terminal tools (`complete_task`, `fail_task`, `wait_task`) and
+  `pipe_to_context` itself are rejected with `error_type: "forbidden_tool"`.
+  Piping a terminal tool would let the loop end without the orchestrator
+  seeing the result; recursion is meaningless.
+- The inner tool's input is validated against its own `inputSchema` before
+  dispatch, so bad arguments come back as `error_type: "invalid_input"`
+  with field-level detail instead of an opaque crash.
+
+If the inner tool returns `is_error: true`, **nothing is written** — the pipe
+returns `error_type: "inner_tool_error"` with the inner message inlined (capped
+at 2KB), so the agent can retry with different arguments.
+
+---
+
 ## `capabilities_refresh` — the meta-tool
 
 The `capabilities`-group tool `capabilities_refresh` exists so the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/chat/agent.ts
+++ b/src/chat/agent.ts
@@ -56,6 +56,7 @@ const CHAT_TOOL_NAMES = new Set([
   "mcp_info",
   "mcp_exec",
   "read_large_result",
+  "pipe_to_context",
   "spawn_worker",
   "skill_list",
   "skill_read",

--- a/src/tools/context/pipe.ts
+++ b/src/tools/context/pipe.ts
@@ -1,0 +1,228 @@
+import { isText } from "istextorbinary";
+import { z } from "zod";
+import { formatDriveRef } from "../../context/drives.ts";
+import { ingestByPath } from "../../context/ingest.ts";
+import {
+  createContextItemStrict,
+  PathConflictError,
+  upsertContextItem,
+} from "../../db/context.ts";
+import { getTool, type ToolDefinition } from "../tool.ts";
+
+const PREVIEW_CHARS = 200;
+const ERROR_MESSAGE_CAP = 2000;
+const TOOL_NAME = "pipe_to_context";
+
+function mimeFromPath(path: string): string {
+  const type = Bun.file(path).type.split(";")[0];
+  return type ?? "application/octet-stream";
+}
+
+function isTextualPath(path: string): boolean {
+  const filename = path.split("/").pop() ?? path;
+  return isText(filename) !== false;
+}
+
+function truncate(s: string, cap: number): string {
+  if (s.length <= cap) return s;
+  return `${s.slice(0, cap)}…[truncated, ${s.length - cap} more chars]`;
+}
+
+const inputSchema = z.object({
+  tool_name: z
+    .string()
+    .describe(
+      "Name of the tool to dispatch. Its full output is piped into a context item; you (the LLM) will only see the storage acknowledgment, never the raw bytes.",
+    ),
+  tool_input: z
+    .record(z.string(), z.unknown())
+    .describe(
+      "Arguments to pass to the inner tool (same shape as a normal call).",
+    ),
+  drive: z
+    .string()
+    .default("agent")
+    .describe(
+      "Drive to write to (defaults to 'agent', the agent's scratch drive).",
+    ),
+  path: z.string().describe("Path within the drive (starts with /)"),
+  title: z
+    .string()
+    .optional()
+    .describe("Title for the file (defaults to filename)"),
+  description: z.string().optional().describe("Description of the file"),
+  on_conflict: z
+    .enum(["error", "overwrite"])
+    .optional()
+    .describe(
+      "What to do if a file already exists at this (drive, path). Defaults to 'error'. Pass 'overwrite' to replace.",
+    ),
+});
+
+const outputSchema = z.object({
+  is_error: z.boolean(),
+  id: z.string().optional(),
+  drive: z.string().optional(),
+  path: z.string().optional(),
+  ref: z.string().optional(),
+  bytes_written: z.number().optional(),
+  preview: z
+    .string()
+    .optional()
+    .describe(
+      `First ${PREVIEW_CHARS} characters of the stored content so you can sanity-check what was captured.`,
+    ),
+  inner_tool_is_error: z.boolean().optional(),
+  error_type: z
+    .enum([
+      "unknown_tool",
+      "forbidden_tool",
+      "invalid_input",
+      "inner_tool_error",
+      "path_conflict",
+    ])
+    .optional(),
+  message: z.string().optional(),
+  next_action_hint: z.string().optional(),
+});
+
+export const pipeToContextTool = {
+  name: TOOL_NAME,
+  description:
+    "[[ bash equivalent command: cmd > file ]] Run another tool and pipe its full output directly into a context item, without the result flowing through the conversation. Use this when you need a large tool output (web pages, search dumps, big mcp_exec results) to be searchable/embedded for later but you do NOT need to read the bytes yourself. You'll only see the storage ack (drive, path, id, size, short preview).",
+  group: "context",
+  inputSchema,
+  outputSchema,
+  execute: async (input, ctx) => {
+    const inner = getTool(input.tool_name);
+    if (!inner) {
+      return {
+        is_error: true,
+        error_type: "unknown_tool",
+        message: `No tool named "${input.tool_name}".`,
+        next_action_hint:
+          "Check the tool name spelling, or call the inner tool directly if you do need to see its output.",
+      };
+    }
+
+    if (inner.name === TOOL_NAME || inner.terminal) {
+      return {
+        is_error: true,
+        error_type: "forbidden_tool",
+        message: `Tool "${inner.name}" cannot be piped (terminal tools and pipe_to_context itself are not allowed).`,
+        next_action_hint:
+          "Pipe a non-terminal tool (search_grep, mcp_exec, context_refresh, etc.) instead.",
+      };
+    }
+
+    const parsedInner = inner.inputSchema.safeParse(input.tool_input);
+    if (!parsedInner.success) {
+      const issues = parsedInner.error.issues
+        .map((i) => `${i.path.join(".")}: ${i.message}`)
+        .join("; ");
+      return {
+        is_error: true,
+        error_type: "invalid_input",
+        message: `Invalid input for ${inner.name}: ${issues}.`,
+        next_action_hint:
+          "Fix tool_input to match the inner tool's schema and retry.",
+      };
+    }
+
+    let innerResult: unknown;
+    try {
+      innerResult = await inner.execute(parsedInner.data, ctx);
+    } catch (err) {
+      return {
+        is_error: true,
+        error_type: "inner_tool_error",
+        inner_tool_is_error: true,
+        message: truncate(
+          `Tool ${inner.name} threw: ${err instanceof Error ? err.message : String(err)}`,
+          ERROR_MESSAGE_CAP,
+        ),
+        next_action_hint:
+          "Retry with different arguments, or call the tool directly to see the full error.",
+      };
+    }
+
+    const innerIsError =
+      typeof innerResult === "object" &&
+      innerResult !== null &&
+      "is_error" in innerResult
+        ? (innerResult as { is_error: boolean }).is_error
+        : false;
+
+    const innerOutput =
+      typeof innerResult === "string"
+        ? innerResult
+        : JSON.stringify(innerResult);
+
+    if (innerIsError) {
+      return {
+        is_error: true,
+        error_type: "inner_tool_error",
+        inner_tool_is_error: true,
+        message: truncate(innerOutput, ERROR_MESSAGE_CAP),
+        next_action_hint:
+          "The inner tool returned an error and nothing was written. Fix the inputs and retry, or pipe a different tool.",
+      };
+    }
+
+    const mimeType = mimeFromPath(input.path);
+    const isTextual = isTextualPath(input.path);
+    const title =
+      input.title ?? input.path.split("/").filter(Boolean).pop() ?? input.path;
+    const onConflict = input.on_conflict ?? "error";
+    const target = { drive: input.drive, path: input.path };
+
+    try {
+      const item =
+        onConflict === "overwrite"
+          ? await upsertContextItem(ctx.conn, {
+              title,
+              description: input.description,
+              content: innerOutput,
+              drive: target.drive,
+              path: target.path,
+              mimeType,
+              isTextual,
+            })
+          : await createContextItemStrict(ctx.conn, {
+              title,
+              description: input.description,
+              content: innerOutput,
+              drive: target.drive,
+              path: target.path,
+              mimeType,
+              isTextual,
+            });
+
+      await ingestByPath(ctx.conn, target, ctx.config);
+
+      return {
+        is_error: false,
+        id: item.id,
+        drive: item.drive,
+        path: item.path,
+        ref: formatDriveRef(item),
+        bytes_written: innerOutput.length,
+        preview: innerOutput.slice(0, PREVIEW_CHARS),
+      };
+    } catch (err) {
+      if (err instanceof PathConflictError) {
+        return {
+          is_error: true,
+          error_type: "path_conflict",
+          drive: err.drive,
+          path: err.path,
+          ref: formatDriveRef({ drive: err.drive, path: err.path }),
+          message: `A file already exists at ${formatDriveRef({ drive: err.drive, path: err.path })} (id: ${err.existingId}). The inner tool ran but its output was discarded.`,
+          next_action_hint:
+            "Retry with on_conflict='overwrite' to replace, or pick a different path.",
+        };
+      }
+      throw err;
+    }
+  },
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -2,6 +2,7 @@
 import { capabilitiesRefreshTool } from "./capabilities/refresh.ts";
 // Context tools
 import { contextListDrivesTool } from "./context/list-drives.ts";
+import { pipeToContextTool } from "./context/pipe.ts";
 import { readLargeResultTool } from "./context/read-large-result.ts";
 import { contextRefreshTool } from "./context/refresh.ts";
 import { contextSearchTool } from "./context/search.ts";
@@ -85,6 +86,7 @@ export function registerAllTools(): void {
   registerTool(updateBeliefsTool);
   registerTool(updateGoalsTool);
   registerTool(readLargeResultTool);
+  registerTool(pipeToContextTool);
 
   // Capabilities
   registerTool(capabilitiesRefreshTool);

--- a/test/tools/context/pipe.test.ts
+++ b/test/tools/context/pipe.test.ts
@@ -1,0 +1,263 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { z } from "zod";
+import type { DbConnection } from "../../../src/db/connection.ts";
+import { pipeToContextTool } from "../../../src/tools/context/pipe.ts";
+import { contextReadTool } from "../../../src/tools/file/read.ts";
+import { registerTool, type ToolContext } from "../../../src/tools/tool.ts";
+import { setupToolContext } from "../../helpers.ts";
+
+// pipe_to_context looks itself up by name when guarding against recursion,
+// so it must be in the registry for that test to pass.
+registerTool(pipeToContextTool);
+
+let conn: DbConnection;
+let ctx: ToolContext;
+
+const D = "agent";
+
+// --- Fixture inner tools (registered once, used across tests) ---
+
+const fixtureOkInput = z.object({
+  payload: z.string(),
+});
+const fixtureOkOutput = z.object({
+  echoed: z.string(),
+  is_error: z.boolean(),
+});
+const FIXTURE_OK = "pipe_test_ok_tool";
+registerTool({
+  name: FIXTURE_OK,
+  description: "Echoes payload back",
+  group: "test",
+  inputSchema: fixtureOkInput,
+  outputSchema: fixtureOkOutput,
+  execute: async (input) => ({ echoed: input.payload, is_error: false }),
+});
+
+const fixtureErrInput = z.object({});
+const fixtureErrOutput = z.object({
+  message: z.string(),
+  is_error: z.boolean(),
+});
+const FIXTURE_ERR = "pipe_test_err_tool";
+registerTool({
+  name: FIXTURE_ERR,
+  description: "Always returns is_error=true",
+  group: "test",
+  inputSchema: fixtureErrInput,
+  outputSchema: fixtureErrOutput,
+  execute: async () => ({ message: "deliberate failure", is_error: true }),
+});
+
+// Fixture terminal tool — used to verify pipe rejects terminal tools.
+const FIXTURE_TERMINAL = "pipe_test_terminal_tool";
+registerTool({
+  name: FIXTURE_TERMINAL,
+  description: "Terminal fixture",
+  group: "test",
+  terminal: true,
+  inputSchema: z.object({}),
+  outputSchema: z.object({ is_error: z.boolean() }),
+  execute: async () => ({ is_error: false }),
+});
+
+beforeEach(async () => {
+  ({ conn, ctx } = await setupToolContext());
+});
+
+describe("pipe_to_context", () => {
+  test("happy path: dispatches inner tool and stores stringified result", async () => {
+    const result = await pipeToContextTool.execute(
+      {
+        tool_name: FIXTURE_OK,
+        tool_input: { payload: "hello pipe" },
+        drive: D,
+        path: "/piped.json",
+      },
+      ctx,
+    );
+
+    expect(result.is_error).toBe(false);
+    expect(result.id).toBeTruthy();
+    expect(result.drive).toBe(D);
+    expect(result.path).toBe("/piped.json");
+    expect(result.bytes_written).toBeGreaterThan(0);
+    expect(result.preview).toContain("hello pipe");
+
+    const read = await contextReadTool.execute(
+      { drive: D, path: "/piped.json" },
+      ctx,
+    );
+    const parsed = JSON.parse(read.content ?? "");
+    expect(parsed.echoed).toBe("hello pipe");
+    expect(parsed.is_error).toBe(false);
+  });
+
+  test("on_conflict='overwrite' replaces existing content", async () => {
+    await pipeToContextTool.execute(
+      {
+        tool_name: FIXTURE_OK,
+        tool_input: { payload: "first" },
+        drive: D,
+        path: "/overwrite.json",
+      },
+      ctx,
+    );
+
+    const result = await pipeToContextTool.execute(
+      {
+        tool_name: FIXTURE_OK,
+        tool_input: { payload: "second" },
+        drive: D,
+        path: "/overwrite.json",
+        on_conflict: "overwrite",
+      },
+      ctx,
+    );
+    expect(result.is_error).toBe(false);
+
+    const read = await contextReadTool.execute(
+      { drive: D, path: "/overwrite.json" },
+      ctx,
+    );
+    expect(read.content).toContain("second");
+    expect(read.content).not.toContain("first");
+  });
+
+  test("default on_conflict='error' returns path_conflict", async () => {
+    await pipeToContextTool.execute(
+      {
+        tool_name: FIXTURE_OK,
+        tool_input: { payload: "original" },
+        drive: D,
+        path: "/conflict.json",
+      },
+      ctx,
+    );
+
+    const result = await pipeToContextTool.execute(
+      {
+        tool_name: FIXTURE_OK,
+        tool_input: { payload: "second" },
+        drive: D,
+        path: "/conflict.json",
+      },
+      ctx,
+    );
+    expect(result.is_error).toBe(true);
+    expect(result.error_type).toBe("path_conflict");
+    expect(result.next_action_hint).toContain("on_conflict='overwrite'");
+
+    const read = await contextReadTool.execute(
+      { drive: D, path: "/conflict.json" },
+      ctx,
+    );
+    expect(read.content).toContain("original");
+  });
+
+  test("inner tool returning is_error=true does NOT write to context", async () => {
+    const result = await pipeToContextTool.execute(
+      {
+        tool_name: FIXTURE_ERR,
+        tool_input: {},
+        drive: D,
+        path: "/should-not-exist.json",
+      },
+      ctx,
+    );
+    expect(result.is_error).toBe(true);
+    expect(result.error_type).toBe("inner_tool_error");
+    expect(result.inner_tool_is_error).toBe(true);
+    expect(result.message).toContain("deliberate failure");
+
+    const exists = await conn.queryGet(
+      "SELECT 1 FROM context_items WHERE drive = ?1 AND path = ?2",
+      D,
+      "/should-not-exist.json",
+    );
+    expect(exists).toBeNull();
+  });
+
+  test("unknown inner tool returns unknown_tool error", async () => {
+    const result = await pipeToContextTool.execute(
+      {
+        tool_name: "no_such_tool_xyz",
+        tool_input: {},
+        drive: D,
+        path: "/never.json",
+      },
+      ctx,
+    );
+    expect(result.is_error).toBe(true);
+    expect(result.error_type).toBe("unknown_tool");
+  });
+
+  test("forbidden inner tool: terminal tools are rejected", async () => {
+    const result = await pipeToContextTool.execute(
+      {
+        tool_name: FIXTURE_TERMINAL,
+        tool_input: {},
+        drive: D,
+        path: "/never.json",
+      },
+      ctx,
+    );
+    expect(result.is_error).toBe(true);
+    expect(result.error_type).toBe("forbidden_tool");
+  });
+
+  test("forbidden inner tool: pipe_to_context itself (no recursion)", async () => {
+    const result = await pipeToContextTool.execute(
+      {
+        tool_name: "pipe_to_context",
+        tool_input: {
+          tool_name: FIXTURE_OK,
+          tool_input: { payload: "x" },
+          drive: D,
+          path: "/inner.json",
+        },
+        drive: D,
+        path: "/outer.json",
+      },
+      ctx,
+    );
+    expect(result.is_error).toBe(true);
+    expect(result.error_type).toBe("forbidden_tool");
+  });
+
+  test("invalid inner input returns invalid_input with field detail", async () => {
+    const result = await pipeToContextTool.execute(
+      {
+        tool_name: FIXTURE_OK,
+        tool_input: { payload: 123 as unknown as string }, // wrong type
+        drive: D,
+        path: "/bad.json",
+      },
+      ctx,
+    );
+    expect(result.is_error).toBe(true);
+    expect(result.error_type).toBe("invalid_input");
+    expect(result.message).toContain("payload");
+  });
+
+  test("ingest runs after a successful pipe (embeddings created)", async () => {
+    const result = await pipeToContextTool.execute(
+      {
+        tool_name: FIXTURE_OK,
+        tool_input: { payload: "searchable kubernetes content" },
+        drive: D,
+        path: "/ingested.txt",
+      },
+      ctx,
+    );
+    expect(result.is_error).toBe(false);
+    expect(result.id).toBeTruthy();
+
+    const row = await conn.queryGet<{ cnt: number }>(
+      "SELECT COUNT(*) AS cnt FROM embeddings WHERE context_item_id = ?1",
+      result.id as string,
+    );
+    expect(row).not.toBeNull();
+    expect(Number(row?.cnt ?? 0)).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

- New `pipe_to_context` tool: dispatches another tool, captures its stringified output, and writes it directly into a context item via the standard ingest pipeline (chunk + embed + index). The model only sees a small ack (id, drive, path, byte count, 200-char preview) — never the raw bytes.
- Useful when the agent wants a large tool output (web fetches, big `mcp_exec` results, wide `search_grep` dumps) to be searchable for later without burning the conversation budget.
- Terminal tools and `pipe_to_context` itself are rejected (`forbidden_tool`); inner-tool errors do not write anything (`inner_tool_error`); inner input is validated against the inner tool's `inputSchema` (`invalid_input`).
- Registered in both worker and chat allowlists.
- Docs updated in `docs/tools.md` and `docs/context-and-search.md`.

## Test plan

- [x] `bun test test/tools/context/pipe.test.ts` (9 cases: happy path, overwrite, path_conflict, inner_tool_error, unknown_tool, forbidden terminal, forbidden recursion, invalid_input, ingest verification)
- [x] `bun test` — full suite (803 tests) green
- [x] `bun run lint` — clean
- [ ] Manual: in `bun run dev chat`, ask the agent to pipe `search_grep` of a common term into `agent:/scratch/grep.txt` and confirm the chat transcript only shows the small confirmation while `context_read agent:/scratch/grep.txt` shows the full content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)