### PR TITLE
Expose delete_task and update_task to the chat agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/chat/agent.ts
+++ b/src/chat/agent.ts
@@ -35,11 +35,13 @@ import {
 
 registerAllTools();
 
-/** Tools available in chat mode — no worker terminal tools (complete/fail/wait), no bulk-destructive file tools (delete, copy/move, dir ops) */
+/** Tools available in chat mode — no worker terminal tools (complete/fail/wait), no bulk-destructive file tools (copy/move, dir ops) */
 const CHAT_TOOL_NAMES = new Set([
   "create_task",
   "list_tasks",
   "view_task",
+  "update_task",
+  "delete_task",
   "context_info",
   "context_tree",
   "context_read",


### PR DESCRIPTION
## Summary

- The chat agent's `CHAT_TOOL_NAMES` allowlist in `src/chat/agent.ts` was filtering out `delete_task` and `update_task` even though both are registered tools and `capabilities_refresh` advertises them in the system prompt — so the agent saw "tool exists" in capabilities but "tool unavailable" in its function list and got stuck trying to clean up an `in_progress` task.
- Adds both names to the allowlist; worker-terminal tools (`complete`/`fail`/`wait`) remain excluded by design.
- Bumps version to 0.15.3.

## Test plan

- [x] `bun run lint` (tsc + biome) — clean
- [x] `bun test` — 863 pass / 0 fail
- [ ] Manual: `bun run dev chat`, ask the agent what task tools it has — confirm `delete_task` and `update_task` appear; delete a non-`in_progress` task and confirm the markdown file under `tasks/` is removed and the lockfile released

🤖 Generated with [Claude Code](https://claude.com/claude-code)