### PR TITLE
Share local time and timezone in agent meta header

### DIFF
--- a/src/worker/prompt.ts
+++ b/src/worker/prompt.ts
@@ -76,8 +76,17 @@ export async function loadPersistentContext(
  * Build common meta header (version, time, OS, user).
  */
 export function buildMetaHeader(projectDir: string): string {
+  const now = new Date();
+  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const localTime = now.toLocaleString("en-US", {
+    timeZone: timezone,
+    dateStyle: "full",
+    timeStyle: "long",
+  });
   return `# Botholomew v${pkg.version}
-Current time: ${new Date().toISOString()}
+Current time (UTC): ${now.toISOString()}
+Current time (local): ${localTime}
+Timezone: ${timezone}
 Project directory: ${projectDir}
 OS: ${process.platform} ${process.arch}
 User: ${process.env.USER || process.env.USERNAME || "unknown"}

--- a/test/worker/prompt.test.ts
+++ b/test/worker/prompt.test.ts
@@ -122,6 +122,16 @@ describe("buildSystemPrompt", () => {
     expect(prompt).toContain(projectDir);
   });
 
+  test("includes UTC time, local time, and IANA timezone in the meta header", async () => {
+    const prompt = await buildSystemPrompt(projectDir);
+    expect(prompt).toMatch(
+      /Current time \(UTC\): \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+    );
+    expect(prompt).toContain("Current time (local):");
+    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    expect(prompt).toContain(`Timezone: ${timezone}`);
+  });
+
   test("includes the Instructions section and the Style block", async () => {
     const prompt = await buildSystemPrompt(projectDir);
     expect(prompt).toContain("## Instructions");


### PR DESCRIPTION
## Summary
- Expand `buildMetaHeader()` in `src/worker/prompt.ts` so the system prompt seen by both the worker and chat agents now includes UTC time, host-local time (full date + long time), and the IANA timezone — instead of UTC only.
- Lets agents reason correctly about "today/tonight", scheduling, and time-of-day phrasing in the user's actual timezone.

## Test plan
- [x] `bun test test/worker/prompt.test.ts` — added assertion covering UTC, local time, and `Timezone: <IANA>` lines.
- [x] `bun run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)