### PR TITLE
Add LLM steering to chat (Esc to abort, mid-turn injection)

### DIFF
--- a/docs/tui.md
+++ b/docs/tui.md
@@ -216,6 +216,16 @@ On the Chat tab, when at least one message is queued:
 The queue is ephemeral (in-memory, not persisted) — it's a way to
 batch follow-ups without interrupting a tool loop mid-flight.
 
+### Steering (Esc to interrupt)
+
+If the agent is heading in the wrong direction, press `Esc` while it's
+streaming a response. Whatever has streamed so far is preserved in the
+chat with a `(steered — response interrupted)` marker, and the next
+queued message — or your next typed prompt — becomes a normal
+follow-up turn. Tool calls that are already in flight finish normally
+(no `AbortSignal` is threaded into tools), but no further LLM turn is
+started after the abort.
+
 ---
 
 ## Tool-call visualization
@@ -275,7 +285,7 @@ just shows the summary to keep the chat view compact.
 | `/` | Open slash-command popup |
 | `Return` | Run highlighted command (popup open, no-arg) / insert `/<name> ` if args needed |
 | `Tab` | Insert highlighted command as `/<name> ` without submitting |
-| `Esc` | Close popup |
+| `Esc` | Close popup, or interrupt a streaming response (steer) |
 | `Ctrl+J` / `Ctrl+K` | Select queued message |
 | `Ctrl+E` | Edit queued message |
 | `Ctrl+X` | Delete queued message |
@@ -338,6 +348,11 @@ A few choices worth knowing if you're reading or modifying the TUI:
 - **Streaming is throttled.** `App.tsx` flushes `streamingText` every
   50 ms max during a response, not per-token. Per-token flushing
   caused visible flicker and ~30× the React commits.
+- **Esc aborts at the SDK layer.** `Esc` on the Chat tab (while a turn
+  is in flight) calls `MessageStream.abort()` on the Anthropic SDK
+  stream. Partial text is persisted to the thread DB and the agent
+  loop short-circuits before the next LLM turn. In-flight tool calls
+  are *not* cancelled — no `AbortSignal` is threaded into tools.
 - **Scroll state lives at the root.** Each list panel (`TaskPanel`,
   `ThreadPanel`, etc.) keeps its scroll offset lifted up so that
   switching tabs doesn't reset your position.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/chat/agent.ts
+++ b/src/chat/agent.ts
@@ -1,4 +1,7 @@
+import type Anthropic from "@anthropic-ai/sdk";
+import { APIUserAbortError } from "@anthropic-ai/sdk";
 import type {
+  Message,
   MessageParam,
   ToolResultBlockParam,
   ToolUseBlock,
@@ -26,6 +29,7 @@ import {
   loadPersistentContext,
   STYLE_RULES,
 } from "../worker/prompt.ts";
+import type { ChatSession } from "./session.ts";
 
 registerAllTools();
 
@@ -176,6 +180,11 @@ export interface ChatTurnCallbacks {
     isError: boolean,
     meta?: ToolEndMeta,
   ) => void;
+  /** Called between LLM turns. The TUI returns any queued user messages so
+   *  the agent can inject them into the running turn instead of waiting for
+   *  the entire tool loop to finish. Each returned message is logged + pushed
+   *  to `messages` before the next `messages.stream(...)` call. */
+  takeInjections?: () => string[];
 }
 
 /**
@@ -205,6 +214,14 @@ export async function runChatTurn(input: {
   threadId: string;
   mcpxClient: McpxClient | null;
   callbacks: ChatTurnCallbacks;
+  /** When supplied, the loop honors `session.aborted` (set by Esc in the TUI)
+   *  and writes the live `MessageStream` to `session.activeStream` so it can
+   *  be aborted from outside. */
+  session?: ChatSession;
+  /** Test seam: inject a pre-built client and skip the model-info fetch.
+   *  Production callers should leave both unset. */
+  _testClient?: Anthropic;
+  _testMaxInputTokens?: number;
 }): Promise<void> {
   const {
     messages,
@@ -214,18 +231,35 @@ export async function runChatTurn(input: {
     threadId,
     mcpxClient,
     callbacks,
+    session,
   } = input;
 
-  const client = createLlmClient(config);
+  const client = input._testClient ?? createLlmClient(config);
 
   const chatTools = getChatTools();
-  const maxInputTokens = await getMaxInputTokens(
-    config.anthropic_api_key,
-    config.model,
-  );
+  const maxInputTokens =
+    input._testMaxInputTokens ??
+    (await getMaxInputTokens(config.anthropic_api_key, config.model));
   const maxTurns = config.max_turns;
 
   for (let turn = 0; !maxTurns || turn < maxTurns; turn++) {
+    if (session?.aborted) return;
+
+    // Steering: drain any user messages the TUI queued during the previous
+    // iteration so they land in the next LLM call rather than waiting for
+    // the whole tool loop to finish.
+    const injections = callbacks.takeInjections?.() ?? [];
+    for (const text of injections) {
+      await withDb(dbPath, (conn) =>
+        logInteraction(conn, threadId, {
+          role: "user",
+          kind: "message",
+          content: text,
+        }),
+      );
+      messages.push({ role: "user", content: text });
+    }
+
     const startTime = Date.now();
 
     // Rebuild the system prompt every iteration so that:
@@ -249,6 +283,7 @@ export async function runChatTurn(input: {
       messages,
       tools: chatTools,
     });
+    if (session) session.activeStream = stream;
 
     // Collect the full response
     let assistantText = "";
@@ -282,7 +317,31 @@ export async function runChatTurn(input: {
       }
     });
 
-    const response = await stream.finalMessage();
+    let response: Message;
+    try {
+      response = await stream.finalMessage();
+    } catch (err) {
+      if (!(err instanceof APIUserAbortError)) throw err;
+      // Esc was pressed mid-stream. Persist whatever text the user already saw
+      // (the `'text'` event has fired for everything reaching us, so
+      // `assistantText` is the right partial value). Deliberately drop any
+      // partial tool_use blocks — they would be unmatched on the next turn.
+      if (assistantText) {
+        await withDb(dbPath, (conn) =>
+          logInteraction(conn, threadId, {
+            role: "assistant",
+            kind: "message",
+            content: assistantText,
+            durationMs: Date.now() - startTime,
+            tokenCount: 0,
+          }),
+        );
+        messages.push({ role: "assistant", content: assistantText });
+      }
+      return;
+    } finally {
+      if (session) session.activeStream = null;
+    }
     const durationMs = Date.now() - startTime;
     const tokenCount =
       response.usage.input_tokens + response.usage.output_tokens;
@@ -382,6 +441,7 @@ export async function runChatTurn(input: {
     }
 
     messages.push({ role: "user", content: toolResults });
+    if (session?.aborted) return;
     // Loop to get the model's next response after tool results
   }
 }

--- a/src/chat/session.ts
+++ b/src/chat/session.ts
@@ -1,3 +1,4 @@
+import type { MessageStream } from "@anthropic-ai/sdk/lib/MessageStream";
 import type { MessageParam } from "@anthropic-ai/sdk/resources/messages";
 import { loadConfig } from "../config/loader.ts";
 import type { BotholomewConfig } from "../config/schemas.ts";
@@ -27,6 +28,24 @@ export interface ChatSession {
   // biome-ignore lint/suspicious/noExplicitAny: mcpx client
   mcpxClient: any;
   cleanup: () => Promise<void>;
+  /** Set by `runChatTurn` while a `messages.stream(...)` is in flight. */
+  activeStream: MessageStream | null;
+  /** Esc-driven steer signal — checked at safe points in the chat agent loop. */
+  aborted: boolean;
+}
+
+/**
+ * Abort the in-flight LLM stream (if any) and set the steer flag so the chat
+ * agent loop short-circuits before issuing another `messages.stream(...)` call.
+ * Safe to call when no stream is active. Returns true if a live stream was aborted.
+ */
+export function abortActiveStream(session: ChatSession): boolean {
+  session.aborted = true;
+  if (session.activeStream && !session.activeStream.aborted) {
+    session.activeStream.abort();
+    return true;
+  }
+  return false;
 }
 
 export async function startChatSession(
@@ -96,6 +115,8 @@ export async function startChatSession(
     skills,
     mcpxClient,
     cleanup,
+    activeStream: null,
+    aborted: false,
   };
 }
 
@@ -104,6 +125,9 @@ export async function sendMessage(
   userMessage: string,
   callbacks: ChatTurnCallbacks,
 ): Promise<void> {
+  // Reset steer flag so a previous turn's Esc doesn't poison this one.
+  session.aborted = false;
+
   // Hot-reload skills so any skill the agent created/edited last turn (or any
   // out-of-band edit) is visible to slash-command dispatch this turn.
   session.skills = await loadSkills(session.projectDir);
@@ -137,6 +161,7 @@ export async function sendMessage(
     threadId: session.threadId,
     mcpxClient: session.mcpxClient,
     callbacks,
+    session,
   });
 }
 
@@ -161,5 +186,7 @@ export async function clearChatSession(
   });
   session.threadId = newThreadId;
   session.messages.length = 0;
+  session.activeStream = null;
+  session.aborted = false;
   return { previousThreadId, newThreadId };
 }

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -1,6 +1,7 @@
 import { Box, Static, Text, useApp, useInput } from "ink";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
+  abortActiveStream,
   type ChatSession,
   clearChatSession,
   endChatSession,
@@ -273,8 +274,20 @@ export function App({
         return;
       }
 
-      // Queue manipulation keybindings (only when queue has items on Chat tab)
       const tab = activeTabRef.current;
+
+      // Esc on Chat tab while a turn is in flight: steer / interrupt.
+      // Calls MessageStream.abort() at the SDK layer; tools already running
+      // finish normally, but no further LLM turn is started.
+      if (key.escape && tab === 1 && processingRef.current) {
+        const session = sessionRef.current;
+        if (session) {
+          abortActiveStream(session);
+          return;
+        }
+      }
+
+      // Queue manipulation keybindings (only when queue has items on Chat tab)
       const queue = queuedMessagesRef.current;
       if (tab === 1 && queue.length > 0 && key.ctrl) {
         if (input === "j") {
@@ -405,8 +418,35 @@ export function App({
             }
             setActiveToolCalls([...pendingToolCalls]);
           },
+          takeInjections: () => {
+            // Drain queued messages into the running turn so the agent sees
+            // them on the next LLM call instead of after the whole tool loop.
+            // Finalize the in-flight assistant segment first so the new user
+            // bubbles render in the right order in the chat view.
+            if (queueRef.current.length === 0) return [];
+            if (currentText || pendingToolCalls.length > 0) {
+              finalizeSegment();
+            }
+            const drained = queueRef.current.splice(0);
+            syncQueue();
+            for (const e of drained) {
+              const userMsg: ChatMessage = {
+                id: msgId(),
+                role: "user",
+                content: e.display,
+                timestamp: new Date(),
+              };
+              setMessages((prev) => [...prev, userMsg]);
+            }
+            return drained.map((e) => e.content);
+          },
         });
 
+        if (sessionRef.current?.aborted) {
+          currentText += currentText
+            ? "\n\n_(steered — response interrupted)_"
+            : "_(steered — no response)_";
+        }
         finalizeSegment();
       } catch (err) {
         const errorMsg: ChatMessage = {

--- a/test/chat/agent-steer.test.ts
+++ b/test/chat/agent-steer.test.ts
@@ -1,0 +1,261 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { APIUserAbortError } from "@anthropic-ai/sdk";
+import type { MessageParam } from "@anthropic-ai/sdk/resources/messages";
+import {
+  mockEmbed,
+  mockEmbedSingle,
+  setupTestDbFile,
+  silentLogger,
+  TEST_CONFIG,
+} from "../helpers.ts";
+
+// Embedder + logger are safe to mock globally — they're already swapped out in
+// other test files. We deliberately do NOT mock createLlmClient or
+// getMaxInputTokens here (mock.module is global to the bun test runner and
+// leaks across files); instead we inject a test client into runChatTurn.
+mock.module("../../src/context/embedder.ts", () => ({
+  embed: mockEmbed,
+  embedSingle: mockEmbedSingle,
+}));
+mock.module("../../src/utils/logger.ts", () => silentLogger);
+
+const { runChatTurn } = await import("../../src/chat/agent.ts");
+const { createThread } = await import("../../src/db/threads.ts");
+
+class FakeMessageStream extends EventEmitter {
+  aborted = false;
+  private _resolve: ((m: unknown) => void) | null = null;
+  private _reject: ((e: unknown) => void) | null = null;
+  private _final: Promise<unknown>;
+  constructor() {
+    super();
+    this._final = new Promise((resolve, reject) => {
+      this._resolve = resolve;
+      this._reject = reject;
+    });
+  }
+  abort(): void {
+    if (this.aborted) return;
+    this.aborted = true;
+    this._reject?.(new APIUserAbortError());
+  }
+  finalMessage(): Promise<unknown> {
+    return this._final;
+  }
+  resolveFinal(msg: unknown): void {
+    this._resolve?.(msg);
+  }
+}
+
+function makeClient(streamFactory: () => FakeMessageStream) {
+  let calls = 0;
+  const client = {
+    messages: {
+      stream: () => {
+        calls++;
+        return streamFactory();
+      },
+    },
+    // biome-ignore lint/suspicious/noExplicitAny: minimal Anthropic stub for runChatTurn injection
+  } as any;
+  return { client, callCount: () => calls };
+}
+
+let dbPath: string;
+let cleanupDb: () => Promise<void>;
+let threadId: string;
+let projectDir: string;
+
+beforeEach(async () => {
+  const setup = await setupTestDbFile();
+  dbPath = setup.dbPath;
+  cleanupDb = setup.cleanup;
+  threadId = await createThread(setup.conn, "chat_session", undefined, "test");
+  projectDir = await mkdtemp(join(tmpdir(), "chat-steer-"));
+  await mkdir(join(projectDir, ".botholomew"), { recursive: true });
+});
+
+afterEach(async () => {
+  await cleanupDb();
+  await rm(projectDir, { recursive: true, force: true });
+});
+
+const noopCallbacks = {
+  onToken: () => {},
+  onToolStart: () => {},
+  onToolEnd: () => {},
+};
+
+function makeSession() {
+  return {
+    dbPath,
+    threadId,
+    projectDir,
+    config: TEST_CONFIG,
+    messages: [] as MessageParam[],
+    skills: new Map(),
+    mcpxClient: null,
+    cleanup: async () => {},
+    activeStream: null,
+    aborted: false,
+    // biome-ignore lint/suspicious/noExplicitAny: test stand-in for ChatSession
+  } as any;
+}
+
+describe("runChatTurn — steering / abort", () => {
+  test("abort during streaming persists partial assistantText and exits the loop", async () => {
+    const session = makeSession();
+    const messages: MessageParam[] = [{ role: "user", content: "hi" }];
+
+    const { client, callCount } = makeClient(() => {
+      const s = new FakeMessageStream();
+      queueMicrotask(() => {
+        s.emit("text", "Hello ");
+        s.emit("text", "world");
+        s.abort();
+      });
+      return s;
+    });
+
+    await runChatTurn({
+      messages,
+      projectDir,
+      config: TEST_CONFIG,
+      dbPath,
+      threadId,
+      mcpxClient: null,
+      callbacks: noopCallbacks,
+      session,
+      _testClient: client,
+      _testMaxInputTokens: 100_000,
+    });
+
+    expect(callCount()).toBe(1);
+    expect(messages.length).toBe(2);
+    expect(messages[1]).toEqual({
+      role: "assistant",
+      content: "Hello world",
+    });
+    expect(session.activeStream).toBeNull();
+  });
+
+  test("session.aborted set before runChatTurn short-circuits without calling stream", async () => {
+    const session = makeSession();
+    session.aborted = true;
+    const messages: MessageParam[] = [{ role: "user", content: "hi" }];
+
+    const { client, callCount } = makeClient(() => {
+      throw new Error("should not be called");
+    });
+
+    await runChatTurn({
+      messages,
+      projectDir,
+      config: TEST_CONFIG,
+      dbPath,
+      threadId,
+      mcpxClient: null,
+      callbacks: noopCallbacks,
+      session,
+      _testClient: client,
+      _testMaxInputTokens: 100_000,
+    });
+
+    expect(callCount()).toBe(0);
+    expect(messages.length).toBe(1);
+  });
+
+  test("takeInjections drains queued user messages between LLM turns", async () => {
+    const session = makeSession();
+    const messages: MessageParam[] = [{ role: "user", content: "first" }];
+    const queued = ["second"];
+    let observedMessagesAtStream: MessageParam[] | null = null;
+
+    const { client } = makeClient(() => {
+      const s = new FakeMessageStream();
+      observedMessagesAtStream = [...messages];
+      queueMicrotask(() => {
+        s.emit("text", "ok");
+        s.resolveFinal({
+          content: [{ type: "text", text: "ok" }],
+          stop_reason: "end_turn",
+          usage: { input_tokens: 1, output_tokens: 1 },
+        });
+      });
+      return s;
+    });
+
+    await runChatTurn({
+      messages,
+      projectDir,
+      config: TEST_CONFIG,
+      dbPath,
+      threadId,
+      mcpxClient: null,
+      callbacks: {
+        ...noopCallbacks,
+        takeInjections: () => queued.splice(0),
+      },
+      session,
+      _testClient: client,
+      _testMaxInputTokens: 100_000,
+    });
+
+    expect(observedMessagesAtStream).not.toBeNull();
+    expect(observedMessagesAtStream as MessageParam[] | null).toEqual([
+      { role: "user", content: "first" },
+      { role: "user", content: "second" },
+    ]);
+    expect(queued.length).toBe(0);
+  });
+
+  test("mid-stream abort with a pending tool_use does not append unmatched tool_use blocks", async () => {
+    const session = makeSession();
+    const messages: MessageParam[] = [{ role: "user", content: "do work" }];
+
+    const { client } = makeClient(() => {
+      const s = new FakeMessageStream();
+      queueMicrotask(() => {
+        s.emit("text", "starting");
+        // Emit a content_block_start for a tool_use, but never the
+        // matching contentBlock — abort fires while the tool_use is partial.
+        s.emit("streamEvent", {
+          type: "content_block_start",
+          content_block: {
+            type: "tool_use",
+            id: "tool_partial",
+            name: "list_tasks",
+          },
+        });
+        s.abort();
+      });
+      return s;
+    });
+
+    await runChatTurn({
+      messages,
+      projectDir,
+      config: TEST_CONFIG,
+      dbPath,
+      threadId,
+      mcpxClient: null,
+      callbacks: noopCallbacks,
+      session,
+      _testClient: client,
+      _testMaxInputTokens: 100_000,
+    });
+
+    expect(messages.length).toBe(2);
+    const appended = messages[1];
+    expect(appended?.role).toBe("assistant");
+    // Critical: the appended assistant content must be plain text, not an
+    // array containing a partial tool_use block (which would break the next
+    // turn with "tool_use without matching tool_result").
+    expect(typeof appended?.content).toBe("string");
+    expect(appended?.content).toBe("starting");
+  });
+});


### PR DESCRIPTION
## Summary
- `Esc` on the Chat tab interrupts a streaming LLM response: partial text is preserved with a `(steered — response interrupted)` marker, `MessageStream.abort()` is called at the SDK layer, and the agent loop short-circuits before the next turn. Tools already running finish normally — no `AbortSignal` is threaded into tools.
- Queued user messages now drain into the active run at the top of each `runChatTurn` iteration via a new `takeInjections` callback, instead of waiting for the entire tool loop to finish.
- Adds 4 unit tests covering abort + injection paths and a `_testClient` injection seam in `runChatTurn` so tests don't need to mock `createLlmClient` (which leaks globally in Bun's test runner).

## Test plan
- [x] `bun run lint` (tsc + biome) — clean
- [x] `bun test` — 827 pass / 0 fail
- [ ] Manual TUI: hit Esc mid-stream → partial text + steer marker, queue resumes; Esc during a tool spinner → tool finishes, no further LLM turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)