### PR TITLE
Refresh docs after disk-first architecture migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,14 @@ An AI agent for knowledge work. See `docs/plans/README.md` for the milestone roa
   - `workers/` — Pidfile + heartbeat store under `workers/<id>.json`
   - `worker/` — Worker tick loop, LLM integration, prompt building, heartbeat
   - `db/` — DuckDB connection for the search-index sidecar (`@duckdb/node-api`), schema migrations
+  - `chat/` — Interactive chat session + agent loop powering `botholomew chat`
+  - `tools/` — Tool registry and `ToolDefinition`s (context_*, file/dir, schedule, search, mcp, capabilities)
+  - `mcpx/` — MCPX client for invoking external MCP servers
+  - `skills/` — Slash-command skill loader, parser, and writer
   - `init/` — Project initialization
   - `tui/` — Ink (React) TUI components
+  - `update/` — Self-update checker and background cache
+  - `types/` — Shared TypeScript ambient declarations
   - `utils/` — Logger, frontmatter, v7-date helpers
 - `test/` — Tests (mirrors src/ structure)
 - `docs/` — User-facing markdown docs (also published at [www.botholomew.com](https://www.botholomew.com))
@@ -76,7 +82,7 @@ An AI agent for knowledge work. See `docs/plans/README.md` for the milestone roa
 - **Migrations**: always call `migrate(conn)` after opening — it's idempotent. The migration set now drops the retired tables (tasks/schedules/threads/interactions/workers/context_items) so an old `index.duckdb` upgrades cleanly to the slim schema (`_migrations` + `context_index`).
 - **Queries**: parameterized (`?1, ?2, ...`) — never string interpolation.
 - **Vectors**: `FLOAT[384]` with `array_cosine_distance()`; no HNSW.
-- **Full-text search**: BM25 over `context_index.chunk_content + title` via the `fts` extension. The FTS index is a snapshot — any writer must call `rebuildSearchIndex(conn)` after committing. The reindex pipeline (`src/context/reindex.ts`) is the only writer.
+- **Full-text search**: BM25 over `context_index.chunk_content + path` via the `fts` extension. The FTS index is a snapshot — any writer must call `rebuildSearchIndex(conn)` after committing. The reindex pipeline (`src/context/reindex.ts`) is the only writer.
 
 ## Embeddings
 
@@ -113,7 +119,7 @@ An AI agent for knowledge work. See `docs/plans/README.md` for the milestone roa
   - Adding a CLI subcommand in `src/commands/` → update the CLI table in `README.md` and the doc for that area.
   - Changing config defaults in `src/config/schemas.ts` → update `docs/configuration.md`.
   - Changing the tick loop, schedule evaluation, or agent loop (`src/worker/*`) → update `docs/architecture.md` and/or `docs/tasks-and-schedules.md`.
-  - Changing worker registration, heartbeat, or reaping (`src/worker/heartbeat.ts`, `src/workers/store.ts`, `src/tasks/claim.ts`, `src/schedules/claim.ts`) → update `docs/architecture.md`.
+  - Changing worker registration, heartbeat, or reaping (`src/worker/heartbeat.ts`, `src/workers/store.ts`) or task/schedule claim logic (`src/tasks/store.ts`, `src/schedules/store.ts`) → update `docs/architecture.md`.
   - Adding or renaming a skill template in `src/init/templates.ts` → update `docs/skills.md` and `src/init/index.ts`.
   - Changing prompts loading (`src/worker/prompt.ts`) → update `docs/prompts.md`.
   - Changing anything in `src/tui/` (new tab, new shortcut, input behavior) → update `docs/tui.md`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,8 +39,12 @@ Concurrency is filesystem-level, not DB-level:
 **Safety note.** Workers are the only things executing LLM tool calls,
 and every path-taking tool routes through a single sandbox helper
 (`src/fs/sandbox.ts::resolveInRoot`) that NFC-normalizes the input,
-rejects `..`/absolute/NUL paths, and `lstat`-walks each component to
-refuse symlinks at any level. Tools are pinned to `context/`;
+rejects `..`/absolute/NUL paths, and `lstat`-walks each component.
+Read-side `context_*` ops (read, list, tree, info, search, reindex,
+delete) opt in to symlinks via `allowSymlinks: true` so users can drop
+symlinks into the agent's tree, but mutating ops (write, edit, move,
+copy, mkdir) never set the flag and reject any symlink component. Tools
+are pinned to `context/`;
 `models/`, `logs/`, `tasks/.locks/`, and `schedules/.locks/` are
 explicitly off-limits. There is no "just read the file system" escape
 hatch. See [the files doc](files.md) for the full argument.
@@ -60,15 +64,16 @@ worker loops over ticks until it receives SIGTERM/SIGINT.
          │                                 schedule, ask the LLM which are
          │                                 "due", enqueue their tasks
          ├─► claimNextTask(workerId)   — highest-priority unblocked pending
-         │                                 task; worker id is stamped on the
-         │                                 `claimed_by` column
+         │                                 task; worker id is written into
+         │                                 the `tasks/.locks/<id>.lock` body
          ├─► createThread("worker_tick") — one thread per tick for logging
          ├─► buildSystemPrompt()       — always-context + task-relevant
          │                                 context
          ├─► runAgentLoop()            — multi-turn Anthropic tool-use loop
          │                                 every message, thinking block, tool
          │                                 call, and tool result is logged as
-         │                                 an `interaction` row
+         │                                 an interaction row in the thread CSV
+         │                                 at `threads/<YYYY-MM-DD>/<id>.csv`
          ├─► updateTaskStatus()        — complete / failed / waiting
          └─► endThread()
 ```

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -14,7 +14,7 @@ you copy the recipe that matches your needs.
 
 `botholomew worker run` (one-shot, default mode) does one thing and exits:
 
-1. Register a worker row in the DB.
+1. Write a worker pidfile to `workers/<id>.json` with PID and heartbeat metadata.
 2. Start a heartbeat `setInterval` so other workers know it's alive.
 3. Evaluate any due schedules and enqueue their tasks.
 4. Claim the next eligible pending task.
@@ -26,9 +26,11 @@ a tight cron without overlapping concerns.
 
 Two things make this safe to run concurrently with other workers:
 
-- Task claims are atomic (`UPDATE ... WHERE status='pending' RETURNING *`).
-- Schedule evaluation is gated by an atomic claim + a minimum-interval window,
-  so two workers can't enqueue duplicate task batches from the same schedule.
+- Task claims are atomic — the worker `open()`s an `O_EXCL` lockfile under
+  `tasks/.locks/<id>.lock`; only one worker wins.
+- Schedule evaluation is gated by an `O_EXCL` lockfile claim under
+  `schedules/.locks/<id>.lock` plus a minimum-interval window, so two workers
+  can't enqueue duplicate task batches from the same schedule.
 
 See [architecture.md](architecture.md#multi-worker-safety).
 
@@ -176,20 +178,23 @@ Same concurrency story as cron: each fire is one task at most.
 ## Troubleshooting
 
 - **"Nothing's happening."** `botholomew worker list` shows every worker
-  the DB has ever seen. Filter with `--status running` to see who's alive
-  right now. If you see zero running and a non-empty queue, spawn one:
-  `botholomew worker start --persist`.
-- **"I see dead workers piling up."** Reaped crashes stay in the table as
-  forensic evidence; only clean exits (`status='stopped'`) get auto-pruned
-  (after `worker_stopped_retention_seconds`, default 1 hour). If dead rows
-  are bothering you, `DELETE FROM workers WHERE status='dead'` clears them
-  safely. `botholomew worker list --status dead` shows the list first.
+  pidfile under `workers/`. Filter with `--status running` to see who's
+  alive right now. If you see zero running and a non-empty queue, spawn
+  one: `botholomew worker start --persist`.
+- **"I see dead workers piling up."** Reaped crashes keep their pidfiles
+  on disk as forensic evidence; only clean exits (`status='stopped'`) get
+  auto-pruned by the reaper after `worker_stopped_retention_seconds`
+  (default 1 hour). If dead pidfiles are bothering you, run
+  `botholomew worker reap` — it walks `workers/` and unlinks both stale
+  dead workers and stopped pidfiles past the retention window. You can
+  also `rm workers/<id>.json` directly. `botholomew worker list --status
+  dead` shows the list first.
 - **"Cron runs aren't firing."** Check `grep CRON /var/log/syslog`
   (Linux) or `log show --predicate 'process == "cron"'` (macOS). Common
   causes: minimal `PATH`, or a relative path to `botholomew`.
 - **"Two workers keep claiming the same task."** They don't — by design.
-  The `claimed_by` column is stamped by the atomic UPDATE, so only one
-  wins. If you're seeing duplicate **output**, it's because the task was
+  The lockfile body holds the worker id and `claimed_at` timestamp, so
+  only one worker wins the `O_EXCL` open. If you're seeing duplicate **output**, it's because the task was
   re-run after its worker was reaped — check `worker list --status dead`.
 - **"The log is getting huge."** Rotate it yourself (logrotate, newsyslog).
   Botholomew used to do this inside the old watchdog; it no longer does.

--- a/docs/captures.md
+++ b/docs/captures.md
@@ -150,7 +150,7 @@ because VHS can't keystroke its way through the tab bar:
 
 - **`BOTHOLOMEW_CAPTURE_TAB_CYCLE=<dwell-ms>`** (default `2500`) — when set,
   `src/tui/App.tsx` schedules timers that walk `activeTab` through
-  2 → 3 → 4 → 5 → 6 → 7 → 1 with the given dwell between tabs. The hook is a
+  2 → 3 → 4 → 5 → 6 → 7 → 8 → 1 with the given dwell between tabs. The hook is a
   no-op unless the env var is defined, so it doesn't affect normal use.
   `docs/tapes/full-tour.tape` enables this via its fixture's `env` block.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -103,7 +103,7 @@ botholomew chat
 ```
 
 The chat command opens an [Ink/React TUI](./tui.md) with eight tabs —
-chat, tasks, workers, context, schedules, threads, history, and logs —
+Chat, Tools, Context, Tasks, Threads, Schedules, Workers, and Help —
 plus slash-command autocomplete, a message queue, tool-call
 visualization, and a live workers panel.
 
@@ -111,7 +111,8 @@ visualization, and a live workers panel.
 
 - [The CLI reference](https://github.com/evantahler/botholomew#the-cli)
   on GitHub
-- [Architecture](./architecture.md) — workers, chat, shared DB
+- [Architecture](./architecture.md) — workers, chat, shared project
+  directory on disk, search-index sidecar
 - [Tasks & schedules](./tasks-and-schedules.md) — the claim loop and
   recurring schedules
 - [Context & hybrid search](./context-and-search.md) — ingest files,

--- a/docs/mcpx.md
+++ b/docs/mcpx.md
@@ -144,9 +144,10 @@ See `src/tools/mcp/*.ts`.
 
 Every MCP call is logged to the current thread as a `tool_use` /
 `tool_result` interaction pair — identical to how built-in tools are
-logged. Duration and token counts are captured. Query the `interactions`
-table (or run `botholomew thread view`) to see exactly what the agent
-sent and got back.
+logged. Duration and token counts are captured. Run `botholomew thread
+view <id>` to see the per-call CSV row in
+`threads/<YYYY-MM-DD>/<id>.csv` with exactly what the agent sent and
+got back.
 
 ---
 


### PR DESCRIPTION
## Summary

- Drop stale DuckDB-centric language from `docs/automation.md`, `docs/architecture.md`, `docs/getting-started.md`, and `docs/mcpx.md` — task/schedule claims are `O_EXCL` lockfiles, workers are JSON pidfiles under `workers/`, and interactions live in thread CSVs at `threads/<YYYY-MM-DD>/<id>.csv`, not retired DB tables.
- Fix the TUI tab list in `docs/getting-started.md` (Chat, Tools, Context, Tasks, Threads, Schedules, Workers, Help) and the capture tab-cycle in `docs/captures.md` (was missing tab 8).
- Update `CLAUDE.md`: add the previously-undocumented `src/` subdirs (`chat`, `tools`, `mcpx`, `skills`, `update`, `types`), correct the FTS index columns (`chunk_content + path`, not `+ title`), and replace references to the non-existent `src/tasks/claim.ts` / `src/schedules/claim.ts` with the real claim sites in their store modules.

## Test plan

- [x] `bun run lint` (tsc + biome)
- [x] `bun run docs:build` (VitePress build, no broken links on changed pages)
- [ ] Spot-check the rendered pages on the deployed site after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)