### PR TITLE
Quiet "Loading embedding model" log on cached runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/context/embedder-impl.ts
+++ b/src/context/embedder-impl.ts
@@ -47,11 +47,13 @@ function isModelCached(model: string): boolean {
 async function getPipeline(model: string): Promise<FeatureExtractionPipeline> {
   let p = pipelinePromises.get(model);
   if (!p) {
-    logger.info(
-      isModelCached(model)
-        ? `Loading embedding model ${model}`
-        : `Loading embedding model ${model} (first run, downloading weights)`,
-    );
+    if (isModelCached(model)) {
+      logger.debug(`Loading embedding model ${model}`);
+    } else {
+      logger.info(
+        `Loading embedding model ${model} (first run, downloading weights)`,
+      );
+    }
     p = pipeline("feature-extraction", model);
     pipelinePromises.set(model, p);
   }


### PR DESCRIPTION
## Summary
- Demote the `Loading embedding model …` message to `debug` when the model is already cached on disk; keep the `info`-level line only for first-run downloads.
- The pipeline is a per-process singleton, but many short-lived CLI invocations (worker, chat, search, context, prepare) each loaded the model and printed the line, so it felt constant at default log level.
- Bump version to 0.11.6.

## Test plan
- [x] `bun run lint`
- [x] `bun test`
- [ ] Manual: run an embedding-touching command twice with the model cached — line is gone at default level
- [ ] Manual: `BOTHOLOMEW_LOG_LEVEL=debug` — dim debug variant appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)