### PR TITLE
TUI: render tool side-effect alerts inside the tool-call card

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/chat/agent.ts
+++ b/src/chat/agent.ts
@@ -156,6 +156,11 @@ export interface ChatTurnCallbacks {
     isError: boolean,
     meta?: ToolEndMeta,
   ) => void;
+  /** Side-effect notification from inside a tool ("Created subtask: …"). The
+   *  TUI renders these inside the tool-call card so they stay anchored to the
+   *  tool that produced them. Workers don't supply this; tools fall back to
+   *  `logger.info`. */
+  onToolNotify?: (toolUseId: string, message: string) => void;
   /** Called between LLM turns. The TUI returns any queued user messages so
    *  the agent can inject them into the running turn instead of waiting for
    *  the entire tool loop to finish. Each returned message is logged + pushed
@@ -406,6 +411,9 @@ export async function runChatTurn(input: {
           config,
           mcpxClient,
           shouldAbort: session ? () => session.aborted : undefined,
+          notify: callbacks.onToolNotify
+            ? (msg) => callbacks.onToolNotify?.(toolUse.id, msg)
+            : undefined,
         });
         const durationMs = Date.now() - start;
         const stored = maybeStoreResult(toolUse.name, result.output);
@@ -454,6 +462,7 @@ interface ChatToolCallCtx {
   config: Required<BotholomewConfig>;
   mcpxClient: McpxClient | null;
   shouldAbort?: () => boolean;
+  notify?: (message: string) => void;
 }
 
 async function executeChatToolCall(

--- a/src/tools/schedule/create.ts
+++ b/src/tools/schedule/create.ts
@@ -33,7 +33,9 @@ export const createScheduleTool = {
       description: input.description,
       frequency: input.frequency,
     });
-    logger.info(`Created schedule: ${schedule.name} (${schedule.id})`);
+    const msg = `Created schedule: ${schedule.name} (${schedule.id})`;
+    if (ctx.notify) ctx.notify(msg);
+    else logger.info(msg);
     return {
       id: schedule.id,
       name: schedule.name,

--- a/src/tools/task/create.ts
+++ b/src/tools/task/create.ts
@@ -55,7 +55,9 @@ export const createTaskTool = {
         blocked_by: input.blocked_by,
         context_paths: input.context_paths,
       });
-      logger.info(`Created subtask: ${newTask.name} (${newTask.id})`);
+      const msg = `Created subtask: ${newTask.name} (${newTask.id})`;
+      if (ctx.notify) ctx.notify(msg);
+      else logger.info(msg);
       return {
         id: newTask.id,
         name: newTask.name,

--- a/src/tools/task/delete.ts
+++ b/src/tools/task/delete.ts
@@ -44,7 +44,9 @@ export const deleteTaskTool = {
         is_error: true,
       };
     }
-    logger.info(`Deleted task: ${existing.name} (${existing.id})`);
+    const msg = `Deleted task: ${existing.name} (${existing.id})`;
+    if (ctx.notify) ctx.notify(msg);
+    else logger.info(msg);
     return {
       deleted_id: existing.id,
       message: `Deleted task "${existing.name}" (${existing.id})`,

--- a/src/tools/task/update.ts
+++ b/src/tools/task/update.ts
@@ -91,7 +91,9 @@ export const updateTaskTool = {
       };
     }
 
-    logger.info(`Updated task: ${updated.name} (${updated.id})`);
+    const msg = `Updated task: ${updated.name} (${updated.id})`;
+    if (ctx.notify) ctx.notify(msg);
+    else logger.info(msg);
     return {
       task: {
         id: updated.id,

--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -22,6 +22,13 @@ export interface ToolContext {
    * Esc-to-abort by reading `session.aborted`. Workers leave this `undefined`.
    */
   shouldAbort?: () => boolean;
+  /**
+   * Chat-mode only. Tools call this to surface a short human-readable
+   * side-effect message (e.g. "Created subtask: …") that the TUI renders
+   * inside the tool-call card. Workers leave this `undefined`; tools fall
+   * back to `logger.info` so worker logs are unchanged.
+   */
+  notify?: (message: string) => void;
 }
 
 type ToolOutputBase = { is_error: z.ZodBoolean };

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -476,6 +476,14 @@ function AppInner({
             }
             setActiveToolCalls([...pendingToolCalls]);
           },
+          onToolNotify: (id, message) => {
+            markActivityRef.current();
+            const tc = pendingToolCalls.find((t) => t.id === id);
+            if (tc) {
+              tc.notes = [...(tc.notes ?? []), message];
+              setActiveToolCalls([...pendingToolCalls]);
+            }
+          },
           onUsage: (info) => {
             setUsage(info);
           },

--- a/src/tui/components/ToolCall.tsx
+++ b/src/tui/components/ToolCall.tsx
@@ -40,6 +40,8 @@ export interface ToolCallData {
   timestamp: Date;
   largeResult?: LargeResultMeta;
   isError?: boolean;
+  /** Side-effect notes emitted by the tool (e.g. "Created subtask: …"). */
+  notes?: string[];
 }
 
 interface ToolCallProps {
@@ -106,6 +108,18 @@ export function ToolCall({ tool }: ToolCallProps) {
           {tool.largeResult.pages}pg]
         </Text>
       )}
+      {tool.notes?.map((note, i) => (
+        <Text
+          // biome-ignore lint/suspicious/noArrayIndexKey: notes are append-only
+          key={i}
+          color={theme.accent}
+          dimColor
+          wrap="truncate-end"
+        >
+          {"    ℹ "}
+          {note}
+        </Text>
+      ))}
     </Box>
   );
 }

--- a/test/tools/schedule.test.ts
+++ b/test/tools/schedule.test.ts
@@ -58,6 +58,18 @@ describe("create_schedule", () => {
     expect(r.success).toBe(false);
   });
 
+  test("calls ctx.notify on success when provided", async () => {
+    const notes: string[] = [];
+    const notifyCtx: ToolContext = { ...ctx, notify: (m) => notes.push(m) };
+    const result = await createScheduleTool.execute(
+      { name: "Morning", frequency: "daily" },
+      notifyCtx,
+    );
+    expect(result.is_error).toBe(false);
+    expect(notes).toHaveLength(1);
+    expect(notes[0]).toContain("Created schedule: Morning");
+  });
+
   test("validates input schema rejects missing name", () => {
     const r = createScheduleTool.inputSchema.safeParse({ frequency: "daily" });
     expect(r.success).toBe(false);

--- a/test/tools/task.test.ts
+++ b/test/tools/task.test.ts
@@ -114,6 +114,19 @@ describe("create_task", () => {
     });
     expect(result.success).toBe(false);
   });
+
+  test("calls ctx.notify with the subtask message when provided", async () => {
+    const notes: string[] = [];
+    const notifyCtx: ToolContext = { ...ctx, notify: (m) => notes.push(m) };
+    const result = await createTaskTool.execute(
+      { name: "Notified" },
+      notifyCtx,
+    );
+    expect(result.is_error).toBe(false);
+    expect(notes).toHaveLength(1);
+    expect(notes[0]).toContain("Created subtask: Notified");
+    expect(notes[0]).toContain(result.id ?? "");
+  });
 });
 
 // ── update_task ────────────────────────────────────────────
@@ -174,6 +187,18 @@ describe("update_task", () => {
     const result = updateTaskTool.inputSchema.safeParse({ name: "test" });
     expect(result.success).toBe(false);
   });
+
+  test("calls ctx.notify on success when provided", async () => {
+    const created = await makeTask({ name: "Original" });
+    const notes: string[] = [];
+    const notifyCtx: ToolContext = { ...ctx, notify: (m) => notes.push(m) };
+    await updateTaskTool.execute(
+      { id: created.id, name: "Renamed" },
+      notifyCtx,
+    );
+    expect(notes).toHaveLength(1);
+    expect(notes[0]).toContain("Updated task: Renamed");
+  });
 });
 
 // ── delete_task ────────────────────────────────────────────
@@ -231,6 +256,15 @@ describe("delete_task", () => {
     expect(result.is_error).toBe(true);
     expect(result.deleted_id).toBeNull();
     expect(result.message).toContain("not found");
+  });
+
+  test("calls ctx.notify on success when provided", async () => {
+    const task = await createTask(projectDir, { name: "scratch" });
+    const notes: string[] = [];
+    const notifyCtx: ToolContext = { ...ctx, notify: (m) => notes.push(m) };
+    await deleteTaskTool.execute({ id: task.id }, notifyCtx);
+    expect(notes).toHaveLength(1);
+    expect(notes[0]).toContain("Deleted task: scratch");
   });
 });
 


### PR DESCRIPTION
## Summary

- Tools like `create_task`, `update_task`, `delete_task`, and `create_schedule` were emitting `Created subtask: …` alerts via `logger.info`, which Ink pushes into scrollback **above** the live region — so the alerts clustered at the top of an interaction instead of next to the tool call that produced them.
- Added an optional `notify` channel on `ToolContext` and a matching `ChatTurnCallbacks.onToolNotify`; chat-mode tools route the message through it, and the TUI renders each note as a dimmed `ℹ` line inside the matching tool-call card.
- Workers leave `notify` unset and tools fall back to `logger.info`, so worker logs are byte-for-byte unchanged.

## Test plan

- [x] `bun run lint`
- [x] `bun test` (867 pass)
- [ ] Manual: `bun run dev chat`, prompt the agent to create several subtasks, confirm each `Created subtask: …` alert renders inside its own `create_task` card rather than above the assistant block.
- [ ] Manual: run a worker that creates/updates tasks, tail `logs/worker-*.log`, confirm the same alert lines still appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)