### PR TITLE
TUI: restore prior tool calls in the Tools tab on chat-thread resume

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -14,8 +14,7 @@ import {
   handleSlashCommand,
   type SlashCommand,
 } from "../skills/commands.ts";
-import { getThread, type Interaction } from "../threads/store.ts";
-import { MAX_INLINE_CHARS, PAGE_SIZE_CHARS } from "../worker/large-results.ts";
+import { getThread } from "../threads/store.ts";
 import { ContextPanel } from "./components/ContextPanel.tsx";
 import { HelpPanel } from "./components/HelpPanel.tsx";
 import { InputBar } from "./components/InputBar.tsx";
@@ -35,6 +34,7 @@ import type { ToolCallData } from "./components/ToolCall.tsx";
 import { ToolPanel } from "./components/ToolPanel.tsx";
 import { WorkerPanel } from "./components/WorkerPanel.tsx";
 import { IdleProvider, useIdle } from "./idle.tsx";
+import { restoreMessagesFromInteractions } from "./restoreMessages.ts";
 import { buildSlashCommands, getSlashMatches } from "./slashCompletion.ts";
 import { ansi } from "./theme.ts";
 
@@ -72,78 +72,6 @@ const TAB_BY_CTRL_KEY: Record<string, TabId> = {
   "/": 8, // help (Kitty keyboard protocol)
   _: 8, // help (terminals that send Ctrl+/ as 0x1F)
 };
-
-function detectToolError(output: string | undefined): boolean {
-  if (!output) return false;
-  try {
-    const parsed = JSON.parse(output);
-    if (typeof parsed === "object" && parsed?.is_error === true) return true;
-  } catch {
-    /* not JSON */
-  }
-  return false;
-}
-
-function restoreMessagesFromInteractions(
-  interactions: Interaction[],
-): ChatMessage[] {
-  const result: ChatMessage[] = [];
-  let pendingTools: ToolCallData[] = [];
-
-  let restoredIdx = 0;
-  for (const ix of interactions) {
-    if (ix.kind === "tool_use") {
-      pendingTools.push({
-        id: `restored-${restoredIdx++}`,
-        name: ix.tool_name ?? "unknown",
-        input: ix.tool_input ?? "{}",
-        running: false,
-        timestamp: ix.created_at,
-      });
-    } else if (ix.kind === "tool_result") {
-      const tc = pendingTools.find((t) => t.name === ix.tool_name && !t.output);
-      if (tc) {
-        tc.output = ix.content;
-        tc.isError = detectToolError(ix.content);
-        if (ix.content.length > MAX_INLINE_CHARS) {
-          tc.largeResult = {
-            id: "(restored)",
-            chars: ix.content.length,
-            pages: Math.ceil(ix.content.length / PAGE_SIZE_CHARS),
-          };
-        }
-      }
-    } else if (ix.kind === "message" && ix.role === "user") {
-      result.push({
-        id: msgId(),
-        role: "user",
-        content: ix.content,
-        timestamp: ix.created_at,
-      });
-    } else if (ix.kind === "message" && ix.role === "assistant") {
-      result.push({
-        id: msgId(),
-        role: "assistant",
-        content: ix.content,
-        timestamp: ix.created_at,
-        toolCalls: pendingTools.length > 0 ? [...pendingTools] : undefined,
-      });
-      pendingTools = [];
-    }
-  }
-
-  if (pendingTools.length > 0) {
-    result.push({
-      id: msgId(),
-      role: "assistant",
-      content: "",
-      timestamp: new Date(),
-      toolCalls: [...pendingTools],
-    });
-  }
-
-  return result;
-}
 
 export function App({
   projectDir,
@@ -245,7 +173,10 @@ function AppInner({
         }
         sessionRef.current = session;
 
-        if (session.messages.length > 0) {
+        if (resumeThreadId) {
+          // Always hydrate on resume so the Tools tab and chat history
+          // pick up prior tool_use/tool_result rows from the CSV — even if
+          // the thread has no plain message-kind interactions yet.
           const threadData = await getThread(
             session.projectDir,
             session.threadId,

--- a/src/tui/restoreMessages.ts
+++ b/src/tui/restoreMessages.ts
@@ -1,0 +1,106 @@
+import type { Interaction } from "../threads/store.ts";
+import { MAX_INLINE_CHARS, PAGE_SIZE_CHARS } from "../worker/large-results.ts";
+import type { ChatMessage } from "./components/MessageList.tsx";
+import type { ToolCallData } from "./components/ToolCall.tsx";
+
+let nextRestoreId = 0;
+function restoreMsgId(): string {
+  return `restore-msg-${++nextRestoreId}`;
+}
+
+function detectToolError(output: string | undefined): boolean {
+  if (!output) return false;
+  try {
+    const parsed = JSON.parse(output);
+    if (typeof parsed === "object" && parsed?.is_error === true) return true;
+  } catch {
+    /* not JSON */
+  }
+  return false;
+}
+
+/**
+ * Reconstruct `ChatMessage[]` from a thread's interaction log so the TUI can
+ * hydrate chat history (plus the Tools tab) when resuming a session.
+ *
+ * Tools attach to the assistant message that *issued* them, not the next one.
+ * `runChatTurn` logs in the order: assistant text → tool_use(s) → tool_result(s)
+ * → next assistant text, so we track the most recent assistant message and
+ * append tool calls there until a user message resets the cursor.
+ */
+export function restoreMessagesFromInteractions(
+  interactions: Interaction[],
+): ChatMessage[] {
+  const result: ChatMessage[] = [];
+  let currentAssistant: ChatMessage | null = null;
+  let orphanTools: ToolCallData[] = [];
+  let restoredIdx = 0;
+
+  const makeToolCall = (ix: Interaction): ToolCallData => ({
+    id: `restored-${restoredIdx++}`,
+    name: ix.tool_name ?? "unknown",
+    input: ix.tool_input ?? "{}",
+    running: false,
+    timestamp: ix.created_at,
+  });
+
+  for (const ix of interactions) {
+    if (ix.kind === "tool_use") {
+      const tc = makeToolCall(ix);
+      if (currentAssistant) {
+        const list = currentAssistant.toolCalls ?? [];
+        list.push(tc);
+        currentAssistant.toolCalls = list;
+      } else {
+        orphanTools.push(tc);
+      }
+    } else if (ix.kind === "tool_result") {
+      const pool = currentAssistant?.toolCalls ?? orphanTools;
+      const tc = pool.find((t) => t.name === ix.tool_name && !t.output);
+      if (tc) {
+        tc.output = ix.content;
+        tc.isError = detectToolError(ix.content);
+        if (ix.content.length > MAX_INLINE_CHARS) {
+          tc.largeResult = {
+            id: "(restored)",
+            chars: ix.content.length,
+            pages: Math.ceil(ix.content.length / PAGE_SIZE_CHARS),
+          };
+        }
+      }
+    } else if (ix.kind === "message" && ix.role === "user") {
+      result.push({
+        id: restoreMsgId(),
+        role: "user",
+        content: ix.content,
+        timestamp: ix.created_at,
+      });
+      currentAssistant = null;
+    } else if (ix.kind === "message" && ix.role === "assistant") {
+      const msg: ChatMessage = {
+        id: restoreMsgId(),
+        role: "assistant",
+        content: ix.content,
+        timestamp: ix.created_at,
+      };
+      if (orphanTools.length > 0) {
+        msg.toolCalls = [...orphanTools];
+        orphanTools = [];
+      }
+      result.push(msg);
+      currentAssistant = msg;
+    }
+  }
+
+  if (orphanTools.length > 0) {
+    result.push({
+      id: restoreMsgId(),
+      role: "assistant",
+      content: "",
+      timestamp: orphanTools[0]?.timestamp ?? new Date(),
+      toolCalls: [...orphanTools],
+    });
+  }
+
+  return result;
+}

--- a/test/tui/restore-messages.test.ts
+++ b/test/tui/restore-messages.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from "bun:test";
+import type { Interaction } from "../../src/threads/store.ts";
+import { restoreMessagesFromInteractions } from "../../src/tui/restoreMessages.ts";
+
+let seq = 0;
+function ix(
+  partial: Partial<Interaction> & Pick<Interaction, "kind" | "role">,
+): Interaction {
+  seq += 1;
+  return {
+    id: `t:${seq}`,
+    thread_id: "t",
+    sequence: seq,
+    role: partial.role,
+    kind: partial.kind,
+    content: partial.content ?? "",
+    tool_name: partial.tool_name ?? null,
+    tool_input: partial.tool_input ?? null,
+    duration_ms: null,
+    token_count: null,
+    created_at: partial.created_at ?? new Date(0),
+  };
+}
+
+describe("restoreMessagesFromInteractions", () => {
+  test("returns [] for empty interactions", () => {
+    expect(restoreMessagesFromInteractions([])).toEqual([]);
+  });
+
+  test("attaches tools to the issuing assistant, not the next one", () => {
+    const interactions: Interaction[] = [
+      ix({ kind: "message", role: "user", content: "hi" }),
+      ix({ kind: "message", role: "assistant", content: "I'll check" }),
+      ix({
+        kind: "tool_use",
+        role: "assistant",
+        tool_name: "context_read",
+        tool_input: '{"path":"a.md"}',
+      }),
+      ix({
+        kind: "tool_result",
+        role: "tool",
+        tool_name: "context_read",
+        content: "file body",
+      }),
+      ix({ kind: "message", role: "assistant", content: "here you go" }),
+    ];
+
+    const msgs = restoreMessagesFromInteractions(interactions);
+    expect(msgs).toHaveLength(3);
+    expect(msgs[0]?.role).toBe("user");
+    expect(msgs[1]?.role).toBe("assistant");
+    expect(msgs[1]?.content).toBe("I'll check");
+    expect(msgs[1]?.toolCalls).toHaveLength(1);
+    expect(msgs[1]?.toolCalls?.[0]?.name).toBe("context_read");
+    expect(msgs[1]?.toolCalls?.[0]?.output).toBe("file body");
+    expect(msgs[1]?.toolCalls?.[0]?.running).toBe(false);
+    expect(msgs[2]?.role).toBe("assistant");
+    expect(msgs[2]?.content).toBe("here you go");
+    expect(msgs[2]?.toolCalls).toBeUndefined();
+  });
+
+  test("creates a synthetic assistant for tools with no following message", () => {
+    const interactions: Interaction[] = [
+      ix({ kind: "message", role: "user", content: "do it" }),
+      ix({
+        kind: "tool_use",
+        role: "assistant",
+        tool_name: "search_threads",
+        tool_input: '{"q":"x"}',
+      }),
+      ix({
+        kind: "tool_result",
+        role: "tool",
+        tool_name: "search_threads",
+        content: "[]",
+      }),
+    ];
+
+    const msgs = restoreMessagesFromInteractions(interactions);
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0]?.role).toBe("user");
+    expect(msgs[1]?.role).toBe("assistant");
+    expect(msgs[1]?.content).toBe("");
+    expect(msgs[1]?.toolCalls).toHaveLength(1);
+    expect(msgs[1]?.toolCalls?.[0]?.name).toBe("search_threads");
+    expect(msgs[1]?.toolCalls?.[0]?.output).toBe("[]");
+  });
+
+  test("multiple tools in the same turn all attach to the same assistant", () => {
+    const interactions: Interaction[] = [
+      ix({ kind: "message", role: "user", content: "go" }),
+      ix({ kind: "message", role: "assistant", content: "doing two things" }),
+      ix({
+        kind: "tool_use",
+        role: "assistant",
+        tool_name: "tool_p",
+        tool_input: "{}",
+      }),
+      ix({
+        kind: "tool_use",
+        role: "assistant",
+        tool_name: "tool_q",
+        tool_input: "{}",
+      }),
+      ix({
+        kind: "tool_result",
+        role: "tool",
+        tool_name: "tool_p",
+        content: "p out",
+      }),
+      ix({
+        kind: "tool_result",
+        role: "tool",
+        tool_name: "tool_q",
+        content: "q out",
+      }),
+    ];
+
+    const msgs = restoreMessagesFromInteractions(interactions);
+    expect(msgs).toHaveLength(2);
+    const calls = msgs[1]?.toolCalls;
+    expect(calls).toHaveLength(2);
+    expect(calls?.[0]?.name).toBe("tool_p");
+    expect(calls?.[0]?.output).toBe("p out");
+    expect(calls?.[1]?.name).toBe("tool_q");
+    expect(calls?.[1]?.output).toBe("q out");
+  });
+
+  test("flags tool errors when the result JSON has is_error", () => {
+    const interactions: Interaction[] = [
+      ix({ kind: "message", role: "user", content: "go" }),
+      ix({ kind: "message", role: "assistant", content: "trying" }),
+      ix({
+        kind: "tool_use",
+        role: "assistant",
+        tool_name: "tool_x",
+        tool_input: "{}",
+      }),
+      ix({
+        kind: "tool_result",
+        role: "tool",
+        tool_name: "tool_x",
+        content: '{"is_error":true,"message":"boom"}',
+      }),
+    ];
+
+    const msgs = restoreMessagesFromInteractions(interactions);
+    expect(msgs[1]?.toolCalls?.[0]?.isError).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Resuming \`botholomew chat --thread-id <id>\` left the **Tools** tab empty even when the thread CSV had \`tool_use\` / \`tool_result\` rows. Two bugs:

- Hydration was gated on \`session.messages.length > 0\`, which is false whenever the resumed thread has no \`kind:"message"\` rows yet (e.g. a thread closed mid-tool-loop). We now always hydrate when \`resumeThreadId\` is set.
- \`restoreMessagesFromInteractions\` buffered tools and attached them to the *next* assistant message, since the CSV order is \`assistant text → tool_use → tool_result → next assistant text\`. Switched to a \`currentAssistant\` cursor that resets on each user message, so tools land on the assistant that issued them.

Extracted the helper to \`src/tui/restoreMessages.ts\` so it's testable without rendering Ink, added five regression tests, and bumped the version.

## Test plan

- [x] \`bun run lint\` clean
- [x] \`bun test\` — 922/922 pass (5 new restore-messages cases)
- [ ] Manual: \`botholomew chat\` → trigger a tool → quit → \`--thread-id <id>\` → ⌃O shows prior tool calls; ⌃A shows tool cards under the issuing assistant bubble

🤖 Generated with [Claude Code](https://claude.com/claude-code)