### PR TITLE
Add sleep tool to chat agent with TUI progress bar (#187)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -154,7 +154,10 @@ set — it does **not** execute long-running work itself. Instead, it:
 - looks up files by path (`context_info`, `context_search`) and can
   refresh ingested URLs in place (`context_refresh`),
 - invokes **skills** (`/review`, `/standup`, …) defined in `skills/`,
-- edits `beliefs.md` and `goals.md` via `update_beliefs` / `update_goals`.
+- edits `beliefs.md` and `goals.md` via `update_beliefs` / `update_goals`,
+- can `sleep` for a fixed duration (1 s – 1 h) when it's deliberately
+  waiting on background work — the TUI shows a progress bar and `Esc`
+  cancels the wait.
 
 It uses Anthropic's streaming API so tokens render in the TUI as they
 arrive. Every session is itself a `chat_session` thread written to its

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -220,9 +220,11 @@ If the agent is heading in the wrong direction, press `Esc` while it's
 streaming a response. Whatever has streamed so far is preserved in the
 chat with a `(steered — response interrupted)` marker, and the next
 queued message — or your next typed prompt — becomes a normal
-follow-up turn. Tool calls that are already in flight finish normally
-(no `AbortSignal` is threaded into tools), but no further LLM turn is
-started after the abort.
+follow-up turn. Tool calls that are already in flight finish normally,
+but no further LLM turn is started after the abort. The one exception
+is the `sleep` tool — it polls the steer flag every ~250 ms and returns
+early when you press `Esc`, so the agent yields immediately instead of
+sitting on the timer.
 
 ---
 
@@ -259,6 +261,22 @@ through the large-results cache and shows a stub instead:
 
 The agent sees paged access to the result via dedicated tools; the TUI
 just shows the summary to keep the chat view compact.
+
+### Sleep progress bar
+
+When the agent calls the `sleep` tool — usually after enqueuing tasks
+for workers and before checking results — the tool box renders a
+progress bar that fills from `0` to the requested duration:
+
+```
+  ⟳ sleep ({"seconds":30,"reason":"waiting for worker"})
+    ████████░░░░░░░░░░░░░░░░ 10.2s / 30s
+    waiting for worker
+```
+
+The bar ticks locally in the TUI (the tool itself just `setTimeout`s
+on the agent side) and disappears when the wait elapses or you press
+`Esc` to steer.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/chat/agent.ts
+++ b/src/chat/agent.ts
@@ -62,6 +62,7 @@ const CHAT_TOOL_NAMES = new Set([
   "skill_edit",
   "skill_search",
   "skill_delete",
+  "sleep",
 ]);
 
 export function getChatTools() {
@@ -364,6 +365,7 @@ export async function runChatTurn(input: {
           projectDir,
           config,
           mcpxClient,
+          shouldAbort: session ? () => session.aborted : undefined,
         });
         const durationMs = Date.now() - start;
         const stored = maybeStoreResult(toolUse.name, result.output);
@@ -411,6 +413,7 @@ interface ChatToolCallCtx {
   projectDir: string;
   config: Required<BotholomewConfig>;
   mcpxClient: McpxClient | null;
+  shouldAbort?: () => boolean;
 }
 
 async function executeChatToolCall(
@@ -434,10 +437,20 @@ async function executeChatToolCall(
   }
 
   try {
-    const result = await withDb(baseCtx.dbPath, (conn) => {
-      const ctx: ToolContext = { ...baseCtx, conn };
-      return tool.execute(parsed.data, ctx);
-    });
+    // `sleep` deliberately yields for up to an hour; opening a DuckDB
+    // connection for that whole window would hold the instance-level file
+    // lock and block any worker that also wants the DB. Run it without a
+    // connection — the tool doesn't touch the DB.
+    const runWithoutDb = tool.name === "sleep";
+    const result = runWithoutDb
+      ? await tool.execute(parsed.data, {
+          ...baseCtx,
+          conn: undefined as unknown as ToolContext["conn"],
+        })
+      : await withDb(baseCtx.dbPath, (conn) => {
+          const ctx: ToolContext = { ...baseCtx, conn };
+          return tool.execute(parsed.data, ctx);
+        });
     const isError =
       typeof result === "object" && result !== null && "is_error" in result
         ? (result as { is_error: boolean }).is_error

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -50,6 +50,8 @@ import { listThreadsTool } from "./thread/list.ts";
 import { searchThreadsTool } from "./thread/search.ts";
 import { viewThreadTool } from "./thread/view.ts";
 import { registerTool } from "./tool.ts";
+// Util tools
+import { sleepTool } from "./util/sleep.ts";
 // Worker tools
 import { spawnWorkerTool } from "./worker/spawn.ts";
 
@@ -110,6 +112,9 @@ export function registerAllTools(): void {
   registerTool(mcpSearchTool);
   registerTool(mcpInfoTool);
   registerTool(mcpExecTool);
+
+  // Util
+  registerTool(sleepTool);
 
   // Worker
   registerTool(spawnWorkerTool);

--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -17,6 +17,11 @@ export interface ToolContext {
   projectDir: string;
   config: Required<BotholomewConfig>;
   mcpxClient: McpxClient | null;
+  /**
+   * Chat-mode only. Lets long-running tools (e.g. `sleep`) poll for
+   * Esc-to-abort by reading `session.aborted`. Workers leave this `undefined`.
+   */
+  shouldAbort?: () => boolean;
 }
 
 type ToolOutputBase = { is_error: z.ZodBoolean };

--- a/src/tools/util/sleep.ts
+++ b/src/tools/util/sleep.ts
@@ -1,0 +1,77 @@
+import { z } from "zod";
+import type { ToolDefinition } from "../tool.ts";
+
+const MIN_SECONDS = 1;
+const MAX_SECONDS = 3600;
+const POLL_INTERVAL_MS = 250;
+
+const inputSchema = z.object({
+  seconds: z
+    .number()
+    .int()
+    .min(MIN_SECONDS)
+    .max(MAX_SECONDS)
+    .describe(
+      `How long to sleep, in seconds (${MIN_SECONDS}–${MAX_SECONDS}). For longer pauses, create a schedule instead.`,
+    ),
+  reason: z
+    .string()
+    .min(1)
+    .describe(
+      "Why you're sleeping — shown to the user under the progress bar. Be specific (e.g. 'waiting for worker to finish task abc').",
+    ),
+});
+
+const outputSchema = z.object({
+  message: z.string(),
+  slept_seconds: z.number(),
+  aborted: z.boolean(),
+  is_error: z.boolean(),
+});
+
+export const sleepTool = {
+  name: "sleep",
+  description:
+    "[[ bash equivalent command: sleep ]] Pause the chat agent for a fixed number of seconds. Useful after enqueuing tasks for workers, before checking results. The user sees a progress bar while you wait; pressing Esc cancels the wait. Returns when the time elapses or the user steers.",
+  group: "util",
+  inputSchema,
+  outputSchema,
+  execute: async (input, ctx): Promise<z.infer<typeof outputSchema>> => {
+    const startedAt = Date.now();
+    const totalMs = input.seconds * 1000;
+    const shouldAbort = ctx.shouldAbort;
+
+    let aborted: boolean = false;
+    await new Promise<void>((resolve) => {
+      let timeout: ReturnType<typeof setTimeout> | null = null;
+      let interval: ReturnType<typeof setInterval> | null = null;
+
+      const finish = () => {
+        if (timeout) clearTimeout(timeout);
+        if (interval) clearInterval(interval);
+        resolve();
+      };
+
+      timeout = setTimeout(finish, totalMs);
+
+      if (shouldAbort) {
+        interval = setInterval(() => {
+          if (shouldAbort()) {
+            aborted = true;
+            finish();
+          }
+        }, POLL_INTERVAL_MS);
+      }
+    });
+
+    const sleptSeconds = (Date.now() - startedAt) / 1000;
+    return {
+      message: aborted
+        ? `Sleep interrupted after ${sleptSeconds.toFixed(1)}s of ${input.seconds}s — user steered.`
+        : `Slept ${sleptSeconds.toFixed(1)}s. ${input.reason}`,
+      slept_seconds: sleptSeconds,
+      aborted,
+      is_error: false,
+    };
+  },
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/tui/components/SleepProgress.tsx
+++ b/src/tui/components/SleepProgress.tsx
@@ -1,0 +1,70 @@
+import { Box, Text } from "ink";
+import { useEffect, useState } from "react";
+import { theme } from "../theme.ts";
+
+interface SleepProgressProps {
+  startedAt: Date;
+  totalSeconds: number;
+  reason?: string;
+}
+
+const BAR_WIDTH = 24;
+const TICK_MS = 200;
+
+export function SleepProgress({
+  startedAt,
+  totalSeconds,
+  reason,
+}: SleepProgressProps) {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), TICK_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  const totalMs = totalSeconds * 1000;
+  const elapsedMs = Math.min(totalMs, Math.max(0, now - startedAt.getTime()));
+  const ratio = totalMs > 0 ? elapsedMs / totalMs : 1;
+  const filled = Math.round(ratio * BAR_WIDTH);
+  const bar = "█".repeat(filled) + "░".repeat(BAR_WIDTH - filled);
+  const elapsedSec = (elapsedMs / 1000).toFixed(1);
+
+  return (
+    <Box flexDirection="column">
+      <Box>
+        <Text dimColor>{"    "}</Text>
+        <Text color={theme.accent}>{bar}</Text>
+        <Text dimColor>
+          {" "}
+          {elapsedSec}s / {totalSeconds}s
+        </Text>
+      </Box>
+      {reason && (
+        <Text dimColor wrap="truncate-end">
+          {"    "}
+          {reason}
+        </Text>
+      )}
+    </Box>
+  );
+}
+
+/**
+ * Pull `seconds` and `reason` out of a sleep tool's stringified JSON input.
+ * Returns `null` if the input can't be parsed or doesn't have a numeric duration.
+ */
+export function parseSleepInput(
+  raw: string,
+): { seconds: number; reason?: string } | null {
+  try {
+    const parsed = JSON.parse(raw);
+    if (typeof parsed?.seconds !== "number") return null;
+    return {
+      seconds: parsed.seconds,
+      reason: typeof parsed.reason === "string" ? parsed.reason : undefined,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/tui/components/ToolCall.tsx
+++ b/src/tui/components/ToolCall.tsx
@@ -1,5 +1,6 @@
 import { Box, Text } from "ink";
 import { theme } from "../theme.ts";
+import { parseSleepInput, SleepProgress } from "./SleepProgress.tsx";
 
 /**
  * For mcp_exec calls, extract server/tool into a top-level display name
@@ -53,6 +54,8 @@ export function ToolCall({ tool }: ToolCallProps) {
   const truncatedInput =
     displayInput.length > 60 ? `${displayInput.slice(0, 60)}…` : displayInput;
   const truncatedOutput = tool.output ? tool.output.slice(0, 120) : "";
+  const sleepArgs =
+    tool.name === "sleep" && tool.running ? parseSleepInput(tool.input) : null;
 
   return (
     <Box flexDirection="column">
@@ -83,6 +86,13 @@ export function ToolCall({ tool }: ToolCallProps) {
         {tool.name === "mcp_exec" && <Text dimColor> (exec)</Text>}
         <Text dimColor> ({truncatedInput})</Text>
       </Box>
+      {sleepArgs && (
+        <SleepProgress
+          startedAt={tool.timestamp}
+          totalSeconds={sleepArgs.seconds}
+          reason={sleepArgs.reason}
+        />
+      )}
       {truncatedOutput && !tool.running && (
         <Text dimColor wrap="truncate-end">
           {"    → "}

--- a/test/tools/util/sleep.test.ts
+++ b/test/tools/util/sleep.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import type { ToolContext } from "../../../src/tools/tool.ts";
+import { sleepTool } from "../../../src/tools/util/sleep.ts";
+
+function makeCtx(shouldAbort?: () => boolean): ToolContext {
+  return {
+    conn: undefined as unknown as ToolContext["conn"],
+    dbPath: ":memory:",
+    projectDir: "/tmp/sleep-test",
+    // biome-ignore lint/suspicious/noExplicitAny: tests don't exercise config
+    config: {} as any,
+    mcpxClient: null,
+    shouldAbort,
+  };
+}
+
+describe("sleepTool", () => {
+  test("sleeps for the requested duration and returns aborted=false", async () => {
+    const start = Date.now();
+    const result = await sleepTool.execute(
+      { seconds: 1, reason: "smoke test" },
+      makeCtx(),
+    );
+    const elapsed = Date.now() - start;
+    expect(result.aborted).toBe(false);
+    expect(result.is_error).toBe(false);
+    expect(elapsed).toBeGreaterThanOrEqual(900);
+    expect(elapsed).toBeLessThan(1500);
+    expect(result.slept_seconds).toBeGreaterThanOrEqual(0.9);
+    expect(result.message).toContain("smoke test");
+  });
+
+  test("returns early when shouldAbort flips to true", async () => {
+    let aborted = false;
+    const start = Date.now();
+    const promise = sleepTool.execute(
+      { seconds: 60, reason: "long sleep" },
+      makeCtx(() => aborted),
+    );
+    setTimeout(() => {
+      aborted = true;
+    }, 300);
+    const result = await promise;
+    const elapsed = Date.now() - start;
+    expect(result.aborted).toBe(true);
+    expect(result.is_error).toBe(false);
+    expect(elapsed).toBeLessThan(1500);
+    expect(result.slept_seconds).toBeLessThan(1.5);
+    expect(result.message).toContain("interrupted");
+  });
+
+  test("rejects out-of-range durations", () => {
+    expect(
+      sleepTool.inputSchema.safeParse({ seconds: 0, reason: "x" }).success,
+    ).toBe(false);
+    expect(
+      sleepTool.inputSchema.safeParse({ seconds: 4000, reason: "x" }).success,
+    ).toBe(false);
+    expect(
+      sleepTool.inputSchema.safeParse({ seconds: 1.5, reason: "x" }).success,
+    ).toBe(false);
+    expect(
+      sleepTool.inputSchema.safeParse({ seconds: 5, reason: "" }).success,
+    ).toBe(false);
+    expect(
+      sleepTool.inputSchema.safeParse({ seconds: 5, reason: "ok" }).success,
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #187. Adds a `sleep(seconds, reason)` tool to the chat agent (1–3600s) so it can deliberately pause after enqueuing tasks for workers and before checking results.
- The TUI renders a live progress bar under the tool call that fills as the wait elapses; pressing `Esc` cancels via a new optional `shouldAbort` on `ToolContext` that the tool polls every 250 ms.
- Sleep deliberately bypasses `withDb` — opening a DuckDB connection for a 1-hour pause would pin the instance-level file lock and block any worker that wants the DB.

## Test plan

- [x] `bun run lint` clean
- [x] `bun test` — 797 pass / 0 fail (3 new sleep tests covering happy path, abort, input validation)
- [ ] Manual: `bun run dev chat`, ask the agent to sleep ~10s, watch the bar fill and confirm `Esc` cancels mid-wait

🤖 Generated with [Claude Code](https://claude.com/claude-code)