### PR TITLE
Bump @evantahler/mcpx to 0.21.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.92.0",
         "@duckdb/node-api": "^1.5.2-r.1",
-        "@evantahler/mcpx": "0.19.1",
+        "@evantahler/mcpx": "0.21.0",
         "@huggingface/transformers": "^4.2.0",
         "ansis": "^4.2.0",
         "commander": "^14.0.0",
@@ -179,7 +179,7 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
 
-    "@evantahler/mcpx": ["@evantahler/mcpx@0.19.1", "", { "dependencies": { "@huggingface/transformers": "^4.2.0", "@modelcontextprotocol/sdk": "^1.29.0", "@types/picomatch": "^4.0.3", "ajv": "^8.20.0", "ansis": "^4.2.0", "commander": "^14.0.3", "nanospinner": "^1.2.2", "picomatch": "^4.0.4" }, "peerDependencies": { "typescript": "^6" }, "bin": { "mcpx": "src/cli.ts" } }, "sha512-FYs37nsSE8kqEKq64Oc1hkfUQRvi6L+cISlngQqQYZEVPE2DFR/oK22V7bQNK2spjn4zRu8dj6hxjscd+aDXHQ=="],
+    "@evantahler/mcpx": ["@evantahler/mcpx@0.21.0", "", { "dependencies": { "@huggingface/transformers": "^4.2.0", "@modelcontextprotocol/sdk": "^1.29.0", "@types/picomatch": "^4.0.3", "ajv": "^8.20.0", "ansis": "^4.2.0", "commander": "^14.0.3", "nanospinner": "^1.2.2", "picomatch": "^4.0.4" }, "peerDependencies": { "typescript": "^6" }, "bin": { "mcpx": "src/cli.ts" } }, "sha512-+ielnIvTvg1tm+dsfN5QKYvRd1RqMRVqGp2hqhSW/U38h6jD+ZU4RMB3jP9JWwC1qOZgifFPfBnY39b8ulk3Gg=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {
@@ -28,7 +28,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.92.0",
     "@duckdb/node-api": "^1.5.2-r.1",
-    "@evantahler/mcpx": "0.19.1",
+    "@evantahler/mcpx": "0.21.0",
     "@huggingface/transformers": "^4.2.0",
     "ansis": "^4.2.0",
     "commander": "^14.0.0",


### PR DESCRIPTION
## Summary
- Bump `@evantahler/mcpx` from `0.19.1` → `0.21.0` (cumulative: shell-style `mcpx exec` args after `--`, stderr-via-logger, `UrlElicitationRequiredError` handling, richer tool-call response blocks).
- Bump botholomew `version` to `0.12.3` for auto-release.
- No source changes needed: `McpxClient` constructor and `CallToolResult` block types we consume are unchanged, and `@huggingface/transformers@^4.2.0` still dedupes so the existing patch covers the nested mcpx copy.

## Test plan
- [x] `bun run lint` clean
- [x] `bun test` — 835 pass, 0 fail
- [x] `bunx mcpx --version` reports `0.21.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)