### PR TITLE
TUI: fix Threads tab label to match its actual Ctrl+E binding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -201,7 +201,7 @@ function AppInner({
             id: msgId(),
             role: "system" as const,
             content:
-              "Switch panels with Ctrl+<letter> (^a chat · ^o tools · ^n context · ^t tasks · ^r threads · ^s schedules · ^w workers) — `?` for help. Type /help for commands.",
+              "Switch panels with Ctrl+<letter> (^a chat · ^o tools · ^n context · ^t tasks · ^e threads · ^s schedules · ^w workers) — `?` for help. Type /help for commands.",
             timestamp: new Date(),
           },
         ]);

--- a/src/tui/components/TabBar.tsx
+++ b/src/tui/components/TabBar.tsx
@@ -10,7 +10,7 @@ const TABS: { id: TabId; label: string; key: string }[] = [
   { id: 2, label: "Tools", key: "^o" },
   { id: 3, label: "Context", key: "^n" },
   { id: 4, label: "Tasks", key: "^t" },
-  { id: 5, label: "Threads", key: "^r" },
+  { id: 5, label: "Threads", key: "^e" },
   { id: 6, label: "Schedules", key: "^s" },
   { id: 7, label: "Workers", key: "^w" },
   { id: 8, label: "Help", key: "^g" },


### PR DESCRIPTION
## Summary
- The TabBar and chat splash hint still labeled the Threads tab `^r`, left over from before #207 moved the binding to `Ctrl+E`. Pressing the displayed `Ctrl+R` from the Chat tab triggered the refresh action (or did nothing on Chat) instead of jumping to Threads.
- Updates `src/tui/components/TabBar.tsx` and the splash hint in `src/tui/App.tsx` so the displayed shortcut matches the keymap. Bumps `version` to `0.16.2`.

## Test plan
- [x] `bun run lint`
- [x] `bun test`
- [ ] Manual: in `botholomew chat`, confirm the tab bar shows `^e Threads` and `Ctrl+E` jumps to Threads from the Chat tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)