### PR TITLE
Rebuild capabilities.md after `mcpx import-global`

### DIFF
--- a/docs/mcpx.md
+++ b/docs/mcpx.md
@@ -89,9 +89,11 @@ every option and argument for that command. The only exception is
 handing it to the agent. `mcpx auth` runs the OAuth flow for HTTP
 servers that need it (most Arcade gateways do), and `mcpx
 import-global` is the usual way to bootstrap a new project from your
-global `~/.mcpx/` configuration. Note that `--args` and `--env` take
-**comma-separated** values — quote them so your shell doesn't split
-them (e.g. `--args "-y,@scope/pkg"`).
+global `~/.mcpx/` configuration — after copying the files it
+automatically rebuilds `.botholomew/capabilities.md` so the freshly
+imported MCPX tools show up alongside the built-ins. Note that
+`--args` and `--env` take **comma-separated** values — quote them so
+your shell doesn't split them (e.g. `--args "-y,@scope/pkg"`).
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/commands/mcpx.ts
+++ b/src/commands/mcpx.ts
@@ -4,7 +4,12 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Command } from "commander";
+import { createSpinner } from "nanospinner";
+import { loadConfig } from "../config/loader.ts";
 import { getMcpxDir } from "../constants.ts";
+import { writeCapabilitiesFile } from "../context/capabilities.ts";
+import { createMcpxClient } from "../mcpx/client.ts";
+import { registerAllTools } from "../tools/registry.ts";
 import { logger } from "../utils/logger.ts";
 
 const require = createRequire(import.meta.url);
@@ -137,10 +142,34 @@ export function registerMcpxCommand(program: Command) {
 
       if (copied === 0) {
         logger.warn("No config files found in ~/.mcpx to copy.");
-      } else {
-        logger.success(
-          `Imported ${copied} file(s) from ~/.mcpx into ${projectMcpxDir}`,
+        return;
+      }
+
+      logger.success(
+        `Imported ${copied} file(s) from ~/.mcpx into ${projectMcpxDir}`,
+      );
+
+      const projectDir = getDir(program);
+      registerAllTools();
+      const config = await loadConfig(projectDir);
+      const mcpxClient = await createMcpxClient(projectDir);
+      const spinner = createSpinner("Rebuilding capabilities.md").start();
+      try {
+        const result = await writeCapabilitiesFile(
+          projectDir,
+          mcpxClient,
+          config,
+          (phase) => spinner.update({ text: phase }),
         );
+        spinner.success({
+          text: `Rebuilt ${result.path} (${result.counts.internal} built-in, ${result.counts.mcp} MCPX)`,
+        });
+      } catch (err) {
+        spinner.error({
+          text: `Failed to rebuild capabilities.md: ${(err as Error).message}`,
+        });
+      } finally {
+        await mcpxClient?.close();
       }
     });
 }

--- a/src/context/capabilities.ts
+++ b/src/context/capabilities.ts
@@ -438,7 +438,7 @@ export async function generateCapabilitiesMarkdown(
       config.anthropic_api_key !== "your-api-key-here";
     if (canSummarize) {
       onPhase?.(
-        `Summarizing ${inv.internalTotal} internal + ${inv.mcpTotal} MCPX tools with Claude`,
+        `Summarizing ${inv.internalTotal} internal + ${inv.mcpTotal} MCPX tools`,
       );
     }
     summary = await summarizeViaLLM(inv, config);


### PR DESCRIPTION
## Summary
- `botholomew mcpx import-global` now auto-rebuilds `.botholomew/capabilities.md` after copying `~/.mcpx` into the project, so freshly imported MCPX tools land in the doc without a separate `botholomew capabilities` run.
- Reuses the existing `writeCapabilitiesFile` helper (same path `init` and `botholomew capabilities` use) and drops a vendor mention from the summarization phase string.
- Doc + version bump (0.12.0 → 0.12.1).

## Test plan
- [ ] `bun run lint` and `bun test` pass (831/831 locally).
- [ ] In a project with `~/.mcpx/servers.json` populated: `bun run dev mcpx import-global` rebuilds `.botholomew/capabilities.md` with the imported MCPX servers' tools listed.
- [ ] In a project with no `~/.mcpx`: command exits 1 with the existing error and skips the rebuild.
- [ ] When `~/.mcpx` exists but no recognized files copy: warning fires, no rebuild runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)