### PR TITLE
TUI: hide timestamp on system message bubbles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/tui/components/MessageList.tsx
+++ b/src/tui/components/MessageList.tsx
@@ -92,7 +92,6 @@ export const MessageBubble = memo(function MessageBubble({
         <Text color={theme.accent} dimColor>
           ⚠ {message.content}
         </Text>
-        <Text dimColor> {time}</Text>
       </Box>
     );
   }


### PR DESCRIPTION
## Summary
- The boot help banner ("Switch panels with Ctrl+<letter>… Type /help for commands.") wraps across lines, and Ink's row layout was inserting the timestamp mid-paragraph between wrap rows.
- System messages (banner, /help, /clear, errors) are transient notifications, so drop the timestamp from `MessageBubble`'s system branch in `src/tui/components/MessageList.tsx` instead of restructuring the bubble. User/assistant timestamps are unchanged.
- Bumps `package.json` to `0.16.4`.

## Test plan
- [x] `bun run lint`
- [x] `bun test` (922 pass)
- [ ] Manual: `bun run dev chat` and confirm the startup banner, `/help`, `/clear`, and error notices render with no timestamp at narrow widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)