### PR TITLE
Bump @evantahler/mcpx to 0.21.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.92.0",
         "@duckdb/node-api": "^1.5.2-r.1",
-        "@evantahler/mcpx": "0.21.0",
+        "@evantahler/mcpx": "0.21.3",
         "@huggingface/transformers": "^4.2.0",
         "ansis": "^4.2.0",
         "commander": "^14.0.0",
@@ -179,7 +179,7 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
 
-    "@evantahler/mcpx": ["@evantahler/mcpx@0.21.0", "", { "dependencies": { "@huggingface/transformers": "^4.2.0", "@modelcontextprotocol/sdk": "^1.29.0", "@types/picomatch": "^4.0.3", "ajv": "^8.20.0", "ansis": "^4.2.0", "commander": "^14.0.3", "nanospinner": "^1.2.2", "picomatch": "^4.0.4" }, "peerDependencies": { "typescript": "^6" }, "bin": { "mcpx": "src/cli.ts" } }, "sha512-+ielnIvTvg1tm+dsfN5QKYvRd1RqMRVqGp2hqhSW/U38h6jD+ZU4RMB3jP9JWwC1qOZgifFPfBnY39b8ulk3Gg=="],
+    "@evantahler/mcpx": ["@evantahler/mcpx@0.21.3", "", { "dependencies": { "@huggingface/transformers": "^4.2.0", "@modelcontextprotocol/sdk": "^1.29.0", "@types/picomatch": "^4.0.3", "ajv": "^8.20.0", "ansis": "^4.2.0", "commander": "^14.0.3", "nanospinner": "^1.2.2", "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c", "picomatch": "^4.0.4" }, "peerDependencies": { "typescript": "^6" }, "bin": { "mcpx": "src/cli.ts" } }, "sha512-CdgCCDeIYurqZD4ojk1VVyO2TAkWhvU0iX/qTTXt+0H/C59wZ0EJUwmDsZ6VwLa8zQZ3Qwxl1eHvsDi+4MMnIA=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {
@@ -28,7 +28,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.92.0",
     "@duckdb/node-api": "^1.5.2-r.1",
-    "@evantahler/mcpx": "0.21.0",
+    "@evantahler/mcpx": "0.21.3",
     "@huggingface/transformers": "^4.2.0",
     "ansis": "^4.2.0",
     "commander": "^14.0.0",

--- a/src/types/file-imports.d.ts
+++ b/src/types/file-imports.d.ts
@@ -1,0 +1,9 @@
+declare module "*.wasm" {
+  const path: string;
+  export default path;
+}
+
+declare module "*.mjs" {
+  const path: string;
+  export default path;
+}


### PR DESCRIPTION
## Summary
- Bumps `@evantahler/mcpx` from `0.21.0` → `0.21.3`. Three patch releases — all internal mcpx fixes (WASM backend adoption, model upgrade to `bge-small-en-v1.5` which we already use, test/build patch automation, and a `cpu` device fallback for npm-installed mcpx).
- Adds `src/types/file-imports.d.ts` (ambient declarations for `*.wasm`/`*.mjs`). mcpx 0.21.1's new `src/search/onnx-wasm-paths.ts` imports asset files via Bun's `with { type: "file" }`, and our `tsc --noEmit` couldn't resolve them — mcpx ships its own `file-imports.d.ts` but it lives under `node_modules` which our tsconfig excludes.
- No transformers patch changes needed: mcpx still depends on `@huggingface/transformers@^4.2.0` (Bun dedupes to one copy) and our existing patch covers `mcp_search` automatically.
- Bumps botholomew `version` to `0.12.4` per the auto-release convention.

## Test plan
- [x] `bun install` resolves cleanly; transformers stays deduped at 4.2.0
- [x] `bun run lint` passes
- [x] `bun test` — all suites pass; `test/context/embedder.test.ts` (the "coexists with DuckDB native module" regression guard) is green
- [ ] CI green
- [ ] Manual: `mcpx search "..."` end-to-end through `mcp_search` tool from a chat session

🤖 Generated with [Claude Code](https://claude.com/claude-code)