### PR TITLE
TUI: keep active tools box stable while streaming long replies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -142,6 +142,7 @@ function AppInner({
   const [isLoading, setIsLoading] = useState(false);
   const [streamingText, setStreamingText] = useState("");
   const [activeToolCalls, setActiveToolCalls] = useState<ToolCallData[]>([]);
+  const [streamStartedAt, setStreamStartedAt] = useState<Date | null>(null);
   const [preparingTool, setPreparingTool] = useState<{
     id: string;
     name: string;
@@ -412,6 +413,7 @@ function AppInner({
       setStreamingText("");
       setActiveToolCalls([]);
       setPreparingTool(null);
+      setStreamStartedAt(new Date());
 
       const userMsg: ChatMessage = {
         id: msgId(),
@@ -439,6 +441,7 @@ function AppInner({
           pendingToolCalls = [];
           setStreamingText("");
           setActiveToolCalls([]);
+          setStreamStartedAt(new Date());
         }
       };
 
@@ -470,30 +473,39 @@ function AppInner({
               running: true,
               timestamp: new Date(),
             };
-            pendingToolCalls.push(tc);
-            setActiveToolCalls([...pendingToolCalls]);
+            pendingToolCalls = [...pendingToolCalls, tc];
+            setActiveToolCalls(pendingToolCalls);
             setPreparingTool(null);
           },
           onToolEnd: (id, _name, output, isError, meta) => {
             markActivityRef.current();
-            const tc = pendingToolCalls.find((t) => t.id === id);
-            if (tc) {
-              tc.running = false;
-              tc.output = output;
-              tc.isError = isError;
-              if (meta?.largeResult) {
-                tc.largeResult = meta.largeResult;
-              }
-            }
-            setActiveToolCalls([...pendingToolCalls]);
+            // Replace the matched entry with a new object so its identity
+            // changes (memoized ToolCall children rely on this); other entries
+            // keep their reference and skip re-render.
+            pendingToolCalls = pendingToolCalls.map((t) =>
+              t.id === id
+                ? {
+                    ...t,
+                    running: false,
+                    output,
+                    isError,
+                    ...(meta?.largeResult
+                      ? { largeResult: meta.largeResult }
+                      : {}),
+                  }
+                : t,
+            );
+            setActiveToolCalls(pendingToolCalls);
           },
           onToolNotify: (id, message) => {
             markActivityRef.current();
-            const tc = pendingToolCalls.find((t) => t.id === id);
-            if (tc) {
-              tc.notes = [...(tc.notes ?? []), message];
-              setActiveToolCalls([...pendingToolCalls]);
-            }
+            let touched = false;
+            pendingToolCalls = pendingToolCalls.map((t) => {
+              if (t.id !== id) return t;
+              touched = true;
+              return { ...t, notes: [...(t.notes ?? []), message] };
+            });
+            if (touched) setActiveToolCalls(pendingToolCalls);
           },
           onUsage: (info) => {
             setUsage(info);
@@ -540,6 +552,7 @@ function AppInner({
         setStreamingText("");
         setActiveToolCalls([]);
         setPreparingTool(null);
+        setStreamStartedAt(null);
       }
     }
 
@@ -695,6 +708,7 @@ function AppInner({
                 setStreamingText("");
                 setActiveToolCalls([]);
                 setPreparingTool(null);
+                setStreamStartedAt(null);
                 setUsage(null);
               } catch (err) {
                 setMessages((prev) => [
@@ -840,6 +854,7 @@ function AppInner({
           isLoading={isLoading}
           activeToolCalls={activeToolCalls}
           preparingTool={preparingTool}
+          streamStartedAt={streamStartedAt}
         />
       </Box>
       <Box

--- a/src/tui/components/MessageList.tsx
+++ b/src/tui/components/MessageList.tsx
@@ -18,6 +18,9 @@ interface MessageListProps {
   isLoading: boolean;
   activeToolCalls: ToolCallData[];
   preparingTool: { id: string; name: string } | null;
+  /** Timestamp the current streaming bubble started. Stable across token flushes
+   * so the displayed time doesn't flicker on every re-render. */
+  streamStartedAt: Date | null;
 }
 
 function formatTime(date: Date): string {
@@ -124,11 +127,46 @@ export const MessageBubble = memo(function MessageBubble({
   );
 });
 
+const ActiveToolsBox = memo(function ActiveToolsBox({
+  toolCalls,
+}: {
+  toolCalls: ToolCallData[];
+}) {
+  if (toolCalls.length === 0) return null;
+  return (
+    <Box
+      flexDirection="column"
+      marginLeft={1}
+      borderStyle="round"
+      borderColor={theme.accentBorder}
+      paddingX={1}
+    >
+      {toolCalls.map((tc) => (
+        <ToolCall key={tc.id} tool={tc} />
+      ))}
+    </Box>
+  );
+});
+
+const StreamingMarkdown = memo(function StreamingMarkdown({
+  text,
+}: {
+  text: string;
+}) {
+  const rendered = useMemo(() => renderMarkdown(text), [text]);
+  return (
+    <Box marginLeft={1}>
+      <Text>{rendered}</Text>
+    </Box>
+  );
+});
+
 export function MessageList({
   streamingText,
   isLoading,
   activeToolCalls,
   preparingTool,
+  streamStartedAt,
 }: MessageListProps) {
   return (
     <>
@@ -139,26 +177,10 @@ export function MessageList({
             <Text bold color="green">
               Botholomew
             </Text>
-            <Text dimColor> {formatTime(new Date())}</Text>
+            <Text dimColor> {formatTime(streamStartedAt ?? new Date())}</Text>
           </Box>
-          {activeToolCalls.length > 0 && (
-            <Box
-              flexDirection="column"
-              marginLeft={1}
-              borderStyle="round"
-              borderColor={theme.accentBorder}
-              paddingX={1}
-            >
-              {activeToolCalls.map((tc) => (
-                <ToolCall key={tc.id} tool={tc} />
-              ))}
-            </Box>
-          )}
-          {streamingText && (
-            <Box marginLeft={1}>
-              <Text>{renderMarkdown(streamingText)}</Text>
-            </Box>
-          )}
+          <ActiveToolsBox toolCalls={activeToolCalls} />
+          {streamingText && <StreamingMarkdown text={streamingText} />}
         </Box>
       )}
 

--- a/src/tui/components/ToolCall.tsx
+++ b/src/tui/components/ToolCall.tsx
@@ -1,4 +1,5 @@
 import { Box, Text } from "ink";
+import { memo } from "react";
 import { theme } from "../theme.ts";
 import { parseSleepInput, SleepProgress } from "./SleepProgress.tsx";
 
@@ -48,7 +49,7 @@ interface ToolCallProps {
   tool: ToolCallData;
 }
 
-export function ToolCall({ tool }: ToolCallProps) {
+export const ToolCall = memo(function ToolCall({ tool }: ToolCallProps) {
   const { displayName, displayInput } = resolveToolDisplay(
     tool.name,
     tool.input,
@@ -122,4 +123,4 @@ export function ToolCall({ tool }: ToolCallProps) {
       ))}
     </Box>
   );
-}
+});


### PR DESCRIPTION
## Summary
- The active-tools box rendered above the streaming reply visibly corrupted (and the TUI ground to a halt) when a turn fired tool calls and was followed by a long markdown response — every 50 ms token flush was re-rendering all `ToolCall` cards and re-parsing the whole growing reply.
- Memoize `ToolCall`, split `MessageList`'s dynamic frame into memoized `ActiveToolsBox` and `StreamingMarkdown` subtrees, and read the bubble's timestamp from a stable `streamStartedAt` prop so token flushes leave the tools box subtree untouched.
- Replace the in-place mutation in `onToolEnd`/`onToolNotify` with a non-mutating `.map()` so only the touched tool's identity changes — siblings keep their reference and skip re-render under `memo`.

## Test plan
- [x] `bun run lint`
- [x] `bun test` (922 pass)
- [ ] Manual: in `botholomew chat`, send a prompt that triggers several tool calls and then a long markdown reply; confirm the bordered tools box stays stable and tokens stream smoothly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)