### PR TITLE
TUI navigation refresh + /clear fix (#190)

### DIFF
--- a/docs/tui.md
+++ b/docs/tui.md
@@ -70,9 +70,11 @@ spinner is shown so the UI doesn't appear frozen.
 ### 2. Tools
 
 Every tool call the agent has made in the current session, in order.
-`↑`/`↓` selects a row; the detail pane shows the full input JSON and
-the full (untruncated) output. `Shift+↑`/`↓` or `j`/`k` scroll the
-detail pane.
+List/detail panels share a focus model: the **list** is focused by
+default — `↑`/`↓` move the selection. Press `→` to enter the detail
+pane; `↑`/`↓` then scroll the detail one line at a time. `←` returns
+focus to the list. `PgUp`/`PgDn` page-scroll the detail; `g`/`G` jump
+to top/bottom.
 
 Tool calls from **MCP** (`mcp_exec`) are displayed as
 `<server> / <tool>` — e.g. `Linear / CreateIssue` — with the `server`
@@ -90,8 +92,9 @@ see [files.md](files.md) and
 [context-and-search.md](context-and-search.md).
 
 - `↑`/`↓` navigate.
-- `Enter` expands a directory or previews a file.
-- `Backspace` goes up one directory.
+- `→` drills into a directory or previews a file.
+- `←` goes up one directory level (or closes a preview).
+- `↑`/`↓` scroll an open file preview; `←` or `Esc` close it.
 - `/` opens a hybrid (keyword + vector) search across `context/`.
 - `d` deletes the selected file.
 
@@ -132,13 +135,14 @@ shows status, short id, mode, and heartbeat age. The detail pane has
 full id, pid, hostname, started time, heartbeat time, stopped time (if
 any), pinned task id (if any), and the per-worker log path.
 
-Press `l` to swap the detail pane into a **log view** that tails the
+Press `l` to swap the right pane into a **log view** that tails the
 selected worker's log file (`logs/<YYYY-MM-DD>/<id>.log`). The log
-auto-refreshes every ~1.5 s and follows the bottom by default — scroll
-up with `Shift+↑`, `k`, or `K` to pause following; `G` (or scrolling
-back to the bottom) resumes it. Press `l` again to return to the
-detail view. Foreground workers (`worker run`) have no log file, so
-the log view shows an empty-state message instead.
+auto-refreshes every ~1.5 s and follows the bottom by default. Press
+`→` to focus the right pane, then `↑` (or `PgUp`) to pause following;
+`G` or scrolling back to the bottom resumes it. `←` returns focus to
+the worker list. Press `l` again to swap the right pane back to detail
+view. Foreground workers (`worker run`) have no log file, so the log
+view shows an empty-state message instead.
 
 The panel polls the DB every ~3s. Workers heartbeat every
 `worker_heartbeat_interval_seconds` (default 15s); ones older than
@@ -268,8 +272,14 @@ just shows the summary to keep the chat view compact.
 
 | Key | Action |
 |---|---|
-| `Tab` | Cycle to the next tab |
-| `1`–`8` | Jump to tab N (not on Chat — the Chat input consumes digits) |
+| `Ctrl+a` | Chat |
+| `Ctrl+o` | Tools |
+| `Ctrl+n` | Context |
+| `Ctrl+t` | Tasks |
+| `Ctrl+r` | Threads |
+| `Ctrl+s` | Schedules |
+| `Ctrl+w` | Workers |
+| `Ctrl+h` | Help |
 | `Esc` | Return to Chat from any other tab |
 | `Ctrl+C` | Exit the TUI |
 
@@ -288,38 +298,35 @@ just shows the summary to keep the chat view compact.
 | `Ctrl+E` | Edit queued message |
 | `Ctrl+X` | Delete queued message |
 
-### List panels (Tools / Tasks / Threads / Schedules)
+### List panels (Tools / Tasks / Threads / Schedules / Workers)
+
+These panels share a list/detail focus model. The list is focused by
+default; `→` enters the detail pane, `←` returns to the list. `↑`/`↓`
+move the selection (list focus) or scroll the detail (detail focus).
 
 | Key | Action |
 |---|---|
-| `↑` / `↓` | Move selection |
-| `Shift+↑` / `Shift+↓` | Scroll detail pane |
-| `j` / `k` | Scroll detail pane (alternate) |
+| `↑` / `↓` | Move selection (list) · scroll detail (detail) |
+| `→` | Enter the detail pane |
+| `←` | Return to the list |
+| `PgUp` / `PgDn` | Page-scroll detail |
+| `g` / `G` | Jump to top / bottom of detail |
 | `f` | Cycle filter (status, type, enabled — per panel) |
 | `p` | Cycle priority filter (Tasks only) |
 | `r` | Refresh from DB |
 | `d` | Delete with confirmation (Threads, Schedules, Context) |
 | `e` | Toggle enable/disable (Schedules only) |
-
-### Workers tab
-
-| Key | Action |
-|---|---|
-| `↑` / `↓` | Select worker |
-| `f` | Cycle status filter (all → running → stopped → dead) |
-| `l` | Toggle between detail and log-tail view |
-| `Shift+↑` / `Shift+↓` | Scroll log up/down (log view) |
-| `j` / `k` | Scroll log down/up by one line (log view) |
-| `J` / `K` | Page scroll the log (log view) |
-| `g` / `G` | Jump to top / bottom of log (log view, `G` resumes follow) |
+| `s` or `/` | Search (Threads only) |
+| `w` | Toggle follow-mode (Threads only) |
+| `l` | Toggle detail / log view (Workers only) |
 
 ### Context tab
 
 | Key | Action |
 |---|---|
-| `↑` / `↓` | Navigate |
-| `Enter` | Expand directory / preview file |
-| `Backspace` | Go up one directory |
+| `↑` / `↓` | Navigate / scroll preview |
+| `→` | Drill into folder · open file preview |
+| `←` | Go up one directory · close preview |
 | `/` | Search |
 | `d` | Delete selected item |
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/chat/session.ts
+++ b/src/chat/session.ts
@@ -180,6 +180,10 @@ export async function endChatSession(session: ChatSession): Promise<void> {
 export async function clearChatSession(
   session: ChatSession,
 ): Promise<{ previousThreadId: string; newThreadId: string }> {
+  // Abort any in-flight stream up front so its callbacks don't continue to
+  // fire into the new thread (caused #190 — old messages reappearing on the
+  // next user submission).
+  abortActiveStream(session);
   const previousThreadId = session.threadId;
   await endThread(session.projectDir, previousThreadId);
   const newThreadId = await createThread(

--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -5,13 +5,21 @@ export function registerChatCommand(program: Command) {
     .command("chat")
     .description(
       "Open the interactive chat TUI\n\n" +
-        "  Keyboard shortcuts:\n" +
+        "  Tab navigation (Ctrl+<letter> from any tab):\n" +
+        "    Ctrl+a  Chat        Ctrl+t  Tasks       Ctrl+w  Workers\n" +
+        "    Ctrl+o  Tools       Ctrl+r  Threads     ?       Help (non-chat)\n" +
+        "    Ctrl+n  Context     Ctrl+s  Schedules   Esc     Return to Chat\n\n" +
+        "  Chat input:\n" +
         "    Enter          Send message\n" +
-        "    ⌥+Enter        Insert newline (multiline input)\n" +
-        "    ↑/↓            Browse input history\n\n" +
-        "  Commands:\n" +
-        "    /help           Show keyboard shortcuts\n" +
-        "    /tools          Open tool call inspector\n" +
+        "    ⌥+Enter        Insert newline\n" +
+        "    ↑/↓            Browse input history\n" +
+        "    Esc            Steer / abort an in-flight turn\n" +
+        "    Ctrl+J/K       Navigate queued messages\n" +
+        "    Ctrl+E/X       Edit / remove the selected queued message\n\n" +
+        "  Slash commands:\n" +
+        "    /help           Show chat-command reference (Help tab has the full keymap)\n" +
+        "    /skills         List available skills\n" +
+        "    /clear          End current thread and start a new one\n" +
         "    /exit           End the chat session",
     )
     .option("--thread-id <id>", "Resume an existing chat thread")

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -47,6 +47,21 @@ function msgId(): string {
   return `msg-${++nextMsgId}`;
 }
 
+// Tab routing: Ctrl+<letter> jumps to a tab. Chosen for memorability — first
+// available letter that doesn't collide with other Ctrl bindings (Ctrl+C exit,
+// Ctrl+J/K/X/E queue ops on Chat). Help is bound to `?` instead of Ctrl+H
+// because most terminals send Ctrl+H as ASCII 0x08 (backspace), which Ink
+// reports as `key.backspace=true`, not `input='h'`.
+const TAB_BY_CTRL_KEY: Record<string, TabId> = {
+  a: 1, // ch[a]t
+  o: 2, // t[o]ols
+  n: 3, // co[n]text
+  t: 4, // [t]asks
+  r: 5, // th[r]eads
+  s: 6, // [s]chedules
+  w: 7, // [w]orkers
+};
+
 function detectToolError(output: string | undefined): boolean {
   if (!output) return false;
   try {
@@ -187,7 +202,7 @@ export function App({
             id: msgId(),
             role: "system" as const,
             content:
-              "Press Tab to switch between panels. Type /help for commands.",
+              "Switch panels with Ctrl+<letter> (^a chat · ^o tools · ^n context · ^t tasks · ^r threads · ^s schedules · ^w workers) — `?` for help. Type /help for commands.",
             timestamp: new Date(),
           },
         ]);
@@ -259,17 +274,30 @@ export function App({
         return;
       }
 
-      // Tab key cycles tabs — but on the Chat tab, let InputBar consume it
-      // whenever the slash autocomplete popup would be open.
-      if (key.tab && !key.shift) {
-        if (activeTabRef.current === 1) {
-          const popupOpen = getSlashMatches(
-            inputValueRef.current,
-            slashCommandsRef.current,
-          );
-          if (popupOpen) return;
+      // Ctrl+<letter> jumps directly to a tab from any tab. On Chat, only
+      // suppress these if the slash-autocomplete popup needs the keystroke
+      // (Ctrl combos don't drive the popup, but keep the guard symmetric
+      // with the previous Tab-cycle behavior).
+      if (key.ctrl) {
+        const tabForKey = TAB_BY_CTRL_KEY[input];
+        if (tabForKey !== undefined) {
+          if (activeTabRef.current === 1) {
+            const popupOpen = getSlashMatches(
+              inputValueRef.current,
+              slashCommandsRef.current,
+            );
+            if (popupOpen) return;
+          }
+          setActiveTab(tabForKey);
+          return;
         }
-        setActiveTab((t) => ((t % 8) + 1) as TabId);
+      }
+
+      // `?` jumps to the Help tab from any non-chat tab (on Chat, `?` is
+      // a regular character). Acts as the Help shortcut since Ctrl+H is
+      // unusable — most terminals send it as backspace.
+      if (input === "?" && activeTabRef.current !== 1) {
+        setActiveTab(8);
         return;
       }
 
@@ -316,12 +344,6 @@ export function App({
       }
 
       if (tab !== 1) {
-        // Number keys jump to tab on non-chat tabs
-        const num = Number.parseInt(input, 10);
-        if (num >= 1 && num <= 8) {
-          setActiveTab(num as TabId);
-          return;
-        }
         // Escape returns to chat
         if (key.escape) {
           setActiveTab(1);
@@ -512,81 +534,30 @@ export function App({
 
       if (trimmed === "/help") {
         const skills = sessionRef.current.skills;
-        const skillLines: string[] = [];
+        const lines: string[] = [
+          "For the full keyboard reference, switch to the Help tab (`?` from any non-chat tab) — this message lists chat commands only.",
+          "",
+          "Slash commands:",
+          "  /help           Show this message",
+          "  /skills         List available skills",
+          "  /clear          End current thread and start a new one",
+          "  /exit           End the chat session",
+        ];
         if (skills.size > 0) {
-          skillLines.push("", "Skills:");
+          lines.push("", "Skills:");
           for (const [skillName, skill] of skills) {
-            skillLines.push(
+            lines.push(
               `  /${skillName.padEnd(14)} ${skill.description || "(no description)"}`,
             );
           }
         } else {
-          skillLines.push("", "Skills:", "  (none — add .md files to skills/)");
+          lines.push("", "Skills:", "  (none — add .md files to skills/)");
         }
 
         const helpMsg: ChatMessage = {
           id: msgId(),
           role: "system",
-          content: [
-            "Navigation:",
-            "  Tab            Cycle between panels",
-            "  1-7            Jump to panel (when not in Chat)",
-            "  Escape         Return to Chat",
-            "",
-            "Chat (Tab 1):",
-            "  Enter          Send message",
-            "  ⌥+Enter        Insert newline",
-            "  ↑/↓            Browse input history",
-            "  /              Open slash-command autocomplete",
-            "  Enter          Run highlighted command / insert if it takes args (popup open)",
-            "  Tab            Insert highlighted command without submitting (popup open)",
-            "  ↑/↓            Move highlight (popup open)",
-            "  Esc            Close popup",
-            "",
-            "Tools (Tab 2):",
-            "  ↑/↓            Select tool call",
-            "  Shift+↑/↓      Scroll detail pane",
-            "  j/k            Scroll detail pane",
-            "",
-            "Context (Tab 3):",
-            "  ↑/↓            Navigate items",
-            "  Enter          Expand directory / preview file",
-            "  Backspace      Go up one directory",
-            "  /              Search context",
-            "  d              Delete selected item",
-            "",
-            "Tasks (Tab 4):",
-            "  ↑/↓            Navigate task list",
-            "  Shift+↑/↓      Scroll detail pane",
-            "  j/k            Scroll detail pane",
-            "  f              Cycle status filter",
-            "  p              Cycle priority filter",
-            "  r              Refresh tasks",
-            "",
-            "Threads (Tab 5):",
-            "  ↑/↓            Navigate thread list",
-            "  Shift+↑/↓      Scroll detail pane",
-            "  j/k            Scroll detail pane",
-            "  f              Cycle type filter",
-            "  d              Delete thread (with confirmation)",
-            "  r              Refresh threads",
-            "",
-            "Schedules (Tab 6):",
-            "  ↑/↓            Navigate schedule list",
-            "  Shift+↑/↓      Scroll detail pane",
-            "  j/k            Scroll detail pane",
-            "  f              Cycle enabled/disabled filter",
-            "  e              Toggle enable/disable",
-            "  d              Delete schedule (with confirmation)",
-            "  r              Refresh schedules",
-            "",
-            "Commands:",
-            "  /help           Show this help",
-            "  /skills         List available skills",
-            "  /clear          End current thread and start a new one",
-            "  /exit           End the chat session",
-            ...skillLines,
-          ].join("\n"),
+          content: lines.join("\n"),
           timestamp: new Date(),
         };
         setMessages((prev) => [...prev, helpMsg]);
@@ -622,8 +593,23 @@ export function App({
             // Drain any queued messages so they don't leak into the new thread.
             queueRef.current.length = 0;
             syncQueue();
-            clearChatSession(session)
-              .then(({ previousThreadId, newThreadId }) => {
+            // Abort any in-flight stream synchronously so its callbacks stop
+            // firing before we reset UI state. clearChatSession also calls
+            // this, but doing it here lets us start the wait-for-quiesce
+            // poll below immediately rather than waiting on the
+            // createThread/endThread round trip first.
+            abortActiveStream(session);
+            void (async () => {
+              // Wait for any in-flight processQueue iteration to finish so
+              // its trailing `finalizeSegment` can't race our state reset
+              // and re-add the previous thread's assistant message after
+              // the UI has been cleared. (Issue #190.)
+              while (processingRef.current) {
+                await new Promise((r) => setTimeout(r, 10));
+              }
+              try {
+                const { previousThreadId, newThreadId } =
+                  await clearChatSession(session);
                 // Ink's <Static> writes messages to terminal scrollback and
                 // can't un-write them, so setMessages alone leaves the old
                 // lines visible. Clear the terminal (including scrollback)
@@ -639,8 +625,10 @@ export function App({
                 ]);
                 setMessagesEpoch((n) => n + 1);
                 setChatTitle(undefined);
-              })
-              .catch((err) => {
+                setStreamingText("");
+                setActiveToolCalls([]);
+                setPreparingTool(null);
+              } catch (err) {
                 setMessages((prev) => [
                   ...prev,
                   {
@@ -650,7 +638,8 @@ export function App({
                     timestamp: new Date(),
                   },
                 ]);
-              });
+              }
+            })();
           },
         });
         if (handled) return;

--- a/src/tui/components/ContextPanel.tsx
+++ b/src/tui/components/ContextPanel.tsx
@@ -1,18 +1,33 @@
 import { Box, Text, useInput, useStdout } from "ink";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
+import { getDbPath } from "../../constants.ts";
 import {
   type ContextEntry,
   listContextDir,
   readContextFile,
 } from "../../context/store.ts";
+import { withDb } from "../../db/connection.ts";
+import {
+  getIndexedPath,
+  type IndexedPathSummary,
+} from "../../db/embeddings.ts";
+import {
+  detailPaneBorderProps,
+  type FocusState,
+  handleListDetailKey,
+} from "../listDetailKeys.ts";
 import { isMarkdownPath, renderMarkdown } from "../markdown.ts";
+import { theme } from "../theme.ts";
+import { useLatestRef } from "../useLatestRef.ts";
+import { Scrollbar } from "./Scrollbar.tsx";
 
 interface ContextPanelProps {
   projectDir: string;
   isActive: boolean;
 }
 
-const CHROME_LINES = 8;
+const SIDEBAR_WIDTH = 32;
+const PAGE_SCROLL_LINES = 10;
 
 export const ContextPanel = memo(function ContextPanel({
   projectDir,
@@ -23,22 +38,20 @@ export const ContextPanel = memo(function ContextPanel({
 
   const [currentPath, setCurrentPath] = useState("");
   const [entries, setEntries] = useState<ContextEntry[]>([]);
-  const [cursor, setCursor] = useState(0);
-  const [scrollOffset, setScrollOffset] = useState(0);
-  const [preview, setPreview] = useState<{
-    entry: ContextEntry;
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [sidebarScrollOffset, setSidebarScrollOffset] = useState(0);
+  const [detailScroll, setDetailScroll] = useState(0);
+  const [focus, setFocus] = useState<FocusState>("list");
+  const [fileContent, setFileContent] = useState<{
+    path: string;
     content: string;
   } | null>(null);
-  const [previewScroll, setPreviewScroll] = useState(0);
+  const [indexStatus, setIndexStatus] = useState<{
+    path: string;
+    summary: IndexedPathSummary | null;
+  } | null>(null);
 
-  const visibleRows = Math.max(1, termRows - CHROME_LINES);
-
-  useEffect(() => {
-    if (cursor < scrollOffset) setScrollOffset(cursor);
-    else if (cursor >= scrollOffset + visibleRows) {
-      setScrollOffset(cursor - visibleRows + 1);
-    }
-  }, [cursor, scrollOffset, visibleRows]);
+  const visibleRows = Math.max(1, termRows - 6);
 
   const refresh = useCallback(
     async (path: string) => {
@@ -51,14 +64,12 @@ export const ContextPanel = memo(function ContextPanel({
           return a.path.localeCompare(b.path);
         });
         setEntries(list);
-        setCursor(0);
-        setScrollOffset(0);
-        setPreview(null);
+        setSelectedIndex(0);
+        setSidebarScrollOffset(0);
       } catch {
         setEntries([]);
-        setCursor(0);
-        setScrollOffset(0);
-        setPreview(null);
+        setSelectedIndex(0);
+        setSidebarScrollOffset(0);
       }
     },
     [projectDir],
@@ -68,167 +79,330 @@ export const ContextPanel = memo(function ContextPanel({
     refresh(currentPath);
   }, [currentPath, refresh]);
 
-  const previewLines = useMemo(() => {
-    if (!preview) return [];
-    const body =
-      isMarkdownPath(preview.entry.path) && preview.entry.is_textual
-        ? renderMarkdown(preview.content)
-        : preview.content;
-    return body.split("\n");
-  }, [preview]);
+  // Keep the sidebar's selection visible by scrolling its viewport when the
+  // cursor approaches the edges.
+  useEffect(() => {
+    if (selectedIndex < sidebarScrollOffset) {
+      setSidebarScrollOffset(selectedIndex);
+    } else if (selectedIndex >= sidebarScrollOffset + visibleRows) {
+      setSidebarScrollOffset(selectedIndex - visibleRows + 1);
+    }
+  }, [selectedIndex, sidebarScrollOffset, visibleRows]);
 
-  const items = entries;
-  const itemCount = items.length;
+  const selectedEntry = entries[selectedIndex];
+
+  // Auto-load file content when the selection lands on a textual file.
+  // Folders and non-textual files clear the right pane.
+  useEffect(() => {
+    let cancelled = false;
+    if (!selectedEntry) {
+      setFileContent(null);
+      setDetailScroll(0);
+      return;
+    }
+    if (selectedEntry.is_directory || !selectedEntry.is_textual) {
+      setFileContent(null);
+      setDetailScroll(0);
+      return;
+    }
+    setDetailScroll(0);
+    readContextFile(projectDir, selectedEntry.path).then((content) => {
+      if (cancelled) return;
+      setFileContent({ path: selectedEntry.path, content });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [projectDir, selectedEntry]);
+
+  // Look up the file's index status so we can show "indexed (N chunks)"
+  // vs "not indexed" in the header. Skips for folders.
+  useEffect(() => {
+    let cancelled = false;
+    if (!selectedEntry || selectedEntry.is_directory) {
+      setIndexStatus(null);
+      return;
+    }
+    const path = selectedEntry.path;
+    const dbPath = getDbPath(projectDir);
+    withDb(dbPath, (conn) => getIndexedPath(conn, path))
+      .then((summary) => {
+        if (cancelled) return;
+        setIndexStatus({ path, summary });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setIndexStatus({ path, summary: null });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [projectDir, selectedEntry]);
+
+  const detailLines = useMemo(() => {
+    if (!fileContent || !selectedEntry) return [];
+    const body = isMarkdownPath(fileContent.path)
+      ? renderMarkdown(fileContent.content)
+      : fileContent.content;
+    return body.split("\n");
+  }, [fileContent, selectedEntry]);
+
+  const visibleDetailRows = Math.max(1, visibleRows - 2);
+  const maxDetailScroll = Math.max(0, detailLines.length - visibleDetailRows);
+
   const visibleItems = useMemo(
-    () => items.slice(scrollOffset, scrollOffset + visibleRows),
-    [items, scrollOffset, visibleRows],
+    () => entries.slice(sidebarScrollOffset, sidebarScrollOffset + visibleRows),
+    [entries, sidebarScrollOffset, visibleRows],
   );
+
+  // Refs read by the keyboard handler so it always sees the latest committed
+  // values (Ink 7's useInput intermittently leaves a stale closure).
+  const itemCountRef = useLatestRef(entries.length);
+  const maxDetailScrollRef = useLatestRef(maxDetailScroll);
+  const selectedEntryRef = useLatestRef(selectedEntry);
+  const currentPathRef = useLatestRef(currentPath);
+  const focusRef = useLatestRef(focus);
 
   useInput(
     (input, key) => {
-      if (preview) {
-        if (key.upArrow) {
-          setPreviewScroll((s) => Math.max(0, s - 1));
-          return;
-        }
-        if (key.downArrow) {
-          const maxScroll = Math.max(0, previewLines.length - visibleRows + 2);
-          setPreviewScroll((s) => Math.min(maxScroll, s + 1));
-          return;
-        }
-        if (key.escape || input === "q") {
-          setPreview(null);
-          setPreviewScroll(0);
-        }
+      if (
+        handleListDetailKey(input, key, {
+          focusRef,
+          setFocus,
+          itemCountRef,
+          maxDetailScrollRef,
+          setSelectedIndex,
+          setDetailScroll,
+          pageScrollLines: PAGE_SCROLL_LINES,
+          // Context-specific: → on a folder drills in (when list-focused);
+          // ← in list-focus goes up a directory.
+          onRightArrow: () => {
+            if (focusRef.current !== "list") return false;
+            const entry = selectedEntryRef.current;
+            if (entry?.is_directory) {
+              setCurrentPath(entry.path);
+              return true;
+            }
+            return false;
+          },
+          onLeftArrow: () => {
+            if (focusRef.current !== "list") return false;
+            const cwd = currentPathRef.current;
+            if (cwd === "") return true; // already at root, swallow the key
+            const parts = cwd.split("/");
+            parts.pop();
+            setCurrentPath(parts.join("/"));
+            return true;
+          },
+        })
+      ) {
         return;
       }
 
-      if (key.upArrow) {
-        setCursor((c) => Math.max(0, c - 1));
-        return;
+      if (input === "r") {
+        refresh(currentPathRef.current);
       }
-      if (key.downArrow) {
-        setCursor((c) => Math.min(itemCount - 1, c + 1));
-        return;
-      }
-      if (key.return) {
-        const entry = entries[cursor];
-        if (!entry) return;
-        if (entry.is_directory) {
-          setCurrentPath(entry.path);
-          return;
-        }
-        if (!entry.is_textual) return;
-        readContextFile(projectDir, entry.path).then((content) => {
-          setPreview({ entry, content });
-          setPreviewScroll(0);
-        });
-        return;
-      }
-      if (key.backspace || key.delete || input === "h") {
-        if (currentPath === "") return;
-        const parts = currentPath.split("/");
-        parts.pop();
-        setCurrentPath(parts.join("/"));
-      }
-      if (input === "r") refresh(currentPath);
     },
     { isActive },
   );
 
-  if (preview) {
-    const visiblePreviewLines = previewLines.slice(
-      previewScroll,
-      previewScroll + visibleRows - 2,
-    );
-    return (
-      <Box flexDirection="column" flexGrow={1} paddingX={1} overflow="hidden">
-        <Box>
-          <Text bold color="cyan">
-            context/{preview.entry.path}
-          </Text>
-          <Text dimColor> (esc/q to go back · ↑↓ to scroll)</Text>
-        </Box>
-        <Box marginTop={1} flexDirection="column">
-          <Text dimColor>
-            {preview.entry.mime_type} · {preview.entry.size} bytes · updated{" "}
-            {preview.entry.mtime.toLocaleDateString()}
-          </Text>
-        </Box>
-        <Box
-          marginTop={1}
-          flexDirection="column"
-          flexGrow={1}
-          overflow="hidden"
-        >
-          {visiblePreviewLines.map((line, i) => {
-            const lineNum = previewScroll + i;
-            return <Text key={lineNum}>{line || " "}</Text>;
-          })}
-        </Box>
-        {previewLines.length > visibleRows - 2 && (
-          <Box>
-            <Text dimColor>
-              [line {previewScroll + 1}–
-              {Math.min(previewScroll + visibleRows - 2, previewLines.length)}{" "}
-              of {previewLines.length}]
-            </Text>
-          </Box>
-        )}
-      </Box>
-    );
-  }
-
   const headerLabel =
     currentPath === "" ? "context/" : `context/${currentPath}/`;
 
+  const detailVisible = detailLines.slice(
+    detailScroll,
+    detailScroll + visibleDetailRows,
+  );
+
   return (
-    <Box flexDirection="column" flexGrow={1} paddingX={1} overflow="hidden">
-      <Box>
-        <Text bold color="cyan">
-          {headerLabel}
-        </Text>
-        <Text dimColor>
-          {" "}
-          ({entries.length} entries · ↑↓ select · ⏎ open · backspace up · r
-          refresh)
-        </Text>
-      </Box>
-      <Box flexDirection="column" marginTop={1} flexGrow={1}>
-        {entries.length === 0 && <Text dimColor>(empty)</Text>}
-        {visibleItems.map((entry, vi) => {
-          const i = vi + scrollOffset;
-          const isSelected = i === cursor;
-          const name = entry.path.split("/").pop() ?? entry.path;
-          const icon = entry.is_directory ? "📁" : "📄";
-          return (
-            <Box key={entry.path}>
-              <Text
-                backgroundColor={isSelected ? "#333" : undefined}
-                color={
-                  isSelected ? "cyan" : entry.is_directory ? "blue" : undefined
-                }
-                bold={isSelected}
-              >
-                {"  "}
-                {icon} {name}
-                {entry.is_directory ? "/" : ""}
-                {!entry.is_directory && (
-                  <Text dimColor> ({entry.mime_type})</Text>
-                )}
-              </Text>
-            </Box>
-          );
-        })}
-      </Box>
-      {itemCount > visibleRows && (
-        <Box>
-          <Text dimColor>
-            [{scrollOffset + 1}–
-            {Math.min(scrollOffset + visibleRows, itemCount)} of {itemCount}]
+    <Box flexGrow={1} height={visibleRows + 1} overflow="hidden">
+      {/* Left: file tree */}
+      <Box
+        flexDirection="column"
+        width={SIDEBAR_WIDTH}
+        height={visibleRows + 1}
+        borderStyle="single"
+        borderColor={theme.muted}
+        borderRight
+        borderTop={false}
+        borderBottom={false}
+        borderLeft={false}
+        overflow="hidden"
+      >
+        <Box paddingX={1}>
+          <Text bold dimColor wrap="truncate-end">
+            {headerLabel}
           </Text>
         </Box>
-      )}
+        {entries.length === 0 ? (
+          <Box paddingX={1}>
+            <Text dimColor>(empty)</Text>
+          </Box>
+        ) : (
+          visibleItems.map((entry, vi) => {
+            const i = vi + sidebarScrollOffset;
+            const isSelected = i === selectedIndex;
+            const name = entry.path.split("/").pop() ?? entry.path;
+            const icon = entry.is_directory ? "📁" : "📄";
+            return (
+              <Box key={entry.path} paddingX={1}>
+                <Text
+                  backgroundColor={isSelected ? theme.selectionBg : undefined}
+                  color={
+                    isSelected
+                      ? theme.info
+                      : entry.is_directory
+                        ? theme.accent
+                        : undefined
+                  }
+                  bold={isSelected}
+                  wrap="truncate-end"
+                >
+                  {isSelected ? "▸" : " "} {icon} {name}
+                  {entry.is_directory ? "/" : ""}
+                </Text>
+              </Box>
+            );
+          })
+        )}
+      </Box>
+
+      {/* Right: file content (or placeholder) */}
+      <Box
+        flexDirection="column"
+        flexGrow={1}
+        height={visibleRows + 1}
+        paddingX={1}
+        {...detailPaneBorderProps(focus)}
+        overflow="hidden"
+      >
+        {selectedEntry ? (
+          <>
+            <ContextDetailHeader
+              entry={selectedEntry}
+              indexStatus={
+                indexStatus && indexStatus.path === selectedEntry.path
+                  ? indexStatus.summary
+                  : null
+              }
+              indexLoaded={
+                !!indexStatus && indexStatus.path === selectedEntry.path
+              }
+            />
+            <Box flexDirection="row" flexGrow={1} overflow="hidden">
+              <Box flexDirection="column" flexGrow={1} overflow="hidden">
+                {selectedEntry.is_directory ? (
+                  <Text dimColor>(folder — press → to drill in)</Text>
+                ) : !selectedEntry.is_textual ? (
+                  <Text dimColor>(binary file — no preview)</Text>
+                ) : (
+                  detailVisible.map((line, i) => {
+                    const lineNum = detailScroll + i;
+                    return (
+                      <Text key={lineNum} wrap="truncate-end">
+                        {line || " "}
+                      </Text>
+                    );
+                  })
+                )}
+              </Box>
+              {selectedEntry &&
+                !selectedEntry.is_directory &&
+                selectedEntry.is_textual && (
+                  <Scrollbar
+                    total={detailLines.length}
+                    visible={visibleDetailRows - 3}
+                    offset={detailScroll}
+                    height={visibleDetailRows - 3}
+                    focused={focus === "detail"}
+                  />
+                )}
+            </Box>
+          </>
+        ) : (
+          <Text dimColor>(no item selected)</Text>
+        )}
+        <Box>
+          <Text dimColor>
+            {focus === "detail"
+              ? "↑↓ scroll · ⇧↑↓ page · g/G top/bot · ← back to list"
+              : "↑↓ select · → drill in/enter detail · ← up · r refresh"}
+          </Text>
+        </Box>
+      </Box>
     </Box>
   );
 });
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatDate(d: Date): string {
+  return d.toLocaleString([], {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function ContextDetailHeader({
+  entry,
+  indexStatus,
+  indexLoaded,
+}: {
+  entry: ContextEntry;
+  indexStatus: IndexedPathSummary | null;
+  indexLoaded: boolean;
+}) {
+  return (
+    <Box flexDirection="column">
+      <Box>
+        <Text bold color="cyan" wrap="truncate-end">
+          {entry.is_directory ? "📁" : "📄"} context/{entry.path}
+          {entry.is_directory ? "/" : ""}
+        </Text>
+      </Box>
+      {entry.is_directory ? (
+        <Box>
+          <Text dimColor wrap="truncate-end">
+            directory · → to open
+          </Text>
+        </Box>
+      ) : (
+        <>
+          <Box>
+            <Text dimColor wrap="truncate-end">
+              {entry.mime_type} · {formatSize(entry.size)} · updated{" "}
+              {formatDate(entry.mtime)}
+            </Text>
+          </Box>
+          <Box>
+            <Text wrap="truncate-end">
+              {!indexLoaded ? (
+                <Text dimColor>checking index…</Text>
+              ) : indexStatus ? (
+                <Text color={theme.success}>
+                  ● indexed
+                  <Text dimColor>
+                    {" ("}
+                    {indexStatus.chunk_count}
+                    {indexStatus.chunk_count === 1 ? " chunk" : " chunks"})
+                  </Text>
+                </Text>
+              ) : (
+                <Text color={theme.muted}>○ not indexed</Text>
+              )}
+            </Text>
+          </Box>
+        </>
+      )}
+      <Box>
+        <Text dimColor>{"─".repeat(2)}</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/tui/components/HelpPanel.tsx
+++ b/src/tui/components/HelpPanel.tsx
@@ -19,19 +19,37 @@ export const HelpPanel = memo(function HelpPanel({
           Navigation
         </Text>
         <Text>
-          {"  "}Tab{"            "}Cycle between tabs
+          {"  "}Ctrl+a{"         "}Chat
         </Text>
         <Text>
-          {"  "}1-6{"            "}Jump to tab (non-chat tabs)
+          {"  "}Ctrl+o{"         "}Tools
         </Text>
         <Text>
-          {"  "}Escape{"         "}Return to Chat tab
+          {"  "}Ctrl+n{"         "}Context
+        </Text>
+        <Text>
+          {"  "}Ctrl+t{"         "}Tasks
+        </Text>
+        <Text>
+          {"  "}Ctrl+r{"         "}Threads
+        </Text>
+        <Text>
+          {"  "}Ctrl+s{"         "}Schedules
+        </Text>
+        <Text>
+          {"  "}Ctrl+w{"         "}Workers
+        </Text>
+        <Text>
+          {"  "}?{"              "}Help (from any non-chat tab)
+        </Text>
+        <Text>
+          {"  "}Escape{"         "}Return to Chat
         </Text>
       </Box>
 
       <Box marginTop={1} flexDirection="column">
         <Text bold color="cyan">
-          Chat (Tab 1)
+          Chat
         </Text>
         <Text>
           {"  "}Enter{"          "}Send message
@@ -42,89 +60,70 @@ export const HelpPanel = memo(function HelpPanel({
         <Text>
           {"  "}↑/↓{"            "}Browse input history
         </Text>
-      </Box>
-
-      <Box marginTop={1} flexDirection="column">
-        <Text bold color="cyan">
-          Tools (Tab 2)
-        </Text>
         <Text>
-          {"  "}↑/↓{"            "}Select tool call
-        </Text>
-        <Text>
-          {"  "}Shift+↑/↓{"      "}Scroll detail pane
-        </Text>
-        <Text>
-          {"  "}j / k{"          "}Scroll detail pane
+          {"  "}Esc{"            "}Steer / abort in-flight turn
         </Text>
       </Box>
 
       <Box marginTop={1} flexDirection="column">
         <Text bold color="cyan">
-          Context (Tab 3)
+          List panels (Tools/Tasks/Threads/Schedules/Workers/Context)
+        </Text>
+        <Text dimColor>
+          {"  "}List focus (default — dashed border on right pane):
         </Text>
         <Text>
-          {"  "}↑/↓{"            "}Navigate items
+          {"  "}↑/↓{"            "}Move list selection
         </Text>
         <Text>
-          {"  "}Enter{"          "}Expand directory / preview file
+          {"  "}→{"              "}Enter the right pane (border turns yellow)
+        </Text>
+        <Text dimColor>{"  "}Detail focus (yellow border on right pane):</Text>
+        <Text>
+          {"  "}↑/↓{"            "}Scroll the right pane (one line)
         </Text>
         <Text>
-          {"  "}Backspace{"      "}Go up one directory
+          {"  "}Shift+↑/↓{"      "}Page-scroll the right pane
+        </Text>
+        <Text>
+          {"  "}g / G{"          "}Top / bottom of the right pane
+        </Text>
+        <Text>
+          {"  "}←{"              "}Return to the list
+        </Text>
+      </Box>
+
+      <Box marginTop={1} flexDirection="column">
+        <Text bold color="cyan">
+          Context (extras)
+        </Text>
+        <Text>
+          {"  "}→{"              "}Drill into selected folder
+        </Text>
+        <Text>
+          {"  "}←{"              "}Go up one directory
         </Text>
         <Text>
           {"  "}/{"              "}Search context
         </Text>
-        <Text>
-          {"  "}d{"              "}Delete selected item (with confirmation)
-        </Text>
       </Box>
 
       <Box marginTop={1} flexDirection="column">
         <Text bold color="cyan">
-          Tasks (Tab 4)
+          Per-panel actions
         </Text>
         <Text>
-          {"  "}↑/↓{"            "}Navigate task list
+          {"  "}Tasks{"          "}f filter · p priority · d delete · r refresh
         </Text>
         <Text>
-          {"  "}Shift+↑/↓{"      "}Scroll detail pane
+          {"  "}Threads{"        "}f filter · s/ search · w follow · d delete ·
+          r refresh
         </Text>
         <Text>
-          {"  "}j / k{"          "}Scroll detail pane
+          {"  "}Schedules{"      "}f filter · e toggle · d delete · r refresh
         </Text>
         <Text>
-          {"  "}f{"              "}Cycle status filter
-        </Text>
-        <Text>
-          {"  "}p{"              "}Cycle priority filter
-        </Text>
-        <Text>
-          {"  "}r{"              "}Refresh tasks
-        </Text>
-      </Box>
-
-      <Box marginTop={1} flexDirection="column">
-        <Text bold color="cyan">
-          Threads (Tab 5)
-        </Text>
-        <Text>
-          {"  "}↑/↓{"            "}Navigate thread list
-        </Text>
-        <Text>
-          {"  "}Shift+↑/↓{"      "}Scroll detail pane
-        </Text>
-        <Text>
-          {"  "}j / k{"          "}Scroll detail pane
-        </Text>
-        <Text>
-          {"  "}f{"              "}Cycle type filter
-        </Text>
-        <Text>
-          {"  "}d{"              "}Delete thread (with confirmation)
-        </Text>
-        <Text>
-          {"  "}r{"              "}Refresh threads
+          {"  "}Workers{"        "}f filter · l toggle log/detail
         </Text>
       </Box>
 

--- a/src/tui/components/SchedulePanel.tsx
+++ b/src/tui/components/SchedulePanel.tsx
@@ -6,7 +6,14 @@ import {
   listSchedules,
   updateSchedule,
 } from "../../schedules/store.ts";
+import {
+  detailPaneBorderProps,
+  type FocusState,
+  handleListDetailKey,
+} from "../listDetailKeys.ts";
 import { ansi, theme } from "../theme.ts";
+import { useLatestRef } from "../useLatestRef.ts";
+import { Scrollbar } from "./Scrollbar.tsx";
 
 interface SchedulePanelProps {
   projectDir: string;
@@ -26,11 +33,6 @@ const ENABLED_ICONS: Record<string, string> = {
 const ENABLED_COLORS: Record<string, string> = {
   true: theme.success,
   false: theme.muted,
-};
-
-const ENABLED_ANSI: Record<string, string> = {
-  true: ansi.success,
-  false: ansi.muted,
 };
 
 const ENABLED_LABELS: Record<string, string> = {
@@ -53,31 +55,7 @@ function formatTimestamp(iso: string | null): string {
 function buildScheduleDetailAnsi(schedule: Schedule): string {
   const lines: string[] = [];
 
-  lines.push(`${ansi.bold}${ansi.info}${schedule.name}${ansi.reset}`);
-  lines.push("");
-
-  const enabledKey = String(schedule.enabled);
-  const statusAnsi = ENABLED_ANSI[enabledKey];
-  lines.push(
-    `${ansi.bold}${ansi.primary}Status${ansi.reset}      ${statusAnsi}${ENABLED_ICONS[enabledKey]} ${ENABLED_LABELS[enabledKey]}${ansi.reset}`,
-  );
-
-  lines.push(
-    `${ansi.bold}${ansi.primary}Frequency${ansi.reset}   ${ansi.accent}${schedule.frequency}${ansi.reset}`,
-  );
-
-  lines.push(
-    `${ansi.bold}${ansi.primary}Created${ansi.reset}     ${ansi.dim}${formatTimestamp(schedule.created_at)}${ansi.reset}`,
-  );
-  lines.push(
-    `${ansi.bold}${ansi.primary}Updated${ansi.reset}     ${ansi.dim}${formatTimestamp(schedule.updated_at)}${ansi.reset}`,
-  );
-
-  lines.push(
-    `${ansi.bold}${ansi.primary}Last Run${ansi.reset}    ${formatTimestamp(schedule.last_run_at)}`,
-  );
-  lines.push("");
-
+  // Body only — name/status/frequency/last-run live in the panel header.
   if (schedule.description) {
     lines.push(`${ansi.bold}${ansi.primary}Description${ansi.reset}`);
     lines.push(schedule.description);
@@ -85,7 +63,13 @@ function buildScheduleDetailAnsi(schedule: Schedule): string {
   }
 
   lines.push(
-    `${ansi.bold}${ansi.primary}ID${ansi.reset}          ${ansi.dim}${schedule.id}${ansi.reset}`,
+    `${ansi.bold}${ansi.primary}Created${ansi.reset}   ${ansi.dim}${formatTimestamp(schedule.created_at)}${ansi.reset}`,
+  );
+  lines.push(
+    `${ansi.bold}${ansi.primary}Updated${ansi.reset}   ${ansi.dim}${formatTimestamp(schedule.updated_at)}${ansi.reset}`,
+  );
+  lines.push(
+    `${ansi.bold}${ansi.primary}ID${ansi.reset}        ${ansi.dim}${schedule.id}${ansi.reset}`,
   );
 
   return lines.join("\n");
@@ -107,6 +91,7 @@ export const SchedulePanel = memo(function SchedulePanel({
   const [schedules, setSchedules] = useState<Schedule[]>([]);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [detailScroll, setDetailScroll] = useState(0);
+  const [focus, setFocus] = useState<FocusState>("list");
   const [enabledFilter, setEnabledFilter] = useState<boolean | null>(null);
   const [refreshTick, setRefreshTick] = useState(0);
   const [confirmDelete, setConfirmDelete] = useState(false);
@@ -171,12 +156,19 @@ export const SchedulePanel = memo(function SchedulePanel({
     setRefreshTick((t) => t + 1);
   }, []);
 
+  const itemCountRef = useLatestRef(schedules.length);
+  const maxDetailScrollRef = useLatestRef(maxDetailScroll);
+  const selectedScheduleRef = useLatestRef(selectedSchedule);
+  const confirmDeleteRef = useLatestRef(confirmDelete);
+  const focusRef = useLatestRef(focus);
+
   useInput(
     (input, key) => {
-      if (confirmDelete) {
+      if (confirmDeleteRef.current) {
         if (input === "y" || input === "d") {
-          if (selectedSchedule) {
-            deleteSchedule(projectDir, selectedSchedule.id).then(() => {
+          const s = selectedScheduleRef.current;
+          if (s) {
+            deleteSchedule(projectDir, s.id).then(() => {
               forceRefresh();
             });
           }
@@ -187,47 +179,17 @@ export const SchedulePanel = memo(function SchedulePanel({
         return;
       }
 
-      if (key.upArrow) {
-        if (key.shift) {
-          setDetailScroll((s) => Math.max(0, s - 1));
-        } else {
-          setSelectedIndex((i) => Math.max(0, i - 1));
-        }
-        return;
-      }
-      if (key.downArrow) {
-        if (key.shift) {
-          setDetailScroll((s) => Math.min(maxDetailScroll, s + 1));
-        } else {
-          setSelectedIndex((i) => Math.min(schedules.length - 1, i + 1));
-        }
-        return;
-      }
-
-      if (input === "j") {
-        setDetailScroll((s) => Math.min(maxDetailScroll, s + 1));
-        return;
-      }
-      if (input === "k") {
-        setDetailScroll((s) => Math.max(0, s - 1));
-        return;
-      }
-      if (input === "J") {
-        setDetailScroll((s) =>
-          Math.min(maxDetailScroll, s + PAGE_SCROLL_LINES),
-        );
-        return;
-      }
-      if (input === "K") {
-        setDetailScroll((s) => Math.max(0, s - PAGE_SCROLL_LINES));
-        return;
-      }
-      if (input === "g") {
-        setDetailScroll(0);
-        return;
-      }
-      if (input === "G") {
-        setDetailScroll(maxDetailScroll);
+      if (
+        handleListDetailKey(input, key, {
+          focusRef,
+          setFocus,
+          itemCountRef,
+          maxDetailScrollRef,
+          setSelectedIndex,
+          setDetailScroll,
+          pageScrollLines: PAGE_SCROLL_LINES,
+        })
+      ) {
         return;
       }
 
@@ -235,15 +197,17 @@ export const SchedulePanel = memo(function SchedulePanel({
         setEnabledFilter((f) => cycleFilter(f, ENABLED_FILTERS));
         return;
       }
-      if (input === "e" && selectedSchedule) {
-        updateSchedule(projectDir, selectedSchedule.id, {
-          enabled: !selectedSchedule.enabled,
+      if (input === "e") {
+        const s = selectedScheduleRef.current;
+        if (!s) return;
+        updateSchedule(projectDir, s.id, {
+          enabled: !s.enabled,
         }).then(() => {
           forceRefresh();
         });
         return;
       }
-      if (input === "d" && selectedSchedule) {
+      if (input === "d" && selectedScheduleRef.current) {
         setConfirmDelete(true);
         return;
       }
@@ -353,29 +317,66 @@ export const SchedulePanel = memo(function SchedulePanel({
         flexGrow={1}
         height={visibleRows + 1}
         paddingX={1}
+        {...detailPaneBorderProps(focus)}
         overflow="hidden"
       >
-        {detailVisible.map((line, i) => {
-          const lineNum = detailScroll + i;
-          return <Text key={lineNum}>{line || " "}</Text>;
-        })}
-        {detailLines.length > visibleRows && (
-          <Box>
-            <Text dimColor>
-              f filter · e toggle · ↑↓ select · j/k scroll · d delete · r
-              refresh · [{detailScroll + 1}–
-              {Math.min(detailScroll + visibleRows, detailLines.length)} of{" "}
-              {detailLines.length}]
-            </Text>
+        {selectedSchedule && (
+          <ScheduleDetailHeader schedule={selectedSchedule} />
+        )}
+        <Box flexDirection="row" flexGrow={1} overflow="hidden">
+          <Box flexDirection="column" flexGrow={1} overflow="hidden">
+            {detailVisible.map((line, i) => {
+              const lineNum = detailScroll + i;
+              return (
+                <Text key={lineNum} wrap="truncate-end">
+                  {line || " "}
+                </Text>
+              );
+            })}
           </Box>
-        )}
-        {detailLines.length <= visibleRows && <Box flexGrow={1} />}
-        {detailLines.length <= visibleRows && (
-          <Text dimColor>
-            f filter · e toggle · ↑↓ select · d delete · r refresh
-          </Text>
-        )}
+          <Scrollbar
+            total={detailLines.length}
+            visible={visibleRows - 3}
+            offset={detailScroll}
+            height={visibleRows - 3}
+            focused={focus === "detail"}
+          />
+        </Box>
+        <Text dimColor>
+          {focus === "detail"
+            ? "↑↓ scroll · ⇧↑↓ page · g/G top/bot · ← back to list"
+            : "↑↓ select · → enter detail · f filter · e toggle · d delete · r refresh"}
+        </Text>
       </Box>
     </Box>
   );
 });
+
+function ScheduleDetailHeader({ schedule }: { schedule: Schedule }) {
+  const enabledKey = String(schedule.enabled);
+  return (
+    <Box flexDirection="column">
+      <Box>
+        <Text bold color={theme.info} wrap="truncate-end">
+          {schedule.name}
+        </Text>
+      </Box>
+      <Box>
+        <Text wrap="truncate-end">
+          <Text color={ENABLED_COLORS[enabledKey]}>
+            {ENABLED_ICONS[enabledKey]} {ENABLED_LABELS[enabledKey]}
+          </Text>
+          <Text dimColor> · </Text>
+          <Text color={theme.accent}>{schedule.frequency}</Text>
+          <Text dimColor>
+            {" · last run "}
+            {formatTimestamp(schedule.last_run_at)}
+          </Text>
+        </Text>
+      </Box>
+      <Box>
+        <Text dimColor>{"─".repeat(2)}</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/tui/components/Scrollbar.tsx
+++ b/src/tui/components/Scrollbar.tsx
@@ -1,0 +1,73 @@
+import { Box, Text } from "ink";
+import { memo } from "react";
+
+interface ScrollbarProps {
+  /** Total number of lines in the document. */
+  total: number;
+  /** Number of lines currently visible. */
+  visible: number;
+  /** Scroll offset (top visible line). */
+  offset: number;
+  /** Height of the scrollbar in rows. */
+  height: number;
+  /** Whether the parent pane is currently focused — colors the thumb. */
+  focused?: boolean;
+}
+
+/**
+ * Vertical scrollbar rendered as a column of unicode block characters.
+ * The thumb's height and position are proportional to how much of the
+ * document is visible. Used in detail panes so the user can see at a glance
+ * where they are within a long document.
+ */
+export const Scrollbar = memo(function Scrollbar({
+  total,
+  visible,
+  offset,
+  height,
+  focused,
+}: ScrollbarProps) {
+  if (height <= 0 || total <= 0 || total <= visible) {
+    // Nothing to scroll — render an empty column to preserve layout.
+    return (
+      <Box flexDirection="column" width={1} height={height}>
+        {Array.from({ length: Math.max(0, height) }, (_, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: positional rows
+          <Text key={i} dimColor>
+            {" "}
+          </Text>
+        ))}
+      </Box>
+    );
+  }
+
+  const thumbHeight = Math.max(1, Math.round((visible / total) * height));
+  const maxOffset = Math.max(1, total - visible);
+  const thumbStart = Math.min(
+    height - thumbHeight,
+    Math.round((offset / maxOffset) * (height - thumbHeight)),
+  );
+
+  const cells: Array<{ thumb: boolean }> = [];
+  for (let i = 0; i < height; i++) {
+    cells.push({ thumb: i >= thumbStart && i < thumbStart + thumbHeight });
+  }
+
+  return (
+    <Box flexDirection="column" width={1} height={height}>
+      {cells.map((cell, i) =>
+        cell.thumb ? (
+          // biome-ignore lint/suspicious/noArrayIndexKey: positional rows
+          <Text key={i} color={focused ? "yellow" : "gray"}>
+            █
+          </Text>
+        ) : (
+          // biome-ignore lint/suspicious/noArrayIndexKey: positional rows
+          <Text key={i} dimColor>
+            │
+          </Text>
+        ),
+      )}
+    </Box>
+  );
+});

--- a/src/tui/components/TabBar.tsx
+++ b/src/tui/components/TabBar.tsx
@@ -2,15 +2,17 @@ import { Box, Text } from "ink";
 
 export type TabId = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
 
-const TABS: { id: TabId; label: string }[] = [
-  { id: 1, label: "Chat" },
-  { id: 2, label: "Tools" },
-  { id: 3, label: "Context" },
-  { id: 4, label: "Tasks" },
-  { id: 5, label: "Threads" },
-  { id: 6, label: "Schedules" },
-  { id: 7, label: "Workers" },
-  { id: 8, label: "Help" },
+// Help uses "?" (no Ctrl) because Ctrl+H is delivered as backspace by most
+// terminals. The other panels use Ctrl+<letter>.
+const TABS: { id: TabId; label: string; key: string }[] = [
+  { id: 1, label: "Chat", key: "^a" },
+  { id: 2, label: "Tools", key: "^o" },
+  { id: 3, label: "Context", key: "^n" },
+  { id: 4, label: "Tasks", key: "^t" },
+  { id: 5, label: "Threads", key: "^r" },
+  { id: 6, label: "Schedules", key: "^s" },
+  { id: 7, label: "Workers", key: "^w" },
+  { id: 8, label: "Help", key: "?" },
 ];
 
 interface TabBarProps {
@@ -20,7 +22,7 @@ interface TabBarProps {
 export function TabBar({ activeTab }: TabBarProps) {
   return (
     <Box paddingX={1} gap={1}>
-      {TABS.map(({ id, label }) => {
+      {TABS.map(({ id, label, key: shortcut }) => {
         const active = id === activeTab;
         return (
           <Box key={id}>
@@ -30,13 +32,11 @@ export function TabBar({ activeTab }: TabBarProps) {
               dimColor={!active}
               backgroundColor={active ? "#1a3a5c" : undefined}
             >
-              {` ${id} ${label} `}
+              {` ${shortcut} ${label} `}
             </Text>
           </Box>
         );
       })}
-      <Box flexGrow={1} />
-      <Text dimColor>tab to switch</Text>
     </Box>
   );
 }

--- a/src/tui/components/TaskPanel.tsx
+++ b/src/tui/components/TaskPanel.tsx
@@ -6,7 +6,14 @@ import {
   type Task,
 } from "../../tasks/schema.ts";
 import { deleteTask, listTasks } from "../../tasks/store.ts";
+import {
+  detailPaneBorderProps,
+  type FocusState,
+  handleListDetailKey,
+} from "../listDetailKeys.ts";
 import { ansi, theme } from "../theme.ts";
+import { useLatestRef } from "../useLatestRef.ts";
+import { Scrollbar } from "./Scrollbar.tsx";
 
 interface TaskPanelProps {
   projectDir: string;
@@ -32,14 +39,6 @@ const STATUS_COLORS: Record<Task["status"], string> = {
   complete: theme.success,
 };
 
-const STATUS_ANSI: Record<Task["status"], string> = {
-  pending: ansi.muted,
-  in_progress: ansi.accent,
-  waiting: ansi.info,
-  failed: ansi.error,
-  complete: ansi.success,
-};
-
 const PRIORITY_LABELS: Record<Task["priority"], string> = {
   high: "HI",
   medium: "MD",
@@ -50,12 +49,6 @@ const PRIORITY_COLORS: Record<Task["priority"], string> = {
   high: theme.error,
   medium: theme.accent,
   low: theme.muted,
-};
-
-const PRIORITY_ANSI: Record<Task["priority"], string> = {
-  high: ansi.error,
-  medium: ansi.accent,
-  low: ansi.muted,
 };
 
 function formatTimestamp(iso: string): string {
@@ -72,28 +65,10 @@ function formatTimestamp(iso: string): string {
 function buildTaskDetailAnsi(task: Task): string {
   const lines: string[] = [];
 
-  lines.push(`${ansi.bold}${ansi.info}${task.name}${ansi.reset}`);
-  lines.push("");
-
-  const statusAnsi = STATUS_ANSI[task.status];
-  lines.push(
-    `${ansi.bold}${ansi.primary}Status${ansi.reset}    ${statusAnsi}${STATUS_ICONS[task.status]} ${task.status}${ansi.reset}`,
-  );
-
-  const priorityAnsi = PRIORITY_ANSI[task.priority];
-  lines.push(
-    `${ansi.bold}${ansi.primary}Priority${ansi.reset}  ${priorityAnsi}${task.priority}${ansi.reset}`,
-  );
-
+  // Body only — name/status/priority/claim/timestamps are rendered in the
+  // panel header.
   lines.push(
     `${ansi.bold}${ansi.primary}Claimed${ansi.reset}   ${task.claimed_by ? task.claimed_by : `${ansi.dim}(unclaimed)${ansi.reset}`}`,
-  );
-
-  lines.push(
-    `${ansi.bold}${ansi.primary}Created${ansi.reset}   ${ansi.dim}${formatTimestamp(task.created_at)}${ansi.reset}`,
-  );
-  lines.push(
-    `${ansi.bold}${ansi.primary}Updated${ansi.reset}   ${ansi.dim}${formatTimestamp(task.updated_at)}${ansi.reset}`,
   );
   lines.push("");
 
@@ -149,6 +124,7 @@ export const TaskPanel = memo(function TaskPanel({
   const [tasks, setTasks] = useState<Task[]>([]);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [detailScroll, setDetailScroll] = useState(0);
+  const [focus, setFocus] = useState<FocusState>("list");
   const [statusFilter, setStatusFilter] = useState<Task["status"] | null>(null);
   const [priorityFilter, setPriorityFilter] = useState<Task["priority"] | null>(
     null,
@@ -218,49 +194,24 @@ export const TaskPanel = memo(function TaskPanel({
     setRefreshTick((t) => t + 1);
   }, []);
 
+  const itemCountRef = useLatestRef(tasks.length);
+  const maxDetailScrollRef = useLatestRef(maxDetailScroll);
+  const selectedTaskRef = useLatestRef(selectedTask);
+  const focusRef = useLatestRef(focus);
+
   useInput(
     (input, key) => {
-      if (key.upArrow) {
-        if (key.shift) {
-          setDetailScroll((s) => Math.max(0, s - 1));
-        } else {
-          setSelectedIndex((i) => Math.max(0, i - 1));
-        }
-        return;
-      }
-      if (key.downArrow) {
-        if (key.shift) {
-          setDetailScroll((s) => Math.min(maxDetailScroll, s + 1));
-        } else {
-          setSelectedIndex((i) => Math.min(tasks.length - 1, i + 1));
-        }
-        return;
-      }
-
-      if (input === "j") {
-        setDetailScroll((s) => Math.min(maxDetailScroll, s + 1));
-        return;
-      }
-      if (input === "k") {
-        setDetailScroll((s) => Math.max(0, s - 1));
-        return;
-      }
-      if (input === "J") {
-        setDetailScroll((s) =>
-          Math.min(maxDetailScroll, s + PAGE_SCROLL_LINES),
-        );
-        return;
-      }
-      if (input === "K") {
-        setDetailScroll((s) => Math.max(0, s - PAGE_SCROLL_LINES));
-        return;
-      }
-      if (input === "g") {
-        setDetailScroll(0);
-        return;
-      }
-      if (input === "G") {
-        setDetailScroll(maxDetailScroll);
+      if (
+        handleListDetailKey(input, key, {
+          focusRef,
+          setFocus,
+          itemCountRef,
+          maxDetailScrollRef,
+          setSelectedIndex,
+          setDetailScroll,
+          pageScrollLines: PAGE_SCROLL_LINES,
+        })
+      ) {
         return;
       }
 
@@ -272,8 +223,10 @@ export const TaskPanel = memo(function TaskPanel({
         setPriorityFilter((f) => cycleFilter(f, TASK_PRIORITIES));
         return;
       }
-      if (input === "d" && selectedTask) {
-        deleteTask(projectDir, selectedTask.id).then(() => {
+      if (input === "d") {
+        const t = selectedTaskRef.current;
+        if (!t) return;
+        deleteTask(projectDir, t.id).then(() => {
           forceRefresh();
         });
         return;
@@ -383,29 +336,67 @@ export const TaskPanel = memo(function TaskPanel({
         flexGrow={1}
         height={visibleRows + 1}
         paddingX={1}
+        {...detailPaneBorderProps(focus)}
         overflow="hidden"
       >
-        {detailVisible.map((line, i) => {
-          const lineNum = detailScroll + i;
-          return <Text key={lineNum}>{line || " "}</Text>;
-        })}
-        {detailLines.length > visibleRows && (
-          <Box>
-            <Text dimColor>
-              f filter · p priority · ↑↓ select · j/k scroll · d delete · r
-              refresh · [{detailScroll + 1}–
-              {Math.min(detailScroll + visibleRows, detailLines.length)} of{" "}
-              {detailLines.length}]
-            </Text>
+        {selectedTask && <TaskDetailHeader task={selectedTask} />}
+        <Box flexDirection="row" flexGrow={1} overflow="hidden">
+          <Box flexDirection="column" flexGrow={1} overflow="hidden">
+            {detailVisible.map((line, i) => {
+              const lineNum = detailScroll + i;
+              return (
+                <Text key={lineNum} wrap="truncate-end">
+                  {line || " "}
+                </Text>
+              );
+            })}
           </Box>
-        )}
-        {detailLines.length <= visibleRows && <Box flexGrow={1} />}
-        {detailLines.length <= visibleRows && (
-          <Text dimColor>
-            f filter · p priority · ↑↓ select · d delete · r refresh
-          </Text>
-        )}
+          <Scrollbar
+            total={detailLines.length}
+            visible={visibleRows - 3}
+            offset={detailScroll}
+            height={visibleRows - 3}
+            focused={focus === "detail"}
+          />
+        </Box>
+        <Text dimColor>
+          {focus === "detail"
+            ? "↑↓ scroll · ⇧↑↓ page · g/G top/bot · ← back to list"
+            : "↑↓ select · → enter detail · f filter · p priority · d delete · r refresh"}
+        </Text>
       </Box>
     </Box>
   );
 });
+
+function TaskDetailHeader({ task }: { task: Task }) {
+  return (
+    <Box flexDirection="column">
+      <Box>
+        <Text bold color={theme.info} wrap="truncate-end">
+          {task.name}
+        </Text>
+      </Box>
+      <Box>
+        <Text wrap="truncate-end">
+          <Text color={STATUS_COLORS[task.status]}>
+            {STATUS_ICONS[task.status]} {task.status}
+          </Text>
+          <Text dimColor> · </Text>
+          <Text color={PRIORITY_COLORS[task.priority]}>
+            {PRIORITY_LABELS[task.priority]}
+          </Text>
+          <Text dimColor>
+            {" · created "}
+            {formatTimestamp(task.created_at)}
+            {" · updated "}
+            {formatTimestamp(task.updated_at)}
+          </Text>
+        </Text>
+      </Box>
+      <Box>
+        <Text dimColor>{"─".repeat(2)}</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/tui/components/ThreadPanel.tsx
+++ b/src/tui/components/ThreadPanel.tsx
@@ -9,7 +9,14 @@ import {
   listThreads,
   type Thread,
 } from "../../threads/store.ts";
+import {
+  detailPaneBorderProps,
+  type FocusState,
+  handleListDetailKey,
+} from "../listDetailKeys.ts";
 import { ansi, theme } from "../theme.ts";
+import { useLatestRef } from "../useLatestRef.ts";
+import { Scrollbar } from "./Scrollbar.tsx";
 
 interface ThreadPanelProps {
   projectDir: string;
@@ -38,11 +45,6 @@ const TYPE_ICONS: Record<Thread["type"], string> = {
 const TYPE_COLORS: Record<Thread["type"], string> = {
   worker_tick: theme.accent,
   chat_session: theme.info,
-};
-
-const TYPE_ANSI: Record<Thread["type"], string> = {
-  worker_tick: ansi.accent,
-  chat_session: ansi.info,
 };
 
 const ROLE_ANSI: Record<string, string> = {
@@ -76,44 +78,18 @@ function formatDate(d: Date): string {
 function buildThreadDetailAnsi(
   thread: Thread,
   interactions: Interaction[],
-  isActiveThread: boolean,
+  _isActiveThread: boolean,
 ): string {
   const lines: string[] = [];
 
-  lines.push(
-    `${ansi.bold}${ansi.italic}${ansi.info}${thread.title || "(untitled)"}${ansi.reset}`,
-  );
-  lines.push("");
-
-  const typeAnsi = TYPE_ANSI[thread.type];
-  lines.push(
-    `${ansi.bold}${ansi.primary}Type${ansi.reset}      ${typeAnsi}${TYPE_ICONS[thread.type]} ${TYPE_LABELS[thread.type]}${ansi.reset}`,
-  );
-
+  // Body only — title/type/timing live in the panel header.
   if (thread.task_id) {
     lines.push(
       `${ansi.bold}${ansi.primary}Task${ansi.reset}      ${ansi.dim}${thread.task_id}${ansi.reset}`,
     );
-  }
-
-  lines.push(
-    `${ansi.bold}${ansi.primary}Started${ansi.reset}   ${ansi.dim}${formatDate(thread.started_at)}${ansi.reset}`,
-  );
-  lines.push(
-    `${ansi.bold}${ansi.primary}Ended${ansi.reset}     ${thread.ended_at ? `${ansi.dim}${formatDate(thread.ended_at)}${ansi.reset}` : `${ansi.success}ongoing${ansi.reset}`}`,
-  );
-  lines.push(
-    `${ansi.bold}${ansi.primary}Duration${ansi.reset}  ${ansi.dim}${formatDuration(thread.started_at, thread.ended_at)}${ansi.reset}`,
-  );
-
-  if (isActiveThread) {
     lines.push("");
-    lines.push(
-      `${ansi.bold}${ansi.success}★ Current session thread${ansi.reset}`,
-    );
   }
 
-  lines.push("");
   lines.push(
     `${ansi.bold}${ansi.primary}Interactions${ansi.reset}  ${interactions.length} total`,
   );
@@ -189,6 +165,7 @@ export const ThreadPanel = memo(function ThreadPanel({
   const [threads, setThreads] = useState<Thread[]>([]);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [detailScroll, setDetailScroll] = useState(0);
+  const [focus, setFocus] = useState<FocusState>("list");
   const [typeFilter, setTypeFilter] = useState<Thread["type"] | null>(null);
   const [refreshTick, setRefreshTick] = useState(0);
   const [confirmDelete, setConfirmDelete] = useState(false);
@@ -346,10 +323,21 @@ export const ThreadPanel = memo(function ThreadPanel({
     setRefreshTick((t) => t + 1);
   }, []);
 
+  // Mirror state into refs to dodge Ink's stale-closure bug.
+  const itemCountRef = useLatestRef(filteredThreads.length);
+  const maxDetailScrollRef = useLatestRef(maxDetailScroll);
+  const selectedThreadRef = useLatestRef(selectedThread);
+  const selectedDetailRef = useLatestRef(selectedDetail);
+  const searchingRef = useLatestRef(searching);
+  const confirmDeleteRef = useLatestRef(confirmDelete);
+  const isActiveSelectedRef = useLatestRef(isActiveSelected);
+  const followingRef = useLatestRef(following);
+  const focusRef = useLatestRef(focus);
+
   useInput(
     (input, key) => {
       // Search mode: capture typed characters
-      if (searching) {
+      if (searchingRef.current) {
         if (key.escape) {
           setSearching(false);
           setSearchQuery("");
@@ -373,10 +361,11 @@ export const ThreadPanel = memo(function ThreadPanel({
       }
 
       // Delete confirmation mode
-      if (confirmDelete) {
+      if (confirmDeleteRef.current) {
         if (input === "y" || input === "d") {
-          if (selectedThread && !isActiveSelected) {
-            deleteThread(projectDir, selectedThread.id).then(() => {
+          const t = selectedThreadRef.current;
+          if (t && !isActiveSelectedRef.current) {
+            deleteThread(projectDir, t.id).then(() => {
               forceRefresh();
             });
           }
@@ -387,47 +376,17 @@ export const ThreadPanel = memo(function ThreadPanel({
         return;
       }
 
-      if (key.upArrow) {
-        if (key.shift) {
-          setDetailScroll((s) => Math.max(0, s - 1));
-        } else {
-          setSelectedIndex((i) => Math.max(0, i - 1));
-        }
-        return;
-      }
-      if (key.downArrow) {
-        if (key.shift) {
-          setDetailScroll((s) => Math.min(maxDetailScroll, s + 1));
-        } else {
-          setSelectedIndex((i) => Math.min(filteredThreads.length - 1, i + 1));
-        }
-        return;
-      }
-
-      if (input === "j") {
-        setDetailScroll((s) => Math.min(maxDetailScroll, s + 1));
-        return;
-      }
-      if (input === "k") {
-        setDetailScroll((s) => Math.max(0, s - 1));
-        return;
-      }
-      if (input === "J") {
-        setDetailScroll((s) =>
-          Math.min(maxDetailScroll, s + PAGE_SCROLL_LINES),
-        );
-        return;
-      }
-      if (input === "K") {
-        setDetailScroll((s) => Math.max(0, s - PAGE_SCROLL_LINES));
-        return;
-      }
-      if (input === "g") {
-        setDetailScroll(0);
-        return;
-      }
-      if (input === "G") {
-        setDetailScroll(maxDetailScroll);
+      if (
+        handleListDetailKey(input, key, {
+          focusRef,
+          setFocus,
+          itemCountRef,
+          maxDetailScrollRef,
+          setSelectedIndex,
+          setDetailScroll,
+          pageScrollLines: PAGE_SCROLL_LINES,
+        })
+      ) {
         return;
       }
 
@@ -435,8 +394,8 @@ export const ThreadPanel = memo(function ThreadPanel({
         setTypeFilter((f) => cycleFilter(f, THREAD_TYPES));
         return;
       }
-      if (input === "d" && selectedThread) {
-        if (isActiveSelected) return; // Can't delete active thread
+      if (input === "d" && selectedThreadRef.current) {
+        if (isActiveSelectedRef.current) return; // Can't delete active thread
         setConfirmDelete(true);
         return;
       }
@@ -449,14 +408,17 @@ export const ThreadPanel = memo(function ThreadPanel({
         setSearchQuery("");
         return;
       }
-      if (input === "w" && selectedThread) {
-        if (following) {
+      if (input === "w") {
+        const t = selectedThreadRef.current;
+        if (!t) return;
+        if (followingRef.current) {
           setFollowing(false);
-        } else if (!selectedThread.ended_at) {
-          const maxSeq = selectedDetail?.interactions.at(-1)?.sequence ?? 0;
+        } else if (!t.ended_at) {
+          const maxSeq =
+            selectedDetailRef.current?.interactions.at(-1)?.sequence ?? 0;
           lastSeenSequenceRef.current = maxSeq;
           setFollowing(true);
-          setDetailScroll(maxDetailScroll);
+          setDetailScroll(maxDetailScrollRef.current);
         }
         return;
       }
@@ -583,46 +545,97 @@ export const ThreadPanel = memo(function ThreadPanel({
         flexGrow={1}
         height={visibleRows + 1}
         paddingX={1}
+        {...detailPaneBorderProps(focus)}
         overflow="hidden"
       >
-        {detailVisible.map((line, i) => {
-          const lineNum = detailScroll + i;
-          return <Text key={lineNum}>{line || " "}</Text>;
-        })}
-        {detailLines.length > visibleRows && (
-          <Box>
-            {following && (
-              <Text color={theme.success} bold>
-                {" "}
-                FOLLOWING{" "}
-              </Text>
-            )}
-            <Text dimColor>
-              s search · f filter · ↑↓ select · j/k scroll · d delete ·
-              {selectedThread && !selectedThread.ended_at ? " w follow ·" : ""}{" "}
-              r refresh · [{detailScroll + 1}–
-              {Math.min(detailScroll + visibleRows, detailLines.length)} of{" "}
-              {detailLines.length}]
-            </Text>
-          </Box>
+        {selectedThread && (
+          <ThreadDetailHeader
+            thread={selectedThread}
+            isActiveThread={isActiveSelected}
+          />
         )}
-        {detailLines.length <= visibleRows && <Box flexGrow={1} />}
-        {detailLines.length <= visibleRows && (
-          <Box>
-            {following && (
-              <Text color={theme.success} bold>
-                {" "}
-                FOLLOWING{" "}
-              </Text>
-            )}
-            <Text dimColor>
-              s search · f filter · ↑↓ select · d delete ·
-              {selectedThread && !selectedThread.ended_at ? " w follow ·" : ""}{" "}
-              r refresh
-            </Text>
+        <Box flexDirection="row" flexGrow={1} overflow="hidden">
+          <Box flexDirection="column" flexGrow={1} overflow="hidden">
+            {detailVisible.map((line, i) => {
+              const lineNum = detailScroll + i;
+              return (
+                <Text key={lineNum} wrap="truncate-end">
+                  {line || " "}
+                </Text>
+              );
+            })}
           </Box>
-        )}
+          <Scrollbar
+            total={detailLines.length}
+            visible={visibleRows - 3}
+            offset={detailScroll}
+            height={visibleRows - 3}
+            focused={focus === "detail"}
+          />
+        </Box>
+        <Box>
+          {following && (
+            <Text color={theme.success} bold>
+              {" "}
+              FOLLOWING{" "}
+            </Text>
+          )}
+          <Text dimColor>
+            {focus === "detail"
+              ? "↑↓ scroll · ⇧↑↓ page · g/G top/bot · ← back to list"
+              : `↑↓ select · → enter detail · s search · f filter · d delete${selectedThread && !selectedThread.ended_at ? " · w follow" : ""} · r refresh`}
+          </Text>
+        </Box>
       </Box>
     </Box>
   );
 });
+
+function ThreadDetailHeader({
+  thread,
+  isActiveThread,
+}: {
+  thread: Thread;
+  isActiveThread: boolean;
+}) {
+  return (
+    <Box flexDirection="column">
+      <Box>
+        <Text wrap="truncate-end">
+          <Text bold italic color={theme.info}>
+            {thread.title || "(untitled)"}
+          </Text>
+          {isActiveThread && (
+            <Text bold color={theme.success}>
+              {" ★"}
+            </Text>
+          )}
+        </Text>
+      </Box>
+      <Box>
+        <Text wrap="truncate-end">
+          <Text color={TYPE_COLORS[thread.type]}>
+            {TYPE_ICONS[thread.type]} {TYPE_LABELS[thread.type]}
+          </Text>
+          <Text dimColor>
+            {" · started "}
+            {formatDate(thread.started_at)}
+            {" · "}
+          </Text>
+          {thread.ended_at ? (
+            <Text dimColor>ended {formatDate(thread.ended_at)}</Text>
+          ) : (
+            <Text color={theme.success}>ongoing</Text>
+          )}
+          <Text dimColor>
+            {" · "}
+            {formatDuration(thread.started_at, thread.ended_at)}
+          </Text>
+        </Text>
+      </Box>
+      <Box>
+        <Text dimColor>{"─".repeat(2)}</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/tui/components/ToolPanel.tsx
+++ b/src/tui/components/ToolPanel.tsx
@@ -1,6 +1,13 @@
 import { Box, Text, useInput, useStdout } from "ink";
 import { memo, useEffect, useMemo, useState } from "react";
+import {
+  detailPaneBorderProps,
+  type FocusState,
+  handleListDetailKey,
+} from "../listDetailKeys.ts";
 import { ansi, theme } from "../theme.ts";
+import { useLatestRef } from "../useLatestRef.ts";
+import { Scrollbar } from "./Scrollbar.tsx";
 import { resolveToolDisplay, type ToolCallData } from "./ToolCall.tsx";
 
 interface ToolPanelProps {
@@ -68,26 +75,9 @@ function colorizeValue(value: unknown, indent: number): string {
 function buildDetailAnsi(tool: ToolCallData): string {
   const lines: string[] = [];
 
-  const time = tool.timestamp.toLocaleTimeString([], {
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-  });
+  const { displayInput } = resolveToolDisplay(tool.name, tool.input);
 
-  const { displayName, displayInput } = resolveToolDisplay(
-    tool.name,
-    tool.input,
-  );
-  lines.push(`${ansi.bold}${ansi.info}${displayName}${ansi.reset}`);
-  if (tool.name === "mcp_exec") {
-    lines.push(`${ansi.dim}via mcp_exec${ansi.reset}`);
-  }
-  lines.push(`${ansi.dim}Time: ${time}${ansi.reset}`);
-  if (tool.running) {
-    lines.push(`${ansi.accent}⟳ running${ansi.reset}`);
-  }
-  lines.push("");
-
+  // Body only — name/server/status/time live in the panel header now.
   lines.push(`${ansi.bold}${ansi.primary}Input${ansi.reset}`);
   lines.push(colorizeJson(displayInput));
   lines.push("");
@@ -123,6 +113,7 @@ export const ToolPanel = memo(function ToolPanel({
   const termRows = stdout?.rows ?? 24;
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [detailScroll, setDetailScroll] = useState(0);
+  const [focus, setFocus] = useState<FocusState>("list");
 
   // Reverse-chronological order (most recent first)
   const reversedCalls = useMemo(() => [...toolCalls].reverse(), [toolCalls]);
@@ -163,57 +154,21 @@ export const ToolPanel = memo(function ToolPanel({
     setDetailScroll(0);
   }, [selectedIndex]);
 
+  const itemCountRef = useLatestRef(reversedCalls.length);
+  const maxDetailScrollRef = useLatestRef(maxDetailScroll);
+  const focusRef = useLatestRef(focus);
+
   useInput(
     (input, key) => {
-      if (key.upArrow) {
-        if (key.shift) {
-          // Shift+up scrolls detail
-          setDetailScroll((s) => Math.max(0, s - 1));
-        } else {
-          setSelectedIndex((i) => Math.max(0, i - 1));
-        }
-        return;
-      }
-      if (key.downArrow) {
-        if (key.shift) {
-          setDetailScroll((s) => Math.min(maxDetailScroll, s + 1));
-        } else {
-          setSelectedIndex((i) => Math.min(reversedCalls.length - 1, i + 1));
-        }
-        return;
-      }
-
-      // j/k vim-style for detail scrolling (single line)
-      if (input === "j") {
-        setDetailScroll((s) => Math.min(maxDetailScroll, s + 1));
-        return;
-      }
-      if (input === "k") {
-        setDetailScroll((s) => Math.max(0, s - 1));
-        return;
-      }
-
-      // J/K for page scrolling (hold shift or caps)
-      if (input === "J") {
-        setDetailScroll((s) =>
-          Math.min(maxDetailScroll, s + PAGE_SCROLL_LINES),
-        );
-        return;
-      }
-      if (input === "K") {
-        setDetailScroll((s) => Math.max(0, s - PAGE_SCROLL_LINES));
-        return;
-      }
-
-      // g/G for top/bottom
-      if (input === "g") {
-        setDetailScroll(0);
-        return;
-      }
-      if (input === "G") {
-        setDetailScroll(maxDetailScroll);
-        return;
-      }
+      handleListDetailKey(input, key, {
+        focusRef,
+        setFocus,
+        itemCountRef,
+        maxDetailScrollRef,
+        setSelectedIndex,
+        setDetailScroll,
+        pageScrollLines: PAGE_SCROLL_LINES,
+      });
     },
     { isActive },
   );
@@ -316,27 +271,71 @@ export const ToolPanel = memo(function ToolPanel({
         flexGrow={1}
         height={visibleRows + 1}
         paddingX={1}
+        {...detailPaneBorderProps(focus)}
         overflow="hidden"
       >
-        {detailVisible.map((line, i) => {
-          const lineNum = detailScroll + i;
-          return <Text key={lineNum}>{line || " "}</Text>;
-        })}
-        {detailLines.length > visibleRows && (
-          <Box>
-            <Text dimColor>
-              ↑↓ select · j/k scroll · J/K page · g/G top/bottom · [
-              {detailScroll + 1}–
-              {Math.min(detailScroll + visibleRows, detailLines.length)} of{" "}
-              {detailLines.length}]
-            </Text>
+        {selectedTool && <ToolDetailHeader tool={selectedTool} />}
+        <Box flexDirection="row" flexGrow={1} overflow="hidden">
+          <Box flexDirection="column" flexGrow={1} overflow="hidden">
+            {detailVisible.map((line, i) => {
+              const lineNum = detailScroll + i;
+              return (
+                <Text key={lineNum} wrap="truncate-end">
+                  {line || " "}
+                </Text>
+              );
+            })}
           </Box>
-        )}
-        {detailLines.length <= visibleRows && <Box flexGrow={1} />}
-        {detailLines.length <= visibleRows && (
-          <Text dimColor>↑↓ select tool calls</Text>
-        )}
+          <Scrollbar
+            total={detailLines.length}
+            visible={visibleRows - 3}
+            offset={detailScroll}
+            height={visibleRows - 3}
+            focused={focus === "detail"}
+          />
+        </Box>
+        <Text dimColor>
+          {focus === "detail"
+            ? "↑↓ scroll · ⇧↑↓ page · g/G top/bot · ← back to list"
+            : "↑↓ select · → enter detail"}
+        </Text>
       </Box>
     </Box>
   );
 });
+
+function ToolDetailHeader({ tool }: { tool: ToolCallData }) {
+  const { displayName } = resolveToolDisplay(tool.name, tool.input);
+  const time = tool.timestamp.toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+  const isMcp = tool.name === "mcp_exec";
+  const status = tool.running
+    ? { color: theme.accent, label: "⟳ running" }
+    : tool.isError
+      ? { color: theme.error, label: "✘ error" }
+      : tool.output
+        ? { color: theme.success, label: "✔ done" }
+        : { color: theme.muted, label: "— no output" };
+  return (
+    <Box flexDirection="column">
+      <Box>
+        <Text bold color={theme.info} wrap="truncate-end">
+          {displayName}
+        </Text>
+      </Box>
+      <Box>
+        <Text wrap="truncate-end">
+          <Text dimColor>{isMcp ? "mcp_exec · " : ""}</Text>
+          <Text color={status.color}>{status.label}</Text>
+          <Text dimColor> · {time}</Text>
+        </Text>
+      </Box>
+      <Box>
+        <Text dimColor>{"─".repeat(2)}</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/tui/components/WorkerPanel.tsx
+++ b/src/tui/components/WorkerPanel.tsx
@@ -2,6 +2,13 @@ import { Box, Text, useInput, useStdout } from "ink";
 import { memo, useEffect, useMemo, useState } from "react";
 import { readLogTail } from "../../worker/log-reader.ts";
 import { listWorkers, type Worker } from "../../workers/store.ts";
+import {
+  detailPaneBorderProps,
+  type FocusState,
+  handleListDetailKey,
+} from "../listDetailKeys.ts";
+import { useLatestRef } from "../useLatestRef.ts";
+import { Scrollbar } from "./Scrollbar.tsx";
 
 interface WorkerPanelProps {
   projectDir: string;
@@ -63,6 +70,7 @@ export const WorkerPanel = memo(function WorkerPanel({
   const [logTruncated, setLogTruncated] = useState(false);
   const [logScroll, setLogScroll] = useState(0);
   const [logFollow, setLogFollow] = useState(true);
+  const [focus, setFocus] = useState<FocusState>("list");
 
   useEffect(() => {
     let mounted = true;
@@ -150,74 +158,48 @@ export const WorkerPanel = memo(function WorkerPanel({
     }
   }, [viewMode, logFollow, maxLogScroll]);
 
+  const itemCountRef = useLatestRef(workers.length);
+  const maxLogScrollRef = useLatestRef(maxLogScroll);
+  const focusRef = useLatestRef(focus);
+
+  // The right pane scrolls with arrows when focused. Tee the log scroll into
+  // the follow-state so reaching the bottom resumes follow mode (and any
+  // explicit scroll-up pauses it).
+  const setLogScrollWithFollow = (
+    next: number | ((prev: number) => number),
+  ) => {
+    setLogScroll((s) => {
+      const v = typeof next === "function" ? next(s) : next;
+      const max = maxLogScrollRef.current;
+      const clamped = Math.max(0, Math.min(max, v));
+      setLogFollow(clamped >= max);
+      return clamped;
+    });
+  };
+
   useInput(
     (input, key) => {
       if (!isActive) return;
 
+      // `l` toggles between detail (worker info) and log (tail) view in the
+      // right pane.
       if (input === "l") {
         setViewMode((m) => (m === "log" ? "detail" : "log"));
         return;
       }
 
-      if (key.upArrow) {
-        if (viewMode === "log" && key.shift) {
-          setLogFollow(false);
-          setLogScroll((s) => Math.max(0, s - 1));
-          return;
-        }
-        setSelectedIndex((i) => Math.max(0, i - 1));
+      if (
+        handleListDetailKey(input, key, {
+          focusRef,
+          setFocus,
+          itemCountRef,
+          maxDetailScrollRef: maxLogScrollRef,
+          setSelectedIndex,
+          setDetailScroll: setLogScrollWithFollow,
+          pageScrollLines: PAGE_SCROLL_LINES,
+        })
+      ) {
         return;
-      }
-      if (key.downArrow) {
-        if (viewMode === "log" && key.shift) {
-          setLogScroll((s) => {
-            const next = Math.min(maxLogScroll, s + 1);
-            if (next >= maxLogScroll) setLogFollow(true);
-            return next;
-          });
-          return;
-        }
-        setSelectedIndex((i) => Math.min(workers.length - 1, i + 1));
-        return;
-      }
-
-      if (viewMode === "log") {
-        if (input === "j") {
-          setLogScroll((s) => {
-            const next = Math.min(maxLogScroll, s + 1);
-            if (next >= maxLogScroll) setLogFollow(true);
-            return next;
-          });
-          return;
-        }
-        if (input === "k") {
-          setLogFollow(false);
-          setLogScroll((s) => Math.max(0, s - 1));
-          return;
-        }
-        if (input === "J") {
-          setLogScroll((s) => {
-            const next = Math.min(maxLogScroll, s + PAGE_SCROLL_LINES);
-            if (next >= maxLogScroll) setLogFollow(true);
-            return next;
-          });
-          return;
-        }
-        if (input === "K") {
-          setLogFollow(false);
-          setLogScroll((s) => Math.max(0, s - PAGE_SCROLL_LINES));
-          return;
-        }
-        if (input === "g") {
-          setLogFollow(false);
-          setLogScroll(0);
-          return;
-        }
-        if (input === "G") {
-          setLogFollow(true);
-          setLogScroll(maxLogScroll);
-          return;
-        }
       }
 
       if (input === "f") {
@@ -240,9 +222,11 @@ export const WorkerPanel = memo(function WorkerPanel({
         <Text dimColor> · filter: </Text>
         <Text color="yellow">{filterLabel}</Text>
         <Text dimColor>
-          {viewMode === "log"
-            ? "  · [l] back  [↑↓] select  [j/k] scroll  [g/G] top/bot  [f] filter"
-            : "  · [l] view log  [f] cycle filter  [↑↓] select"}
+          {focus === "detail"
+            ? "  · ↑↓ scroll  ⇧↑↓ page  g/G top/bot  ← back to list  l toggle"
+            : viewMode === "log"
+              ? "  · ↑↓ select  → enter log  l detail  f filter"
+              : "  · ↑↓ select  → enter detail  l view log  f filter"}
         </Text>
       </Box>
 
@@ -287,22 +271,38 @@ export const WorkerPanel = memo(function WorkerPanel({
               );
             })}
           </Box>
-          <Box flexDirection="column" flexGrow={1}>
-            {selected ? (
-              viewMode === "log" ? (
-                <WorkerLogView
-                  worker={selected}
-                  lines={logLines}
-                  scroll={logScroll}
-                  visibleRows={visibleRows}
-                  truncated={logTruncated}
-                  size={logSize}
-                  follow={logFollow}
-                />
-              ) : (
-                <WorkerDetail worker={selected} now={now} />
-              )
-            ) : null}
+          <Box
+            flexDirection="row"
+            flexGrow={1}
+            paddingX={1}
+            {...detailPaneBorderProps(focus)}
+          >
+            <Box flexDirection="column" flexGrow={1}>
+              {selected ? (
+                viewMode === "log" ? (
+                  <WorkerLogView
+                    worker={selected}
+                    lines={logLines}
+                    scroll={logScroll}
+                    visibleRows={visibleRows}
+                    truncated={logTruncated}
+                    size={logSize}
+                    follow={logFollow}
+                  />
+                ) : (
+                  <WorkerDetail worker={selected} now={now} />
+                )
+              ) : null}
+            </Box>
+            {viewMode === "log" && (
+              <Scrollbar
+                total={logLines.length}
+                visible={visibleRows - 1}
+                offset={logScroll}
+                height={visibleRows - 1}
+                focused={focus === "detail"}
+              />
+            )}
           </Box>
         </Box>
       )}

--- a/src/tui/listDetailKeys.ts
+++ b/src/tui/listDetailKeys.ts
@@ -1,0 +1,124 @@
+import type { RefObject } from "react";
+
+/**
+ * Standard list+detail keyboard model used by every non-chat panel.
+ *
+ * Two columns: a list/tree on the left and a detail/preview pane on the
+ * right. The right pane has an explicit focus state — visualized by its
+ * border (dashed when unfocused, solid yellow when focused) — and the
+ * arrow keys mean different things depending on it.
+ *
+ *   focus = "list"  (default)
+ *     ↑ / ↓        Move list selection
+ *     →            Move focus into the detail pane
+ *     ←            (panel-specific; e.g. Context goes up a directory)
+ *
+ *   focus = "detail"
+ *     ↑ / ↓        Scroll the detail pane (one line)
+ *     Shift+↑/↓    Page-scroll the detail pane
+ *     g / G        Jump to top / bottom of the detail pane
+ *     ←            Return focus to the list
+ *
+ * Panels can intercept ←/→ via `onLeftArrow` / `onRightArrow` to add their
+ * own semantics (Context uses → on a folder to drill in). Returning `true`
+ * from those callbacks means "I handled it, don't fall through to the
+ * default focus transition".
+ *
+ * State is read through refs because Ink 7's `useInput` (wrapped in React's
+ * `useEffectEvent`) intermittently sees a stale closure on Bun + React 19.2.
+ */
+export type FocusState = "list" | "detail";
+
+export interface ListDetailKeyOptions {
+  focusRef: RefObject<FocusState>;
+  setFocus: (next: FocusState) => void;
+  itemCountRef: RefObject<number>;
+  maxDetailScrollRef: RefObject<number>;
+  setSelectedIndex: (updater: (prev: number) => number) => void;
+  setDetailScroll: (next: number | ((prev: number) => number)) => void;
+  pageScrollLines?: number;
+  /** Return true if the panel handled ←; otherwise falls through to default. */
+  onLeftArrow?: () => boolean;
+  /** Return true if the panel handled →; otherwise falls through to default. */
+  onRightArrow?: () => boolean;
+}
+
+const DEFAULT_PAGE_SCROLL = 10;
+
+export function handleListDetailKey(
+  input: string,
+  // biome-ignore lint/suspicious/noExplicitAny: Ink's Key type is not exported
+  key: any,
+  opts: ListDetailKeyOptions,
+): boolean {
+  const page = opts.pageScrollLines ?? DEFAULT_PAGE_SCROLL;
+  const focus = opts.focusRef.current;
+
+  if (key.rightArrow) {
+    if (opts.onRightArrow?.()) return true;
+    if (focus === "list") opts.setFocus("detail");
+    return true;
+  }
+  if (key.leftArrow) {
+    if (opts.onLeftArrow?.()) return true;
+    if (focus === "detail") opts.setFocus("list");
+    return true;
+  }
+  if (key.upArrow) {
+    if (focus === "detail") {
+      const step = key.shift ? page : 1;
+      opts.setDetailScroll((s) => Math.max(0, s - step));
+    } else {
+      opts.setSelectedIndex((i) => Math.max(0, i - 1));
+    }
+    return true;
+  }
+  if (key.downArrow) {
+    if (focus === "detail") {
+      const step = key.shift ? page : 1;
+      opts.setDetailScroll((s) =>
+        Math.min(opts.maxDetailScrollRef.current, s + step),
+      );
+    } else {
+      opts.setSelectedIndex((i) =>
+        Math.min(opts.itemCountRef.current - 1, i + 1),
+      );
+    }
+    return true;
+  }
+  // Jump keys only make sense in the detail pane.
+  if (focus === "detail") {
+    if (input === "g") {
+      opts.setDetailScroll(0);
+      return true;
+    }
+    if (input === "G") {
+      opts.setDetailScroll(opts.maxDetailScrollRef.current);
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Visual style for the right pane's border. Panels render the right column
+ * inside a `<Box>` with these props so the focus state is obvious at a
+ * glance: dashed dim border when the list owns focus, bold yellow border
+ * when the detail pane owns it.
+ */
+const DASHED_BORDER = {
+  topLeft: "┌",
+  top: "┄",
+  topRight: "┐",
+  left: "┆",
+  bottomLeft: "└",
+  bottom: "┄",
+  bottomRight: "┘",
+  right: "┆",
+} as const;
+
+export function detailPaneBorderProps(focus: FocusState) {
+  return focus === "detail"
+    ? { borderStyle: "bold" as const, borderColor: "yellow" as const }
+    : { borderStyle: DASHED_BORDER, borderColor: "gray" as const };
+}

--- a/src/tui/useLatestRef.ts
+++ b/src/tui/useLatestRef.ts
@@ -1,0 +1,18 @@
+import { useRef } from "react";
+
+/**
+ * Returns a ref whose `.current` is always the latest committed value.
+ *
+ * Workaround for a stale-closure issue we hit with Ink 7's `useInput`: the
+ * callback we pass is wrapped in React's `useEffectEvent`, but on Bun + React
+ * 19.2 the keyboard handler often sees the *initial* render's closure even
+ * after subsequent commits (e.g. an `entries` array still appearing empty
+ * after the populating `setState` has rendered). Reading from a ref that's
+ * eagerly assigned during render side-steps the issue — refs always read the
+ * latest assigned value regardless of which closure the caller is in.
+ */
+export function useLatestRef<T>(value: T) {
+  const ref = useRef<T>(value);
+  ref.current = value;
+  return ref;
+}

--- a/test/chat/session.test.ts
+++ b/test/chat/session.test.ts
@@ -105,4 +105,28 @@ describe("clearChatSession", () => {
       await endChatSession(session);
     }
   });
+
+  test("aborts an in-flight stream so its callbacks stop firing", async () => {
+    // Issue #190: /clear must abort the active stream synchronously so the
+    // turn it interrupts can't finalize a stale assistant segment into the
+    // freshly-cleared UI on the next user submission.
+    const session = await startChatSession(projectDir);
+    try {
+      let aborted = false;
+      const fakeStream = {
+        aborted: false,
+        abort() {
+          aborted = true;
+          this.aborted = true;
+        },
+      };
+      // biome-ignore lint/suspicious/noExplicitAny: minimal MessageStream shape for the abort path
+      session.activeStream = fakeStream as any;
+      await clearChatSession(session);
+      expect(aborted).toBe(true);
+      expect(session.activeStream).toBeNull();
+    } finally {
+      await endChatSession(session);
+    }
+  });
 });


### PR DESCRIPTION
Closes #190.

## Summary

- **Tab switching**: `Ctrl+<letter>` jumps directly to a tab from anywhere — `^a` Chat, `^o` Tools, `^n` Context, `^t` Tasks, `^r` Threads, `^s` Schedules, `^w` Workers, plus `?` for the Help tab from any non-chat tab. `Tab`/`Shift+Tab` cycling and `1–8` digit jumps are gone.
- **Uniform list/detail focus model** across every non-chat panel, codified in `src/tui/listDetailKeys.ts`. Right pane has a dashed dim border by default and a bold yellow border when focused. `↑/↓` navigates the list; `→` enters the detail pane; `←` returns. In detail focus, `↑/↓` scroll one line, `Shift+↑/↓` page-scroll, `g`/`G` jump to top/bottom. ContextPanel is now a true two-column tree+preview; `→` drills into a folder, `←` walks up.
- **Detail-pane headers**: each panel's right pane has a 2–3 line header (filename + index status for Context, name + status + dates for Tasks, title + type + timing for Threads, name + freq + last run for Schedules, displayName + status + time for Tools), a vertical scrollbar (yellow when focused), and `wrap=\"truncate-end\"` on every body row so long lines can't push the right border out of column.
- **`/clear` regression fix** (was: previous thread's messages reappeared on the next user submission). `clearChatSession` now aborts the active stream up front, and the App-level handler awaits processQueue to quiesce before resetting state. Tests added.
- **Stale-closure workaround** for Ink 7's `useInput` on Bun + React 19.2 via a small `useLatestRef` helper — without it, ContextPanel's `→` saw an empty `entries` even after the tree rendered.
- `/help` in chat is now terse (slash commands + skills + a pointer to the Help tab); CLI `chat --help`, `docs/tui.md`, and `HelpPanel` all updated to match. Version bumped to 0.14.0.

## Test plan

- [ ] \`bun test\` (795 tests passing locally, includes new \`clearChatSession\` abort regression test)
- [ ] \`bun run lint\` clean
- [ ] Smoke-test \`bun dev chat\`: Ctrl+letter jumps from any tab, \`?\` opens Help, \`/clear\` mid-stream then send a follow-up shows no leaked messages
- [ ] Per-panel: \`→\` enters detail, border turns yellow, scrollbar visible; \`Shift+↑/↓\` page-scrolls; \`←\` returns to list

🤖 Generated with [Claude Code](https://claude.com/claude-code)