### PR TITLE
Pause + grey out TUI animations after idle timeout (#198)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,6 +20,7 @@ project directory. The full schema lives in `src/config/schemas.ts`.
   "worker_stopped_retention_seconds": 3600,
   "schedule_min_interval_seconds": 60,
   "schedule_claim_stale_seconds": 300,
+  "tui_idle_timeout_seconds": 180,
   "log_level": ""
 }
 ```
@@ -45,6 +46,7 @@ project directory. The full schema lives in `src/config/schemas.ts`.
 | `worker_stopped_retention_seconds` | `3600` | Cleanly-stopped workers older than this are deleted from the `workers` table. Dead workers are kept as forensic evidence and not auto-pruned. |
 | `schedule_min_interval_seconds` | `60` | Minimum gap between successive evaluations of the same schedule. A schedule that ran less than this many seconds ago is skipped. |
 | `schedule_claim_stale_seconds` | `300` | If a worker claimed a schedule but never released it (crash), another worker may steal the claim after this many seconds. |
+| `tui_idle_timeout_seconds` | `180` | Seconds of inactivity (no keystrokes, no streamed agent tokens, no tool events) before the chat TUI freezes its visible animations and pauses the status-bar count refresh. Animations resume on the next activity. Set to `0` to disable (always animate — useful for demo recordings). |
 | `log_level` | `""` | Verbosity for `botholomew` CLI logs. One of `silent`, `error`, `warn`, `info`, `debug`. Empty string falls back to the runtime default (`info` normally, `error` under `NODE_ENV=test`). `BOTHOLOMEW_LOG_LEVEL` env var overrides this. |
 
 ---

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -394,6 +394,13 @@ A few choices worth knowing if you're reading or modifying the TUI:
   `disambiguateEscapeCodes` flag when starting Ink so modifiers
   (`Shift+↑`, `⌥+Enter`, etc.) are distinguishable from plain arrow /
   Enter presses on supporting terminals.
+- **Idle freeze.** After `tui_idle_timeout_seconds` (default 180) with no
+  keystrokes and no streamed agent activity, the cursor blink, status-bar
+  mascot, and status-bar count refresh all pause. Frozen elements (mascot,
+  status-bar text, input-bar border + prompt) also turn grey so it's
+  obvious the UI is idle rather than hung. Everything resumes — and
+  recolors — on the next keystroke or stream event. Set
+  `tui_idle_timeout_seconds: 0` to disable (useful for demo recordings).
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { loadConfig } from "../config/loader.ts";
 
 export function registerChatCommand(program: Command) {
   program
@@ -29,6 +30,8 @@ export function registerChatCommand(program: Command) {
       const React = await import("react");
       const { App } = await import("../tui/App.tsx");
       const dir = program.opts().dir;
+      const config = await loadConfig(dir);
+      const idleTimeoutMs = config.tui_idle_timeout_seconds * 1000;
 
       // VHS/ttyd doesn't fully negotiate the Kitty Keyboard protocol, so
       // Ink's "enabled" mode drops non-text keystrokes (Tab, Escape) under
@@ -41,6 +44,7 @@ export function registerChatCommand(program: Command) {
           projectDir: dir,
           threadId: opts.threadId,
           initialPrompt: opts.prompt,
+          idleTimeoutMs,
         }),
         {
           exitOnCtrlC: false,

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -14,6 +14,7 @@ export interface BotholomewConfig {
   worker_stopped_retention_seconds?: number;
   schedule_min_interval_seconds?: number;
   schedule_claim_stale_seconds?: number;
+  tui_idle_timeout_seconds?: number;
   log_level?: string;
 }
 
@@ -33,5 +34,6 @@ export const DEFAULT_CONFIG: Required<BotholomewConfig> = {
   worker_stopped_retention_seconds: 3600,
   schedule_min_interval_seconds: 60,
   schedule_claim_stale_seconds: 300,
+  tui_idle_timeout_seconds: 180,
   log_level: "",
 };

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -33,6 +33,7 @@ import { ThreadPanel } from "./components/ThreadPanel.tsx";
 import type { ToolCallData } from "./components/ToolCall.tsx";
 import { ToolPanel } from "./components/ToolPanel.tsx";
 import { WorkerPanel } from "./components/WorkerPanel.tsx";
+import { IdleProvider, useIdle } from "./idle.tsx";
 import { buildSlashCommands, getSlashMatches } from "./slashCompletion.ts";
 import { ansi } from "./theme.ts";
 
@@ -40,6 +41,7 @@ interface AppProps {
   projectDir: string;
   threadId?: string;
   initialPrompt?: string;
+  idleTimeoutMs: number;
 }
 
 let nextMsgId = 0;
@@ -138,8 +140,32 @@ export function App({
   projectDir,
   threadId: resumeThreadId,
   initialPrompt,
+  idleTimeoutMs,
 }: AppProps) {
+  return (
+    <IdleProvider timeoutMs={idleTimeoutMs}>
+      <AppInner
+        projectDir={projectDir}
+        threadId={resumeThreadId}
+        initialPrompt={initialPrompt}
+      />
+    </IdleProvider>
+  );
+}
+
+interface AppInnerProps {
+  projectDir: string;
+  threadId?: string;
+  initialPrompt?: string;
+}
+
+function AppInner({
+  projectDir,
+  threadId: resumeThreadId,
+  initialPrompt,
+}: AppInnerProps) {
   const { exit } = useApp();
+  const { markActivity } = useIdle();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [messagesEpoch, setMessagesEpoch] = useState(0);
   const [inputValue, setInputValue] = useState("");
@@ -265,9 +291,14 @@ export function App({
   const slashCommandsRef = useRef<SlashCommand[]>([]);
   const inputValueRef = useRef("");
 
+  const markActivityRef = useRef(markActivity);
+  markActivityRef.current = markActivity;
+
   const stableAppHandler = useCallback(
     // biome-ignore lint/suspicious/noExplicitAny: Ink's Key type is not exported
     (input: string, key: any) => {
+      markActivityRef.current();
+
       // Ctrl+C exits
       if (input === "c" && key.ctrl) {
         exit();
@@ -407,12 +438,15 @@ export function App({
             if (now - lastStreamFlush >= 50) {
               setStreamingText(currentText);
               lastStreamFlush = now;
+              markActivityRef.current();
             }
           },
           onToolPreparing: (id, name) => {
+            markActivityRef.current();
             setPreparingTool({ id, name });
           },
           onToolStart: (id, name, input) => {
+            markActivityRef.current();
             if (currentText) {
               finalizeSegment();
             }
@@ -428,6 +462,7 @@ export function App({
             setPreparingTool(null);
           },
           onToolEnd: (id, _name, output, isError, meta) => {
+            markActivityRef.current();
             const tc = pendingToolCalls.find((t) => t.id === id);
             if (tc) {
               tc.running = false;

--- a/src/tui/components/InputBar.tsx
+++ b/src/tui/components/InputBar.tsx
@@ -9,6 +9,7 @@ import {
   useState,
 } from "react";
 import type { SlashCommand } from "../../skills/commands.ts";
+import { useIdle } from "../idle.tsx";
 import { getSlashMatches, shouldSubmitOnEnter } from "../slashCompletion.ts";
 import { SlashCommandPopup } from "./SlashCommandPopup.tsx";
 
@@ -38,6 +39,7 @@ export const InputBar = memo(function InputBar({
   const [popupDismissed, setPopupDismissed] = useState(false);
   const savedInput = useRef("");
   const lastActivity = useRef(Date.now());
+  const { isIdle } = useIdle();
 
   // Refs for values read inside the input handler — eagerly updated so rapid
   // keystrokes that arrive before React re-renders always see fresh state.
@@ -94,7 +96,7 @@ export const InputBar = memo(function InputBar({
   // Blink cursor when input is active — skip ticks while typing so the
   // cursor stays solid and we avoid unnecessary renders during rapid input.
   useEffect(() => {
-    if (disabled) {
+    if (disabled || isIdle) {
       setCursorVisible(true);
       return;
     }
@@ -105,7 +107,7 @@ export const InputBar = memo(function InputBar({
       setCursorVisible((prev) => (prev === phase ? prev : phase));
     }, 530);
     return () => clearInterval(id);
-  }, [disabled]);
+  }, [disabled, isIdle]);
 
   // Stable input handler — the callback reference never changes, which
   // prevents Ink's useInput from removing/re-adding the stdin listener on
@@ -337,14 +339,14 @@ export const InputBar = memo(function InputBar({
       <Box
         flexDirection="column"
         borderStyle="single"
-        borderColor={disabled ? "gray" : "green"}
+        borderColor={disabled || isIdle ? "gray" : "green"}
         paddingX={1}
       >
         {header}
         {!disabled && (
           <Box flexDirection="column">
             <Box>
-              <Text color="green">{"› "}</Text>
+              <Text color={isIdle ? "gray" : "green"}>{"› "}</Text>
               {placeholder ? (
                 <Text dimColor>Type a message...</Text>
               ) : (

--- a/src/tui/components/Logo.tsx
+++ b/src/tui/components/Logo.tsx
@@ -1,5 +1,6 @@
 import { Box, Text } from "ink";
 import { useEffect, useState } from "react";
+import { useIdle } from "../idle.tsx";
 import { theme } from "../theme.ts";
 
 const STARTUP_FRAMES = [
@@ -23,8 +24,10 @@ const IDLE_MS = 2000;
 export function AnimatedLogo() {
   const [frameIndex, setFrameIndex] = useState(0);
   const [startupDone, setStartupDone] = useState(false);
+  const { isIdle } = useIdle();
 
   useEffect(() => {
+    if (isIdle) return;
     const interval = setInterval(
       () => {
         setFrameIndex((prev) => {
@@ -42,20 +45,21 @@ export function AnimatedLogo() {
       startupDone ? IDLE_MS : STARTUP_MS,
     );
     return () => clearInterval(interval);
-  }, [startupDone]);
+  }, [startupDone, isIdle]);
 
   const frames = startupDone ? IDLE_FRAMES : STARTUP_FRAMES;
   // biome-ignore lint: frameIndex is always in bounds
   const frame = frames[frameIndex]!;
+  const color = isIdle ? "gray" : theme.accent;
 
   return (
     <Box flexDirection="column" alignItems="center" justifyContent="center">
       {frame.map((line) => (
-        <Text key={line} color={theme.accent}>
+        <Text key={line} color={color}>
           {line}
         </Text>
       ))}
-      <Text bold color={theme.accent}>
+      <Text bold color={color}>
         Botholomew
       </Text>
       <Text dimColor>Starting chat session...</Text>
@@ -67,13 +71,19 @@ const CHAR_FRAMES = ["{o,o}", "{o,o}", "{-,-}", "{o,o}"];
 
 export function LogoChar() {
   const [frameIndex, setFrameIndex] = useState(0);
+  const { isIdle } = useIdle();
 
   useEffect(() => {
+    if (isIdle) return;
     const interval = setInterval(() => {
       setFrameIndex((prev) => (prev + 1) % CHAR_FRAMES.length);
     }, IDLE_MS);
     return () => clearInterval(interval);
-  }, []);
+  }, [isIdle]);
 
-  return <Text color={theme.accent}>{CHAR_FRAMES[frameIndex]} </Text>;
+  return (
+    <Text color={isIdle ? "gray" : theme.accent}>
+      {CHAR_FRAMES[frameIndex]}{" "}
+    </Text>
+  );
 }

--- a/src/tui/components/SleepProgress.tsx
+++ b/src/tui/components/SleepProgress.tsx
@@ -1,5 +1,6 @@
 import { Box, Text } from "ink";
 import { useEffect, useState } from "react";
+import { useIdle } from "../idle.tsx";
 import { theme } from "../theme.ts";
 
 interface SleepProgressProps {
@@ -17,11 +18,13 @@ export function SleepProgress({
   reason,
 }: SleepProgressProps) {
   const [now, setNow] = useState(() => Date.now());
+  const { isIdle } = useIdle();
 
   useEffect(() => {
+    if (isIdle) return;
     const id = setInterval(() => setNow(Date.now()), TICK_MS);
     return () => clearInterval(id);
-  }, []);
+  }, [isIdle]);
 
   const totalMs = totalSeconds * 1000;
   const elapsedMs = Math.min(totalMs, Math.max(0, now - startedAt.getTime()));
@@ -34,7 +37,7 @@ export function SleepProgress({
     <Box flexDirection="column">
       <Box>
         <Text dimColor>{"    "}</Text>
-        <Text color={theme.accent}>{bar}</Text>
+        <Text color={isIdle ? "gray" : theme.accent}>{bar}</Text>
         <Text dimColor>
           {" "}
           {elapsedSec}s / {totalSeconds}s

--- a/src/tui/components/StatusBar.tsx
+++ b/src/tui/components/StatusBar.tsx
@@ -2,6 +2,7 @@ import { Box, Text } from "ink";
 import { useEffect, useState } from "react";
 import { listTasks } from "../../tasks/store.ts";
 import { listWorkers } from "../../workers/store.ts";
+import { useIdle } from "../idle.tsx";
 import { LogoChar } from "./Logo.tsx";
 
 interface StatusBarProps {
@@ -32,8 +33,10 @@ export function StatusBar({
     pendingCount: 0,
     inProgressCount: 0,
   });
+  const { isIdle } = useIdle();
 
   useEffect(() => {
+    if (isIdle) return;
     let mounted = true;
 
     // Errors here (e.g. transient DuckDB lock conflicts while a freshly
@@ -66,32 +69,32 @@ export function StatusBar({
       mounted = false;
       clearInterval(interval);
     };
-  }, [projectDir, onWorkerStatusChange]);
+  }, [projectDir, onWorkerStatusChange, isIdle]);
 
   return (
     <Box paddingX={0}>
       <LogoChar />
-      <Text bold color="blue">
+      <Text bold color={isIdle ? "gray" : "blue"}>
         Botholomew
       </Text>
       {chatTitle && (
         <>
           <Text dimColor> | </Text>
-          <Text color="cyan" bold italic>
+          <Text color={isIdle ? "gray" : "cyan"} bold italic>
             {chatTitle.length > 30 ? `${chatTitle.slice(0, 29)}…` : chatTitle}
           </Text>
         </>
       )}
       <Text dimColor> | </Text>
       {status.workerCount > 0 ? (
-        <Text color="green">
+        <Text color={isIdle ? "gray" : "green"}>
           {status.workerCount} worker{status.workerCount === 1 ? "" : "s"}
         </Text>
       ) : (
-        <Text color="yellow">no workers</Text>
+        <Text color={isIdle ? "gray" : "yellow"}>no workers</Text>
       )}
       <Text dimColor> | </Text>
-      <Text>
+      <Text dimColor={isIdle}>
         {status.pendingCount} pending, {status.inProgressCount} active
       </Text>
     </Box>

--- a/src/tui/idle.tsx
+++ b/src/tui/idle.tsx
@@ -1,0 +1,68 @@
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+const CHECK_INTERVAL_MS = 10_000;
+
+export function shouldBeIdle(
+  lastActivity: number,
+  now: number,
+  timeoutMs: number,
+): boolean {
+  if (timeoutMs <= 0) return false;
+  return now - lastActivity >= timeoutMs;
+}
+
+interface IdleContextValue {
+  isIdle: boolean;
+  markActivity: () => void;
+}
+
+const IdleContext = createContext<IdleContextValue>({
+  isIdle: false,
+  markActivity: () => {},
+});
+
+interface IdleProviderProps {
+  timeoutMs: number;
+  children: ReactNode;
+}
+
+export function IdleProvider({ timeoutMs, children }: IdleProviderProps) {
+  const lastActivityRef = useRef(Date.now());
+  const [isIdle, setIsIdle] = useState(false);
+  const isIdleRef = useRef(isIdle);
+  isIdleRef.current = isIdle;
+
+  const markActivity = useCallback(() => {
+    lastActivityRef.current = Date.now();
+    if (isIdleRef.current) {
+      setIsIdle(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (timeoutMs <= 0) return;
+    const id = setInterval(() => {
+      const idle = shouldBeIdle(lastActivityRef.current, Date.now(), timeoutMs);
+      setIsIdle((prev) => (prev === idle ? prev : idle));
+    }, CHECK_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [timeoutMs]);
+
+  return (
+    <IdleContext.Provider value={{ isIdle, markActivity }}>
+      {children}
+    </IdleContext.Provider>
+  );
+}
+
+export function useIdle(): IdleContextValue {
+  return useContext(IdleContext);
+}

--- a/test/tui/idle.test.ts
+++ b/test/tui/idle.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { shouldBeIdle } from "../../src/tui/idle.tsx";
+
+describe("shouldBeIdle", () => {
+  const TIMEOUT = 180_000;
+
+  test("fresh activity is not idle", () => {
+    const now = 1_000_000;
+    expect(shouldBeIdle(now, now, TIMEOUT)).toBe(false);
+  });
+
+  test("activity within the window is not idle", () => {
+    const last = 1_000_000;
+    expect(shouldBeIdle(last, last + TIMEOUT - 1, TIMEOUT)).toBe(false);
+  });
+
+  test("activity exactly at the threshold is idle", () => {
+    const last = 1_000_000;
+    expect(shouldBeIdle(last, last + TIMEOUT, TIMEOUT)).toBe(true);
+  });
+
+  test("activity past the threshold is idle", () => {
+    const last = 1_000_000;
+    expect(shouldBeIdle(last, last + TIMEOUT + 1, TIMEOUT)).toBe(true);
+  });
+
+  test("timeout of 0 disables idle detection", () => {
+    const last = 1_000_000;
+    expect(shouldBeIdle(last, last + 10 * TIMEOUT, 0)).toBe(false);
+  });
+
+  test("negative timeout disables idle detection", () => {
+    const last = 1_000_000;
+    expect(shouldBeIdle(last, last + 10 * TIMEOUT, -1)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- New `tui_idle_timeout_seconds` config (default 180, `0` disables): after that many seconds with no keystrokes and no streamed agent activity, the chat TUI freezes its visible animations (cursor blink, status-bar mascot, status-bar count refresh, sleep-progress tick).
- A single `IdleProvider` (`src/tui/idle.tsx`) tracks `lastActivity` and exposes `useIdle()`; `App.tsx` calls `markActivity()` on every keystroke and on `onToken` / `onToolPreparing` / `onToolStart` / `onToolEnd`.
- Frozen elements (mascot, status-bar text, input-bar border + prompt, sleep bar) turn grey so the UI is clearly asleep rather than hung — everything snaps back on the next activity.
- Panel-specific polls (Tasks/Threads/Workers/Schedules/chat-title) intentionally keep ticking — pausing them would silently desync data when the user switches tabs.

Resolves #198.

## Test plan
- [x] `bun run lint`
- [x] `bun test` (added `test/tui/idle.test.ts` covering `shouldBeIdle` thresholds + the `timeoutMs<=0` escape hatch)
- [ ] Manual: set `tui_idle_timeout_seconds: 10`, confirm cursor goes solid + grey, mascot freezes + greys, status counts dim, then a keystroke restores everything
- [ ] Manual: trigger a long agent stream, confirm animations stay live while tokens arrive

🤖 Generated with [Claude Code](https://claude.com/claude-code)