### PR TITLE
TUI: unify delete with d+d arm/confirm pattern (#197)

### DIFF
--- a/docs/tui.md
+++ b/docs/tui.md
@@ -332,11 +332,12 @@ move the selection (list focus) or scroll the detail (detail focus).
 | `f` | Cycle filter (status, type, enabled — per panel) |
 | `p` | Cycle priority filter (Tasks only) |
 | `r` | Refresh from DB |
-| `d` | Delete with confirmation (Threads, Schedules, Context) |
+| `d` then `d` | Delete the selected item (Tasks, Threads, Schedules, Context). First press arms; second confirms. Any other key or 3s of inactivity disarms. The active chat thread cannot be deleted. |
 | `e` | Toggle enable/disable (Schedules only) |
 | `s` or `/` | Search (Threads only) |
 | `w` | Toggle follow-mode (Threads only) |
 | `l` | Toggle detail / log view (Workers only) |
+| `d` then `d` (Workers, log view) | Delete the worker's on-disk log file. The worker record itself is preserved. |
 
 ### Context tab
 
@@ -346,7 +347,7 @@ move the selection (list focus) or scroll the detail (detail focus).
 | `→` | Drill into folder · open file preview |
 | `←` | Go up one directory · close preview |
 | `/` | Search |
-| `d` | Delete selected item |
+| `d` then `d` | Delete the selected file or folder. Folders delete recursively; index entries are removed and the search index is rebuilt. Symlinks are unlinked safely (the target is never touched). |
 
 ---
 

--- a/src/db/embeddings.ts
+++ b/src/db/embeddings.ts
@@ -94,6 +94,23 @@ export async function deleteIndexedPath(
   return result.changes;
 }
 
+/**
+ * Remove every indexed entry whose path equals `prefix` or lives beneath
+ * `prefix/`. Used when a folder is deleted from `context/` and we need to
+ * drop all child entries in one shot.
+ */
+export async function deleteIndexedPathsUnder(
+  conn: DbConnection,
+  prefix: string,
+): Promise<number> {
+  const result = await conn.queryRun(
+    "DELETE FROM context_index WHERE path = ?1 OR path LIKE ?2",
+    prefix,
+    `${prefix}/%`,
+  );
+  return result.changes;
+}
+
 export interface IndexedPathSummary {
   path: string;
   content_hash: string;

--- a/src/tui/components/ContextPanel.tsx
+++ b/src/tui/components/ContextPanel.tsx
@@ -3,13 +3,17 @@ import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { getDbPath } from "../../constants.ts";
 import {
   type ContextEntry,
+  deleteContextPath,
   listContextDir,
   readContextFile,
 } from "../../context/store.ts";
 import { withDb } from "../../db/connection.ts";
 import {
+  deleteIndexedPath,
+  deleteIndexedPathsUnder,
   getIndexedPath,
   type IndexedPathSummary,
+  rebuildSearchIndex,
 } from "../../db/embeddings.ts";
 import {
   detailPaneBorderProps,
@@ -18,7 +22,9 @@ import {
 } from "../listDetailKeys.ts";
 import { isMarkdownPath, renderMarkdown } from "../markdown.ts";
 import { theme } from "../theme.ts";
+import { useDeleteConfirm } from "../useDeleteConfirm.ts";
 import { useLatestRef } from "../useLatestRef.ts";
+import { DeleteArmedBanner } from "./DeleteArmedBanner.tsx";
 import { Scrollbar } from "./Scrollbar.tsx";
 
 interface ContextPanelProps {
@@ -163,8 +169,33 @@ export const ContextPanel = memo(function ContextPanel({
   const currentPathRef = useLatestRef(currentPath);
   const focusRef = useLatestRef(focus);
 
+  const deleteConfirm = useDeleteConfirm(() => {
+    const entry = selectedEntryRef.current;
+    if (!entry) return;
+    const path = entry.path;
+    const isDirectory = entry.is_directory;
+    (async () => {
+      try {
+        await deleteContextPath(projectDir, path, { recursive: isDirectory });
+        await withDb(getDbPath(projectDir), async (conn) => {
+          if (isDirectory) {
+            await deleteIndexedPathsUnder(conn, path);
+          } else {
+            await deleteIndexedPath(conn, path);
+          }
+          await rebuildSearchIndex(conn);
+        });
+      } catch {
+        // ignore — refresh will reflect any partial state
+      }
+      refresh(currentPathRef.current);
+    })();
+  });
+
   useInput(
     (input, key) => {
+      if (input !== "d") deleteConfirm.cancel();
+
       if (
         handleListDetailKey(input, key, {
           focusRef,
@@ -199,6 +230,12 @@ export const ContextPanel = memo(function ContextPanel({
         return;
       }
 
+      if (input === "d") {
+        const entry = selectedEntryRef.current;
+        if (!entry) return;
+        deleteConfirm.pressDelete(entry.path);
+        return;
+      }
       if (input === "r") {
         refresh(currentPathRef.current);
       }
@@ -322,11 +359,15 @@ export const ContextPanel = memo(function ContextPanel({
         ) : (
           <Text dimColor>(no item selected)</Text>
         )}
+        <DeleteArmedBanner
+          armed={deleteConfirm.armed}
+          label={deleteConfirm.armedLabel}
+        />
         <Box>
           <Text dimColor>
             {focus === "detail"
               ? "↑↓ scroll · ⇧↑↓ page · g/G top/bot · ← back to list"
-              : "↑↓ select · → drill in/enter detail · ← up · r refresh"}
+              : "↑↓ select · → drill in/enter detail · ← up · d delete (×2) · r refresh"}
           </Text>
         </Box>
       </Box>

--- a/src/tui/components/DeleteArmedBanner.tsx
+++ b/src/tui/components/DeleteArmedBanner.tsx
@@ -1,0 +1,18 @@
+import { Box, Text } from "ink";
+import { theme } from "../theme.ts";
+
+interface DeleteArmedBannerProps {
+  armed: boolean;
+  label: string | null;
+}
+
+export function DeleteArmedBanner({ armed, label }: DeleteArmedBannerProps) {
+  if (!armed) return null;
+  return (
+    <Box>
+      <Text color={theme.error} bold>
+        ⚠ Press d again to delete {label ?? ""} (any other key cancels)
+      </Text>
+    </Box>
+  );
+}

--- a/src/tui/components/HelpPanel.tsx
+++ b/src/tui/components/HelpPanel.tsx
@@ -112,18 +112,28 @@ export const HelpPanel = memo(function HelpPanel({
         <Text bold color="cyan">
           Per-panel actions
         </Text>
-        <Text>
-          {"  "}Tasks{"          "}f filter · p priority · d delete · r refresh
+        <Text dimColor>
+          {"  "}d delete needs two presses — arms first, confirms second
+          (cancels on any other key or after 3s)
         </Text>
         <Text>
-          {"  "}Threads{"        "}f filter · s/ search · w follow · d delete ·
-          r refresh
+          {"  "}Tasks{"          "}f filter · p priority · d delete (×2) · r
+          refresh
         </Text>
         <Text>
-          {"  "}Schedules{"      "}f filter · e toggle · d delete · r refresh
+          {"  "}Threads{"        "}f filter · s/ search · w follow · d delete
+          (×2) · r refresh
         </Text>
         <Text>
-          {"  "}Workers{"        "}f filter · l toggle log/detail
+          {"  "}Schedules{"      "}f filter · e toggle · d delete (×2) · r
+          refresh
+        </Text>
+        <Text>
+          {"  "}Context{"        "}d delete (×2) · r refresh
+        </Text>
+        <Text>
+          {"  "}Workers{"        "}f filter · l toggle log/detail · d delete log
+          (×2, log view)
         </Text>
       </Box>
 

--- a/src/tui/components/SchedulePanel.tsx
+++ b/src/tui/components/SchedulePanel.tsx
@@ -12,7 +12,9 @@ import {
   handleListDetailKey,
 } from "../listDetailKeys.ts";
 import { ansi, theme } from "../theme.ts";
+import { useDeleteConfirm } from "../useDeleteConfirm.ts";
 import { useLatestRef } from "../useLatestRef.ts";
+import { DeleteArmedBanner } from "./DeleteArmedBanner.tsx";
 import { Scrollbar } from "./Scrollbar.tsx";
 
 interface SchedulePanelProps {
@@ -94,7 +96,6 @@ export const SchedulePanel = memo(function SchedulePanel({
   const [focus, setFocus] = useState<FocusState>("list");
   const [enabledFilter, setEnabledFilter] = useState<boolean | null>(null);
   const [refreshTick, setRefreshTick] = useState(0);
-  const [confirmDelete, setConfirmDelete] = useState(false);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: refreshTick triggers manual refresh
   useEffect(() => {
@@ -159,25 +160,19 @@ export const SchedulePanel = memo(function SchedulePanel({
   const itemCountRef = useLatestRef(schedules.length);
   const maxDetailScrollRef = useLatestRef(maxDetailScroll);
   const selectedScheduleRef = useLatestRef(selectedSchedule);
-  const confirmDeleteRef = useLatestRef(confirmDelete);
   const focusRef = useLatestRef(focus);
+
+  const deleteConfirm = useDeleteConfirm(() => {
+    const s = selectedScheduleRef.current;
+    if (!s) return;
+    deleteSchedule(projectDir, s.id).then(() => {
+      forceRefresh();
+    });
+  });
 
   useInput(
     (input, key) => {
-      if (confirmDeleteRef.current) {
-        if (input === "y" || input === "d") {
-          const s = selectedScheduleRef.current;
-          if (s) {
-            deleteSchedule(projectDir, s.id).then(() => {
-              forceRefresh();
-            });
-          }
-          setConfirmDelete(false);
-        } else {
-          setConfirmDelete(false);
-        }
-        return;
-      }
+      if (input !== "d") deleteConfirm.cancel();
 
       if (
         handleListDetailKey(input, key, {
@@ -208,7 +203,8 @@ export const SchedulePanel = memo(function SchedulePanel({
         return;
       }
       if (input === "d" && selectedScheduleRef.current) {
-        setConfirmDelete(true);
+        const s = selectedScheduleRef.current;
+        deleteConfirm.pressDelete(s.name);
         return;
       }
       if (input === "r") {
@@ -273,13 +269,6 @@ export const SchedulePanel = memo(function SchedulePanel({
             </Text>
           )}
         </Box>
-        {confirmDelete && selectedSchedule && (
-          <Box paddingX={1}>
-            <Text color="red" bold>
-              Delete schedule? (y/n)
-            </Text>
-          </Box>
-        )}
         {sidebarVisible.map((schedule, vi) => {
           const i = vi + sidebarScrollOffset;
           const isSelected = i === selectedIndex;
@@ -342,10 +331,14 @@ export const SchedulePanel = memo(function SchedulePanel({
             focused={focus === "detail"}
           />
         </Box>
+        <DeleteArmedBanner
+          armed={deleteConfirm.armed}
+          label={deleteConfirm.armedLabel}
+        />
         <Text dimColor>
           {focus === "detail"
             ? "↑↓ scroll · ⇧↑↓ page · g/G top/bot · ← back to list"
-            : "↑↓ select · → enter detail · f filter · e toggle · d delete · r refresh"}
+            : "↑↓ select · → enter detail · f filter · e toggle · d delete (×2) · r refresh"}
         </Text>
       </Box>
     </Box>

--- a/src/tui/components/TaskPanel.tsx
+++ b/src/tui/components/TaskPanel.tsx
@@ -12,7 +12,9 @@ import {
   handleListDetailKey,
 } from "../listDetailKeys.ts";
 import { ansi, theme } from "../theme.ts";
+import { useDeleteConfirm } from "../useDeleteConfirm.ts";
 import { useLatestRef } from "../useLatestRef.ts";
+import { DeleteArmedBanner } from "./DeleteArmedBanner.tsx";
 import { Scrollbar } from "./Scrollbar.tsx";
 
 interface TaskPanelProps {
@@ -199,8 +201,18 @@ export const TaskPanel = memo(function TaskPanel({
   const selectedTaskRef = useLatestRef(selectedTask);
   const focusRef = useLatestRef(focus);
 
+  const deleteConfirm = useDeleteConfirm(() => {
+    const t = selectedTaskRef.current;
+    if (!t) return;
+    deleteTask(projectDir, t.id).then(() => {
+      forceRefresh();
+    });
+  });
+
   useInput(
     (input, key) => {
+      if (input !== "d") deleteConfirm.cancel();
+
       if (
         handleListDetailKey(input, key, {
           focusRef,
@@ -226,9 +238,7 @@ export const TaskPanel = memo(function TaskPanel({
       if (input === "d") {
         const t = selectedTaskRef.current;
         if (!t) return;
-        deleteTask(projectDir, t.id).then(() => {
-          forceRefresh();
-        });
+        deleteConfirm.pressDelete(t.name || t.id);
         return;
       }
       if (input === "r") {
@@ -359,10 +369,14 @@ export const TaskPanel = memo(function TaskPanel({
             focused={focus === "detail"}
           />
         </Box>
+        <DeleteArmedBanner
+          armed={deleteConfirm.armed}
+          label={deleteConfirm.armedLabel}
+        />
         <Text dimColor>
           {focus === "detail"
             ? "↑↓ scroll · ⇧↑↓ page · g/G top/bot · ← back to list"
-            : "↑↓ select · → enter detail · f filter · p priority · d delete · r refresh"}
+            : "↑↓ select · → enter detail · f filter · p priority · d delete (×2) · r refresh"}
         </Text>
       </Box>
     </Box>

--- a/src/tui/components/ThreadPanel.tsx
+++ b/src/tui/components/ThreadPanel.tsx
@@ -15,7 +15,9 @@ import {
   handleListDetailKey,
 } from "../listDetailKeys.ts";
 import { ansi, theme } from "../theme.ts";
+import { useDeleteConfirm } from "../useDeleteConfirm.ts";
 import { useLatestRef } from "../useLatestRef.ts";
+import { DeleteArmedBanner } from "./DeleteArmedBanner.tsx";
 import { Scrollbar } from "./Scrollbar.tsx";
 
 interface ThreadPanelProps {
@@ -168,7 +170,6 @@ export const ThreadPanel = memo(function ThreadPanel({
   const [focus, setFocus] = useState<FocusState>("list");
   const [typeFilter, setTypeFilter] = useState<Thread["type"] | null>(null);
   const [refreshTick, setRefreshTick] = useState(0);
-  const [confirmDelete, setConfirmDelete] = useState(false);
   const [searching, setSearching] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedDetail, setSelectedDetail] = useState<{
@@ -329,10 +330,17 @@ export const ThreadPanel = memo(function ThreadPanel({
   const selectedThreadRef = useLatestRef(selectedThread);
   const selectedDetailRef = useLatestRef(selectedDetail);
   const searchingRef = useLatestRef(searching);
-  const confirmDeleteRef = useLatestRef(confirmDelete);
   const isActiveSelectedRef = useLatestRef(isActiveSelected);
   const followingRef = useLatestRef(following);
   const focusRef = useLatestRef(focus);
+
+  const deleteConfirm = useDeleteConfirm(() => {
+    const t = selectedThreadRef.current;
+    if (!t || isActiveSelectedRef.current) return;
+    deleteThread(projectDir, t.id).then(() => {
+      forceRefresh();
+    });
+  });
 
   useInput(
     (input, key) => {
@@ -360,21 +368,7 @@ export const ThreadPanel = memo(function ThreadPanel({
         return;
       }
 
-      // Delete confirmation mode
-      if (confirmDeleteRef.current) {
-        if (input === "y" || input === "d") {
-          const t = selectedThreadRef.current;
-          if (t && !isActiveSelectedRef.current) {
-            deleteThread(projectDir, t.id).then(() => {
-              forceRefresh();
-            });
-          }
-          setConfirmDelete(false);
-        } else {
-          setConfirmDelete(false);
-        }
-        return;
-      }
+      if (input !== "d") deleteConfirm.cancel();
 
       if (
         handleListDetailKey(input, key, {
@@ -396,7 +390,8 @@ export const ThreadPanel = memo(function ThreadPanel({
       }
       if (input === "d" && selectedThreadRef.current) {
         if (isActiveSelectedRef.current) return; // Can't delete active thread
-        setConfirmDelete(true);
+        const t = selectedThreadRef.current;
+        deleteConfirm.pressDelete(t.title || "(untitled)");
         return;
       }
       if (input === "r") {
@@ -490,13 +485,6 @@ export const ThreadPanel = memo(function ThreadPanel({
             <Text color={theme.info}>▌</Text>
           </Box>
         )}
-        {confirmDelete && selectedThread && (
-          <Box paddingX={1}>
-            <Text color="red" bold>
-              Delete thread? (y/n)
-            </Text>
-          </Box>
-        )}
         {sidebarVisible.map((thread, vi) => {
           const i = vi + sidebarScrollOffset;
           const isSelected = i === selectedIndex;
@@ -573,6 +561,10 @@ export const ThreadPanel = memo(function ThreadPanel({
             focused={focus === "detail"}
           />
         </Box>
+        <DeleteArmedBanner
+          armed={deleteConfirm.armed}
+          label={deleteConfirm.armedLabel}
+        />
         <Box>
           {following && (
             <Text color={theme.success} bold>
@@ -583,7 +575,7 @@ export const ThreadPanel = memo(function ThreadPanel({
           <Text dimColor>
             {focus === "detail"
               ? "↑↓ scroll · ⇧↑↓ page · g/G top/bot · ← back to list"
-              : `↑↓ select · → enter detail · s search · f filter · d delete${selectedThread && !selectedThread.ended_at ? " · w follow" : ""} · r refresh`}
+              : `↑↓ select · → enter detail · s search · f filter · d delete (×2)${selectedThread && !selectedThread.ended_at ? " · w follow" : ""} · r refresh`}
           </Text>
         </Box>
       </Box>

--- a/src/tui/components/WorkerPanel.tsx
+++ b/src/tui/components/WorkerPanel.tsx
@@ -1,13 +1,20 @@
+import { basename } from "node:path";
 import { Box, Text, useInput, useStdout } from "ink";
 import { memo, useEffect, useMemo, useState } from "react";
 import { readLogTail } from "../../worker/log-reader.ts";
-import { listWorkers, type Worker } from "../../workers/store.ts";
+import {
+  deleteWorkerLog,
+  listWorkers,
+  type Worker,
+} from "../../workers/store.ts";
 import {
   detailPaneBorderProps,
   type FocusState,
   handleListDetailKey,
 } from "../listDetailKeys.ts";
+import { useDeleteConfirm } from "../useDeleteConfirm.ts";
 import { useLatestRef } from "../useLatestRef.ts";
+import { DeleteArmedBanner } from "./DeleteArmedBanner.tsx";
 import { Scrollbar } from "./Scrollbar.tsx";
 
 interface WorkerPanelProps {
@@ -161,6 +168,21 @@ export const WorkerPanel = memo(function WorkerPanel({
   const itemCountRef = useLatestRef(workers.length);
   const maxLogScrollRef = useLatestRef(maxLogScroll);
   const focusRef = useLatestRef(focus);
+  const viewModeRef = useLatestRef(viewMode);
+  const selectedLogPathRef = useLatestRef(selectedLogPath);
+
+  const deleteConfirm = useDeleteConfirm(() => {
+    const path = selectedLogPathRef.current;
+    if (!path) return;
+    deleteWorkerLog(projectDir, path)
+      .catch(() => {})
+      .finally(() => {
+        setLogContent("");
+        setLogSize(0);
+        setLogTruncated(false);
+        setLogScroll(0);
+      });
+  });
 
   // The right pane scrolls with arrows when focused. Tee the log scroll into
   // the follow-state so reaching the bottom resumes follow mode (and any
@@ -180,6 +202,8 @@ export const WorkerPanel = memo(function WorkerPanel({
   useInput(
     (input, key) => {
       if (!isActive) return;
+
+      if (input !== "d") deleteConfirm.cancel();
 
       // `l` toggles between detail (worker info) and log (tail) view in the
       // right pane.
@@ -206,6 +230,14 @@ export const WorkerPanel = memo(function WorkerPanel({
         setFilterIdx((i) => (i + 1) % STATUS_FILTERS.length);
         return;
       }
+
+      if (input === "d") {
+        if (viewModeRef.current !== "log") return;
+        const path = selectedLogPathRef.current;
+        if (!path) return;
+        deleteConfirm.pressDelete(`worker log: ${basename(path)}`);
+        return;
+      }
     },
     { isActive },
   );
@@ -225,10 +257,14 @@ export const WorkerPanel = memo(function WorkerPanel({
           {focus === "detail"
             ? "  · ↑↓ scroll  ⇧↑↓ page  g/G top/bot  ← back to list  l toggle"
             : viewMode === "log"
-              ? "  · ↑↓ select  → enter log  l detail  f filter"
+              ? "  · ↑↓ select  → enter log  l detail  f filter  d delete log (×2)"
               : "  · ↑↓ select  → enter detail  l view log  f filter"}
         </Text>
       </Box>
+      <DeleteArmedBanner
+        armed={deleteConfirm.armed}
+        label={deleteConfirm.armedLabel}
+      />
 
       {workers.length === 0 ? (
         <Text dimColor>

--- a/src/tui/useDeleteConfirm.ts
+++ b/src/tui/useDeleteConfirm.ts
@@ -1,0 +1,115 @@
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Two-press delete confirmation. First press arms; second press within
+ * `ttlMs` confirms. Any non-`d` keystroke should call `cancel()`. The TTL
+ * is a safety net for idle/escape.
+ */
+
+export interface DeleteConfirmController {
+  isArmed(): boolean;
+  armedLabel(): string | null;
+  pressDelete: (label: string) => void;
+  cancel: () => void;
+  dispose: () => void;
+}
+
+export function createDeleteConfirmController(
+  onConfirm: () => void,
+  opts: { ttlMs?: number; onChange?: () => void } = {},
+): DeleteConfirmController {
+  const ttlMs = opts.ttlMs ?? 3000;
+  let armed = false;
+  let label: string | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const clearTimer = () => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+
+  const notify = () => {
+    opts.onChange?.();
+  };
+
+  const pressDelete = (next: string) => {
+    if (armed) {
+      clearTimer();
+      armed = false;
+      label = null;
+      notify();
+      onConfirm();
+      return;
+    }
+    armed = true;
+    label = next;
+    timer = setTimeout(() => {
+      armed = false;
+      label = null;
+      timer = null;
+      notify();
+    }, ttlMs);
+    notify();
+  };
+
+  const cancel = () => {
+    if (!armed && !timer) return;
+    clearTimer();
+    armed = false;
+    label = null;
+    notify();
+  };
+
+  const dispose = () => {
+    clearTimer();
+  };
+
+  return {
+    isArmed: () => armed,
+    armedLabel: () => label,
+    pressDelete,
+    cancel,
+    dispose,
+  };
+}
+
+export interface UseDeleteConfirmResult {
+  armed: boolean;
+  armedLabel: string | null;
+  pressDelete: (label: string) => void;
+  cancel: () => void;
+}
+
+export function useDeleteConfirm(
+  onConfirm: () => void,
+  opts: { ttlMs?: number } = {},
+): UseDeleteConfirmResult {
+  const [, setTick] = useState(0);
+
+  const onConfirmRef = useRef(onConfirm);
+  onConfirmRef.current = onConfirm;
+
+  const controllerRef = useRef<DeleteConfirmController | null>(null);
+  if (!controllerRef.current) {
+    controllerRef.current = createDeleteConfirmController(
+      () => onConfirmRef.current(),
+      { ttlMs: opts.ttlMs, onChange: () => setTick((t) => t + 1) },
+    );
+  }
+
+  useEffect(() => {
+    return () => {
+      controllerRef.current?.dispose();
+    };
+  }, []);
+
+  const c = controllerRef.current;
+  return {
+    armed: c.isArmed(),
+    armedLabel: c.armedLabel(),
+    pressDelete: c.pressDelete,
+    cancel: c.cancel,
+  };
+}

--- a/src/workers/store.ts
+++ b/src/workers/store.ts
@@ -1,6 +1,6 @@
 import { readdir, stat, unlink } from "node:fs/promises";
-import { join } from "node:path";
-import { getWorkersDir } from "../constants.ts";
+import { join, resolve } from "node:path";
+import { getWorkerLogsDir, getWorkersDir } from "../constants.ts";
 import { atomicWrite, readWithMtime } from "../fs/atomic.ts";
 
 export const WORKER_MODES = ["persist", "once"] as const;
@@ -210,6 +210,28 @@ export async function deleteWorker(
 ): Promise<boolean> {
   try {
     await unlink(workerFilePath(projectDir, id));
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw err;
+  }
+}
+
+/**
+ * Delete a worker's on-disk log file. Refuses to touch anything outside
+ * `<projectDir>/logs/`. ENOENT is treated as success (idempotent).
+ */
+export async function deleteWorkerLog(
+  projectDir: string,
+  logPath: string,
+): Promise<boolean> {
+  const logsDir = resolve(getWorkerLogsDir(projectDir));
+  const target = resolve(logPath);
+  if (target !== logsDir && !target.startsWith(`${logsDir}/`)) {
+    throw new Error(`refusing to delete log outside ${logsDir}: ${logPath}`);
+  }
+  try {
+    await unlink(target);
     return true;
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") return false;

--- a/test/db/embeddings.test.ts
+++ b/test/db/embeddings.test.ts
@@ -12,6 +12,7 @@ import { EMBEDDING_DIMENSION } from "../../src/constants.ts";
 import { type DbConnection, getConnection } from "../../src/db/connection.ts";
 import {
   deleteIndexedPath,
+  deleteIndexedPathsUnder,
   getIndexedPath,
   indexStats,
   listIndexedPaths,
@@ -113,6 +114,35 @@ describe("deleteIndexedPath", () => {
     await deleteIndexedPath(conn, "a.md");
     const summary = await listIndexedPaths(conn);
     expect(summary.map((s) => s.path).sort()).toEqual(["b.md"]);
+  });
+});
+
+describe("deleteIndexedPathsUnder", () => {
+  test("removes the prefix path itself and every entry beneath it", async () => {
+    await seed("docs/intro.md", [{ index: 0, text: "x" }]);
+    await seed("docs/sub/a.md", [{ index: 0, text: "y" }]);
+    await seed("docs/sub/b.md", [{ index: 0, text: "z" }]);
+    await seed("notes.md", [{ index: 0, text: "n" }]);
+
+    const removed = await deleteIndexedPathsUnder(conn, "docs");
+    expect(removed).toBeGreaterThanOrEqual(3);
+
+    const remaining = await listIndexedPaths(conn);
+    expect(remaining.map((s) => s.path).sort()).toEqual(["notes.md"]);
+  });
+
+  test("does not match unrelated sibling prefixes", async () => {
+    await seed("docs/a.md", [{ index: 0, text: "x" }]);
+    await seed("docs-old/a.md", [{ index: 0, text: "y" }]);
+
+    await deleteIndexedPathsUnder(conn, "docs");
+
+    const remaining = await listIndexedPaths(conn);
+    expect(remaining.map((s) => s.path).sort()).toEqual(["docs-old/a.md"]);
+  });
+
+  test("returns 0 when nothing matches", async () => {
+    expect(await deleteIndexedPathsUnder(conn, "missing")).toBe(0);
   });
 });
 

--- a/test/tui/useDeleteConfirm.test.ts
+++ b/test/tui/useDeleteConfirm.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import { createDeleteConfirmController } from "../../src/tui/useDeleteConfirm.ts";
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("createDeleteConfirmController", () => {
+  test("first press arms and stores label", () => {
+    let confirms = 0;
+    const c = createDeleteConfirmController(() => confirms++, { ttlMs: 50 });
+    expect(c.isArmed()).toBe(false);
+    expect(c.armedLabel()).toBeNull();
+    c.pressDelete("hello");
+    expect(c.isArmed()).toBe(true);
+    expect(c.armedLabel()).toBe("hello");
+    expect(confirms).toBe(0);
+    c.dispose();
+  });
+
+  test("second press within TTL fires onConfirm and disarms", () => {
+    let confirms = 0;
+    const c = createDeleteConfirmController(() => confirms++, { ttlMs: 50 });
+    c.pressDelete("a");
+    c.pressDelete("a");
+    expect(confirms).toBe(1);
+    expect(c.isArmed()).toBe(false);
+    expect(c.armedLabel()).toBeNull();
+    c.dispose();
+  });
+
+  test("auto-disarms after TTL; subsequent press only re-arms", async () => {
+    let confirms = 0;
+    const c = createDeleteConfirmController(() => confirms++, { ttlMs: 30 });
+    c.pressDelete("a");
+    await wait(60);
+    expect(c.isArmed()).toBe(false);
+    c.pressDelete("a");
+    expect(confirms).toBe(0);
+    expect(c.isArmed()).toBe(true);
+    c.dispose();
+  });
+
+  test("cancel disarms and prevents the next press from confirming", () => {
+    let confirms = 0;
+    const c = createDeleteConfirmController(() => confirms++, { ttlMs: 50 });
+    c.pressDelete("a");
+    c.cancel();
+    expect(c.isArmed()).toBe(false);
+    c.pressDelete("a");
+    expect(confirms).toBe(0);
+    expect(c.isArmed()).toBe(true);
+    c.dispose();
+  });
+
+  test("onChange fires on arm, confirm, cancel, and TTL expiry", async () => {
+    let changes = 0;
+    const c = createDeleteConfirmController(() => {}, {
+      ttlMs: 30,
+      onChange: () => changes++,
+    });
+    c.pressDelete("a");
+    expect(changes).toBe(1);
+    c.cancel();
+    expect(changes).toBe(2);
+    c.pressDelete("b");
+    expect(changes).toBe(3);
+    await wait(60);
+    expect(changes).toBe(4);
+    c.pressDelete("c");
+    c.pressDelete("c");
+    expect(changes).toBe(6);
+    c.dispose();
+  });
+
+  test("dispose clears pending TTL timer", async () => {
+    let changes = 0;
+    const c = createDeleteConfirmController(() => {}, {
+      ttlMs: 20,
+      onChange: () => changes++,
+    });
+    c.pressDelete("a");
+    c.dispose();
+    await wait(40);
+    expect(changes).toBe(1);
+  });
+});

--- a/test/workers/store.test.ts
+++ b/test/workers/store.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   deleteWorker,
+  deleteWorkerLog,
   getWorker,
   heartbeat,
   isWorkerRunning,
@@ -150,5 +151,25 @@ describe("workers store", () => {
     expect(await deleteWorker(projectDir, "doomed")).toBe(true);
     expect(await getWorker(projectDir, "doomed")).toBeNull();
     expect(await deleteWorker(projectDir, "doomed")).toBe(false);
+  });
+
+  test("deleteWorkerLog removes the file under logs/ and is idempotent", async () => {
+    const dateDir = join(projectDir, "logs", "2026-05-05");
+    await mkdir(dateDir, { recursive: true });
+    const logPath = join(dateDir, "w1.log");
+    await writeFile(logPath, "hello\n");
+
+    expect(await deleteWorkerLog(projectDir, logPath)).toBe(true);
+    expect(await deleteWorkerLog(projectDir, logPath)).toBe(false);
+  });
+
+  test("deleteWorkerLog refuses paths outside logs/", async () => {
+    const escapePath = join(projectDir, "workers", "evil.log");
+    await mkdir(join(projectDir, "workers"), { recursive: true });
+    await writeFile(escapePath, "x");
+    await expect(deleteWorkerLog(projectDir, escapePath)).rejects.toThrow(
+      /refusing to delete log outside/,
+    );
+    expect(await readFile(escapePath, "utf-8")).toBe("x");
   });
 });


### PR DESCRIPTION
## Summary
- Adds a shared `useDeleteConfirm` hook + `DeleteArmedBanner` and wires every list panel (Tasks, Threads, Schedules, Context, Workers-log-view) to a single `d`-then-`d` delete UX. First press arms, second confirms; any other key or 3s of inactivity disarms. Replaces the old immediate-delete (Tasks) and y/n prompts (Threads/Schedules).
- Adds delete to `ContextPanel` via `deleteContextPath` plus a new `deleteIndexedPathsUnder` SQL helper and a forced FTS rebuild — folders delete recursively, symlinks unlink safely. Adds `deleteWorkerLog` (sandboxed under `logs/`) so `WorkerPanel` can drop a worker's log file in log view without touching the worker record.
- Updates `HelpPanel` and `docs/tui.md` to document the new pattern, and adds tests for the controller, the new embeddings helper, and `deleteWorkerLog`.

## Test plan
- [x] `bun run lint`
- [x] `bun test` (849 pass)
- [ ] Manual smoke: `bun run dev`, exercise `d`+`d` in Tasks/Threads/Schedules/Context/Workers-log-view; verify active thread cannot be deleted, symlink in `context/` unlinks safely, and a deleted Context folder also disappears from `context_index`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)