### PR TITLE
TUI: Ctrl+R refreshes browsing tabs; Threads tab moves to Ctrl+E

### DIFF
--- a/docs/tui.md
+++ b/docs/tui.md
@@ -122,7 +122,7 @@ render as plain text.
 The task queue, with filters for status (pending / in_progress /
 completed / failed) and priority. Select a row to see the full task
 body, its payload, predecessor outputs (for DAG tasks), and the log of
-attempts. `r` refreshes. See [tasks-and-schedules.md](tasks-and-schedules.md).
+attempts. `Ctrl+R` refreshes. See [tasks-and-schedules.md](tasks-and-schedules.md).
 
 ### 5. Threads
 
@@ -136,7 +136,7 @@ thread you're currently attached to.
 
 ### 6. Schedules
 
-Recurring tasks. Toggle `e`nabled, `d`elete, or `r`efresh. Schedules
+Recurring tasks. Toggle `e`nabled, `d`elete, or `Ctrl+R` to refresh. Schedules
 are evaluated by an LLM pass during the tick loop against natural-language
 rules like "every weekday at 9am" — see
 [tasks-and-schedules.md](tasks-and-schedules.md).
@@ -308,10 +308,11 @@ on the agent side) and disappears when the wait elapses or you press
 | `Ctrl+o` | Tools |
 | `Ctrl+n` | Context |
 | `Ctrl+t` | Tasks |
-| `Ctrl+r` | Threads |
+| `Ctrl+e` | Threads |
 | `Ctrl+s` | Schedules |
 | `Ctrl+w` | Workers |
 | `Ctrl+g` | Help (`Ctrl+/` also works in most terminals — it's typically delivered as the same byte) |
+| `Ctrl+R` | Refresh the active list (Context · Tasks · Threads · Schedules · Workers) |
 | `Esc` | Return to Chat from any other tab |
 | `Ctrl+C` | Exit the TUI |
 
@@ -345,7 +346,7 @@ move the selection (list focus) or scroll the detail (detail focus).
 | `g` / `G` | Jump to top / bottom of detail |
 | `f` | Cycle filter (status, type, enabled — per panel) |
 | `p` | Cycle priority filter (Tasks only) |
-| `r` | Refresh from DB |
+| `Ctrl+R` | Refresh from disk |
 | `d` then `d` | Delete the selected item (Tasks, Threads, Schedules, Context). First press arms; second confirms. Any other key or 3s of inactivity disarms. The active chat thread cannot be deleted. |
 | `e` | Toggle enable/disable (Schedules only) |
 | `s` or `/` | Search (Threads only) |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -8,8 +8,9 @@ export function registerChatCommand(program: Command) {
       "Open the interactive chat TUI\n\n" +
         "  Tab navigation (Ctrl+<letter> from any tab):\n" +
         "    Ctrl+a  Chat        Ctrl+t  Tasks       Ctrl+w  Workers\n" +
-        "    Ctrl+o  Tools       Ctrl+r  Threads     Ctrl+g  Help\n" +
+        "    Ctrl+o  Tools       Ctrl+e  Threads     Ctrl+g  Help\n" +
         "    Ctrl+n  Context     Ctrl+s  Schedules   Esc     Return to Chat\n\n" +
+        "  Refresh: Ctrl+R refreshes Context · Tasks · Threads · Schedules · Workers\n\n" +
         "  Chat input:\n" +
         "    Enter          Send message\n" +
         "    ⌥+Enter        Insert newline\n" +

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -65,7 +65,7 @@ const TAB_BY_CTRL_KEY: Record<string, TabId> = {
   o: 2, // t[o]ols
   n: 3, // co[n]text
   t: 4, // [t]asks
-  r: 5, // th[r]eads
+  e: 5, // thr[e]ads
   s: 6, // [s]chedules
   w: 7, // [w]orkers
   g: 8, // help (also catches Ctrl+/ on terminals that map it to BEL)
@@ -328,9 +328,18 @@ function AppInner({
               slashCommandsRef.current,
             );
             if (popupOpen) return;
+            // Ctrl+E edits a queued message when one is selected; only
+            // fall through to the Threads tab-jump when the queue is empty.
+            if (input === "e" && queuedMessagesRef.current.length > 0) {
+              // handled by the queue keybindings block below
+            } else {
+              setActiveTab(tabForKey);
+              return;
+            }
+          } else {
+            setActiveTab(tabForKey);
+            return;
           }
-          setActiveTab(tabForKey);
-          return;
         }
       }
 

--- a/src/tui/components/ContextPanel.tsx
+++ b/src/tui/components/ContextPanel.tsx
@@ -236,8 +236,9 @@ export const ContextPanel = memo(function ContextPanel({
         deleteConfirm.pressDelete(entry.path);
         return;
       }
-      if (input === "r") {
+      if (key.ctrl && (input === "r" || input === "R")) {
         refresh(currentPathRef.current);
+        return;
       }
     },
     { isActive },
@@ -367,7 +368,7 @@ export const ContextPanel = memo(function ContextPanel({
           <Text dimColor>
             {focus === "detail"
               ? "↑↓ scroll · ⇧↑↓ page · g/G top/bot · ← back to list"
-              : "↑↓ select · → drill in/enter detail · ← up · d delete (×2) · r refresh"}
+              : "↑↓ select · → drill in/enter detail · ← up · d delete (×2) · ^R refresh"}
           </Text>
         </Box>
       </Box>

--- a/src/tui/components/HelpPanel.tsx
+++ b/src/tui/components/HelpPanel.tsx
@@ -56,7 +56,7 @@ export const HelpPanel = memo(function HelpPanel({
           {"  "}Ctrl+t{"         "}Tasks
         </Text>
         <Text>
-          {"  "}Ctrl+r{"         "}Threads
+          {"  "}Ctrl+e{"         "}Threads
         </Text>
         <Text>
           {"  "}Ctrl+s{"         "}Schedules
@@ -142,19 +142,21 @@ export const HelpPanel = memo(function HelpPanel({
           (cancels on any other key or after 3s)
         </Text>
         <Text>
-          {"  "}Tasks{"          "}f filter · p priority · d delete (×2) · r
-          refresh
+          {"  "}Ctrl+R{"         "}Refresh (Context · Tasks · Threads ·
+          Schedules · Workers)
+        </Text>
+        <Text>
+          {"  "}Tasks{"          "}f filter · p priority · d delete (×2)
         </Text>
         <Text>
           {"  "}Threads{"        "}f filter · s/ search · w follow · d delete
-          (×2) · r refresh
+          (×2)
         </Text>
         <Text>
-          {"  "}Schedules{"      "}f filter · e toggle · d delete (×2) · r
-          refresh
+          {"  "}Schedules{"      "}f filter · e toggle · d delete (×2)
         </Text>
         <Text>
-          {"  "}Context{"        "}d delete (×2) · r refresh
+          {"  "}Context{"        "}d delete (×2)
         </Text>
         <Text>
           {"  "}Workers{"        "}f filter · l toggle log/detail · d delete log

--- a/src/tui/components/SchedulePanel.tsx
+++ b/src/tui/components/SchedulePanel.tsx
@@ -207,7 +207,7 @@ export const SchedulePanel = memo(function SchedulePanel({
         deleteConfirm.pressDelete(s.name);
         return;
       }
-      if (input === "r") {
+      if (key.ctrl && (input === "r" || input === "R")) {
         forceRefresh();
         return;
       }
@@ -338,7 +338,7 @@ export const SchedulePanel = memo(function SchedulePanel({
         <Text dimColor>
           {focus === "detail"
             ? "↑↓ scroll · ⇧↑↓ page · g/G top/bot · ← back to list"
-            : "↑↓ select · → enter detail · f filter · e toggle · d delete (×2) · r refresh"}
+            : "↑↓ select · → enter detail · f filter · e toggle · d delete (×2) · ^R refresh"}
         </Text>
       </Box>
     </Box>

--- a/src/tui/components/TaskPanel.tsx
+++ b/src/tui/components/TaskPanel.tsx
@@ -241,7 +241,7 @@ export const TaskPanel = memo(function TaskPanel({
         deleteConfirm.pressDelete(t.name || t.id);
         return;
       }
-      if (input === "r") {
+      if (key.ctrl && (input === "r" || input === "R")) {
         forceRefresh();
         return;
       }
@@ -376,7 +376,7 @@ export const TaskPanel = memo(function TaskPanel({
         <Text dimColor>
           {focus === "detail"
             ? "↑↓ scroll · ⇧↑↓ page · g/G top/bot · ← back to list"
-            : "↑↓ select · → enter detail · f filter · p priority · d delete (×2) · r refresh"}
+            : "↑↓ select · → enter detail · f filter · p priority · d delete (×2) · ^R refresh"}
         </Text>
       </Box>
     </Box>

--- a/src/tui/components/ThreadPanel.tsx
+++ b/src/tui/components/ThreadPanel.tsx
@@ -394,7 +394,7 @@ export const ThreadPanel = memo(function ThreadPanel({
         deleteConfirm.pressDelete(t.title || "(untitled)");
         return;
       }
-      if (input === "r") {
+      if (key.ctrl && (input === "r" || input === "R")) {
         forceRefresh();
         return;
       }
@@ -575,7 +575,7 @@ export const ThreadPanel = memo(function ThreadPanel({
           <Text dimColor>
             {focus === "detail"
               ? "↑↓ scroll · ⇧↑↓ page · g/G top/bot · ← back to list"
-              : `↑↓ select · → enter detail · s search · f filter · d delete (×2)${selectedThread && !selectedThread.ended_at ? " · w follow" : ""} · r refresh`}
+              : `↑↓ select · → enter detail · s search · f filter · d delete (×2)${selectedThread && !selectedThread.ended_at ? " · w follow" : ""} · ^R refresh`}
           </Text>
         </Box>
       </Box>

--- a/src/tui/components/WorkerPanel.tsx
+++ b/src/tui/components/WorkerPanel.tsx
@@ -1,6 +1,6 @@
 import { basename } from "node:path";
 import { Box, Text, useInput, useStdout } from "ink";
-import { memo, useEffect, useMemo, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { readLogTail } from "../../worker/log-reader.ts";
 import {
   deleteWorkerLog,
@@ -70,6 +70,7 @@ export const WorkerPanel = memo(function WorkerPanel({
   const [workers, setWorkers] = useState<Worker[]>([]);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [filterIdx, setFilterIdx] = useState(0);
+  const [refreshTick, setRefreshTick] = useState(0);
   const [now, setNow] = useState(() => new Date());
   const [viewMode, setViewMode] = useState<"detail" | "log">("detail");
   const [logContent, setLogContent] = useState("");
@@ -79,6 +80,7 @@ export const WorkerPanel = memo(function WorkerPanel({
   const [logFollow, setLogFollow] = useState(true);
   const [focus, setFocus] = useState<FocusState>("list");
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: refreshTick triggers manual refresh
   useEffect(() => {
     let mounted = true;
 
@@ -104,7 +106,7 @@ export const WorkerPanel = memo(function WorkerPanel({
       mounted = false;
       clearInterval(interval);
     };
-  }, [projectDir, filterIdx]);
+  }, [projectDir, filterIdx, refreshTick]);
 
   const selected = workers[selectedIndex];
   const selectedLogPath = selected?.log_path ?? null;
@@ -170,6 +172,10 @@ export const WorkerPanel = memo(function WorkerPanel({
   const focusRef = useLatestRef(focus);
   const viewModeRef = useLatestRef(viewMode);
   const selectedLogPathRef = useLatestRef(selectedLogPath);
+
+  const forceRefresh = useCallback(() => {
+    setRefreshTick((t) => t + 1);
+  }, []);
 
   const deleteConfirm = useDeleteConfirm(() => {
     const path = selectedLogPathRef.current;
@@ -238,6 +244,11 @@ export const WorkerPanel = memo(function WorkerPanel({
         deleteConfirm.pressDelete(`worker log: ${basename(path)}`);
         return;
       }
+
+      if (key.ctrl && (input === "r" || input === "R")) {
+        forceRefresh();
+        return;
+      }
     },
     { isActive },
   );
@@ -257,8 +268,8 @@ export const WorkerPanel = memo(function WorkerPanel({
           {focus === "detail"
             ? "  · ↑↓ scroll  ⇧↑↓ page  g/G top/bot  ← back to list  l toggle"
             : viewMode === "log"
-              ? "  · ↑↓ select  → enter log  l detail  f filter  d delete log (×2)"
-              : "  · ↑↓ select  → enter detail  l view log  f filter"}
+              ? "  · ↑↓ select  → enter log  l detail  f filter  d delete log (×2)  ^R refresh"
+              : "  · ↑↓ select  → enter detail  l view log  f filter  ^R refresh"}
         </Text>
       </Box>
       <DeleteArmedBanner


### PR DESCRIPTION
## Summary
- `Ctrl+R` now refreshes the active browsing tab (Context, Tasks, Threads, Schedules, Workers). Workers gains a manual refresh for the first time; the single-key `r` shortcut is removed.
- The Threads tab-jump moves from `Ctrl+R` to `Ctrl+E` (thr[e]ads). On the Chat tab, `Ctrl+E` still defers to the queued-message edit handler when a queued message is selected.
- Help panel, CLI help text in `botholomew chat --help`, and `docs/tui.md` updated to match.

## Test plan
- [x] `bun run lint`
- [x] `bun test` (867 pass)
- [ ] Manual: `bun run dev chat` — verify `Ctrl+E` jumps to Threads, `Ctrl+R` refreshes each browsing tab, and `Ctrl+E` still edits a selected queued message on Chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)