### PR TITLE
Match Auto Release test timeout to CI; bump version

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -62,7 +62,7 @@ jobs:
           bun-version: latest
       - run: bun install --frozen-lockfile
       - run: bun run lint
-      - run: bun test
+      - run: bun test --timeout 30000
 
   publish-npm:
     needs: [check-version, ci]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- `auto-release.yml` was running `bun test` with the bare 5s default timeout, while `ci.yml` uses `--timeout 30000`. The `thread list` tests spawn the full CLI (mcpx client + DuckDB + embedder init) and run right at the 5s line. The mcpx 0.21.3 bump (a374fa5) tipped them over, failing the Auto Release run and skipping `publish-npm` for `v0.12.4`.
- Aligns auto-release's test step with CI: `bun test --timeout 30000`.
- Bumps version `0.12.4` → `0.12.5` so the next push triggers a clean release+publish — `v0.12.4`'s GitHub release exists but was never published to npm; the workflow's `should_release` check would otherwise skip.

## Test plan

- [ ] CI green (lint + test + docs-build).
- [ ] On merge, Auto Release succeeds end-to-end and publishes `botholomew@0.12.5` to npm.
- [ ] Optional follow-up: delete the orphan `v0.12.4` GitHub release/tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)