### PR TITLE
TUI: shade detail-pane headers with distinct background color

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/tui/components/ContextPanel.tsx
+++ b/src/tui/components/ContextPanel.tsx
@@ -400,7 +400,7 @@ function ContextDetailHeader({
   indexLoaded: boolean;
 }) {
   return (
-    <Box flexDirection="column">
+    <Box flexDirection="column" width="100%" backgroundColor={theme.headerBg}>
       <Box>
         <Text bold color="cyan" wrap="truncate-end">
           {entry.is_directory ? "📁" : "📄"} context/{entry.path}
@@ -441,9 +441,6 @@ function ContextDetailHeader({
           </Box>
         </>
       )}
-      <Box>
-        <Text dimColor>{"─".repeat(2)}</Text>
-      </Box>
     </Box>
   );
 }

--- a/src/tui/components/SchedulePanel.tsx
+++ b/src/tui/components/SchedulePanel.tsx
@@ -348,7 +348,7 @@ export const SchedulePanel = memo(function SchedulePanel({
 function ScheduleDetailHeader({ schedule }: { schedule: Schedule }) {
   const enabledKey = String(schedule.enabled);
   return (
-    <Box flexDirection="column">
+    <Box flexDirection="column" width="100%" backgroundColor={theme.headerBg}>
       <Box>
         <Text bold color={theme.info} wrap="truncate-end">
           {schedule.name}
@@ -366,9 +366,6 @@ function ScheduleDetailHeader({ schedule }: { schedule: Schedule }) {
             {formatTimestamp(schedule.last_run_at)}
           </Text>
         </Text>
-      </Box>
-      <Box>
-        <Text dimColor>{"─".repeat(2)}</Text>
       </Box>
     </Box>
   );

--- a/src/tui/components/TaskPanel.tsx
+++ b/src/tui/components/TaskPanel.tsx
@@ -385,7 +385,7 @@ export const TaskPanel = memo(function TaskPanel({
 
 function TaskDetailHeader({ task }: { task: Task }) {
   return (
-    <Box flexDirection="column">
+    <Box flexDirection="column" width="100%" backgroundColor={theme.headerBg}>
       <Box>
         <Text bold color={theme.info} wrap="truncate-end">
           {task.name}
@@ -407,9 +407,6 @@ function TaskDetailHeader({ task }: { task: Task }) {
             {formatTimestamp(task.updated_at)}
           </Text>
         </Text>
-      </Box>
-      <Box>
-        <Text dimColor>{"─".repeat(2)}</Text>
       </Box>
     </Box>
   );

--- a/src/tui/components/ThreadPanel.tsx
+++ b/src/tui/components/ThreadPanel.tsx
@@ -591,7 +591,7 @@ function ThreadDetailHeader({
   isActiveThread: boolean;
 }) {
   return (
-    <Box flexDirection="column">
+    <Box flexDirection="column" width="100%" backgroundColor={theme.headerBg}>
       <Box>
         <Text wrap="truncate-end">
           <Text bold italic color={theme.info}>
@@ -624,9 +624,6 @@ function ThreadDetailHeader({
             {formatDuration(thread.started_at, thread.ended_at)}
           </Text>
         </Text>
-      </Box>
-      <Box>
-        <Text dimColor>{"─".repeat(2)}</Text>
       </Box>
     </Box>
   );

--- a/src/tui/theme.ts
+++ b/src/tui/theme.ts
@@ -49,6 +49,7 @@ export const theme = {
   accentBorder: isDark ? "yellow" : "#B8860B",
   userBg: isDark ? "#2a5a8c" : "#d0e0f0",
   selectionBg: isDark ? "#333" : "#ddd",
+  headerBg: isDark ? "#3a4655" : "#f5f7fa",
   success: "green",
   error: "red",
   info: "cyan",


### PR DESCRIPTION
## Summary
- Adds a `headerBg` theme token (light/dark variants) and applies it to the outer `<Box>` of `ContextDetailHeader`, `ThreadDetailHeader`, `TaskDetailHeader`, and `ScheduleDetailHeader` with `width="100%"` so the bg fills the pane.
- Drops the redundant 2-char `─` divider row from each header — the background change is the divider now.
- Bumps version to `0.15.3`.

## Test plan
- [x] `bun run lint`
- [x] `bun test`
- [ ] `bun run dev chat` and visually confirm header bg in each tab in both light and dark terminal modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)