### PR TITLE
TUI: fix tail-mode in Threads pane (was blanking on every new interaction)

### DIFF
--- a/docs/tui.md
+++ b/docs/tui.md
@@ -59,7 +59,7 @@ filter state survive a round trip.
 | 2 | **Tools** | Scrollable log of every tool call in the current session, with full input/output. |
 | 3 | **Context** | Browse the agent's `context/` tree on disk. Preview, search, delete. |
 | 4 | **Tasks** | Task queue with status + priority filters. View details, payloads, and predecessor outputs. |
-| 5 | **Threads** | Browse past chat and worker threads. View interactions, delete with confirmation. |
+| 5 | **Threads** | Browse chat and worker threads, including live ones. Press `w` to tail an in-progress thread. |
 | 6 | **Schedules** | Recurring work. Toggle enabled/disabled, delete, inspect last run. |
 | 7 | **Workers** | Live view of registered workers (running / stopped / dead), pid, mode, heartbeat age. `f` cycles the status filter. |
 | 8 | **Help** | System info, worker status, keyboard reference. |
@@ -126,10 +126,19 @@ attempts. `Ctrl+R` refreshes. See [tasks-and-schedules.md](tasks-and-schedules.m
 
 ### 5. Threads
 
-Every thread ever persisted to the project DB, with a type filter
+Every thread ever persisted to the project, with a type filter
 (chat vs. worker). Threads store the full interaction history
 (messages, tool calls, tool results) — the same data the agent uses to
 reconstruct context on resume.
+
+Press `w` on an ongoing thread to tail it like `tail -f`: the detail
+pane polls the thread CSV every ~1 s, appends new interactions as they
+land, and auto-scrolls to the bottom. A green `● TAILING` badge marks
+the active state. Tailing exits automatically when the thread ends; the
+`w` keypress is a no-op on already-ended threads (the hint disappears
+too). Pairs well with `Ctrl+e` to jump to a worker thread that's in
+flight — you get a live read of what the worker is doing without
+spawning a separate `tail` on its CSV.
 
 `d` deletes a thread, with a yes/no confirmation. You can't delete the
 thread you're currently attached to.
@@ -350,7 +359,7 @@ move the selection (list focus) or scroll the detail (detail focus).
 | `d` then `d` | Delete the selected item (Tasks, Threads, Schedules, Context). First press arms; second confirms. Any other key or 3s of inactivity disarms. The active chat thread cannot be deleted. |
 | `e` | Toggle enable/disable (Schedules only) |
 | `s` or `/` | Search (Threads only) |
-| `w` | Toggle follow-mode (Threads only) |
+| `w` | Toggle tail/follow on the selected ongoing thread (Threads only) |
 | `l` | Toggle detail / log view (Workers only) |
 | `d` then `d` (Workers, log view) | Delete the worker's on-disk log file. The worker record itself is preserved. |
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/tui/components/HelpPanel.tsx
+++ b/src/tui/components/HelpPanel.tsx
@@ -149,8 +149,8 @@ export const HelpPanel = memo(function HelpPanel({
           {"  "}Tasks{"          "}f filter · p priority · d delete (×2)
         </Text>
         <Text>
-          {"  "}Threads{"        "}f filter · s/ search · w follow · d delete
-          (×2)
+          {"  "}Threads{"        "}f filter · s/ search · w tail live thread · d
+          delete (×2)
         </Text>
         <Text>
           {"  "}Schedules{"      "}f filter · e toggle · d delete (×2)

--- a/src/tui/components/ThreadPanel.tsx
+++ b/src/tui/components/ThreadPanel.tsx
@@ -18,7 +18,7 @@ import { ansi, theme } from "../theme.ts";
 import { useDeleteConfirm } from "../useDeleteConfirm.ts";
 import { useLatestRef } from "../useLatestRef.ts";
 import { useTerminalSize } from "../useTerminalSize.ts";
-import { wrapDetailLines } from "../wrapDetail.ts";
+import { clampScroll, wrapDetailLines } from "../wrapDetail.ts";
 import { DeleteArmedBanner } from "./DeleteArmedBanner.tsx";
 import { Scrollbar } from "./Scrollbar.tsx";
 
@@ -449,9 +449,10 @@ export const ThreadPanel = memo(function ThreadPanel({
     sidebarScrollOffset + visibleRows,
   );
 
+  const safeDetailScroll = clampScroll(detailScroll, maxDetailScroll);
   const detailVisible = detailLines.slice(
-    detailScroll,
-    detailScroll + visibleRows,
+    safeDetailScroll,
+    safeDetailScroll + visibleRows,
   );
 
   return (
@@ -547,7 +548,7 @@ export const ThreadPanel = memo(function ThreadPanel({
         <Box flexDirection="row" flexGrow={1} overflow="hidden">
           <Box flexDirection="column" flexGrow={1} overflow="hidden">
             {detailVisible.map((line, i) => {
-              const lineNum = detailScroll + i;
+              const lineNum = safeDetailScroll + i;
               return (
                 <Text key={lineNum} wrap="truncate-end">
                   {line || " "}
@@ -558,7 +559,7 @@ export const ThreadPanel = memo(function ThreadPanel({
           <Scrollbar
             total={detailLines.length}
             visible={visibleRows - 3}
-            offset={detailScroll}
+            offset={safeDetailScroll}
             height={visibleRows - 3}
             focused={focus === "detail"}
           />
@@ -571,13 +572,13 @@ export const ThreadPanel = memo(function ThreadPanel({
           {following && (
             <Text color={theme.success} bold>
               {" "}
-              FOLLOWING{" "}
+              ● TAILING{" "}
             </Text>
           )}
           <Text dimColor>
             {focus === "detail"
               ? "↑↓ scroll · ⇧↑↓ page · g/G top/bot · ← back to list"
-              : `↑↓ select · → enter detail · s search · f filter · d delete (×2)${selectedThread && !selectedThread.ended_at ? " · w follow" : ""} · ^R refresh`}
+              : `↑↓ select · → enter detail · s search · f filter · ${selectedThread && !selectedThread.ended_at ? "w tail (live) · " : ""}d delete (×2) · ^R refresh`}
           </Text>
         </Box>
       </Box>

--- a/src/tui/wrapDetail.ts
+++ b/src/tui/wrapDetail.ts
@@ -13,3 +13,14 @@ export function wrapDetailLines(text: string, width: number): string[] {
   if (width <= 0) return text.split("\n");
   return wrapAnsi(text, width, { hard: true, trim: false }).split("\n");
 }
+
+/**
+ * Clamp a scroll offset into the valid range for a detail pane. The Threads
+ * pane uses `Number.MAX_SAFE_INTEGER` as a "stay-at-bottom" sentinel during
+ * tail mode, and any panel can end up with an out-of-range scroll after a
+ * terminal resize shrinks `visibleRows`. Without clamping, `Array.slice`
+ * silently returns `[]`.
+ */
+export function clampScroll(scroll: number, maxScroll: number): number {
+  return Math.min(Math.max(0, scroll), Math.max(0, maxScroll));
+}

--- a/test/tui/wrapDetail.test.ts
+++ b/test/tui/wrapDetail.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { clampScroll } from "../../src/tui/wrapDetail.ts";
+
+describe("clampScroll", () => {
+  test("returns scroll unchanged when in range", () => {
+    expect(clampScroll(0, 80)).toBe(0);
+    expect(clampScroll(40, 80)).toBe(40);
+    expect(clampScroll(80, 80)).toBe(80);
+  });
+
+  test("pins MAX_SAFE_INTEGER sentinel to maxScroll (tail-mode bug fix)", () => {
+    // Threads-pane follow mode sets detailScroll to MAX_SAFE_INTEGER as a
+    // "stay-at-bottom" signal. Without this clamp, Array.slice returned []
+    // and the detail pane went blank every time a new interaction streamed
+    // in. Regression guard.
+    expect(clampScroll(Number.MAX_SAFE_INTEGER, 80)).toBe(80);
+    expect(clampScroll(Number.MAX_SAFE_INTEGER, 0)).toBe(0);
+  });
+
+  test("clamps negatives to zero", () => {
+    expect(clampScroll(-5, 80)).toBe(0);
+    expect(clampScroll(-Number.MAX_SAFE_INTEGER, 80)).toBe(0);
+  });
+
+  test("handles negative maxScroll defensively", () => {
+    // Could happen if detailLines.length < visibleRows and someone forgets
+    // the Math.max(0, ...) on maxScroll itself.
+    expect(clampScroll(0, -5)).toBe(0);
+    expect(clampScroll(10, -5)).toBe(0);
+  });
+
+  test("slice with clamped scroll yields the trailing window", () => {
+    // The actual usage in ThreadPanel: slice(safeScroll, safeScroll + visibleRows).
+    const detailLines = Array.from({ length: 100 }, (_, i) => `line ${i}`);
+    const visibleRows = 20;
+    const maxScroll = detailLines.length - visibleRows; // 80
+    const safe = clampScroll(Number.MAX_SAFE_INTEGER, maxScroll);
+    const window = detailLines.slice(safe, safe + visibleRows);
+    expect(window).toHaveLength(20);
+    expect(window[0]).toBe("line 80");
+    expect(window[19]).toBe("line 99");
+  });
+});


### PR DESCRIPTION
## Summary

- Tail/follow mode in the Threads pane (`Ctrl+e` → `w`) was broken: it set `detailScroll = Number.MAX_SAFE_INTEGER` as a stay-at-bottom sentinel, but the slice site never clamped, so `Array.slice` returned `[]` and the detail pane went blank every time a new interaction streamed in.
- Fix: extract a small `clampScroll` helper, wire it through `ThreadPanel` (slice + `Scrollbar` offset), with a regression test in `test/tui/wrapDetail.test.ts`.
- Renames the affordance from "follow" to "tail" everywhere it surfaces (footer hint `w tail (live)`, badge `● TAILING`, Help panel, `docs/tui.md` table + § 5 paragraph + keyboard reference) since the user's mental model is `tail -f`.

## Test plan

- [x] `bun run lint`
- [x] `bun test` (927/927)
- [x] `bun run docs:build`
- [ ] Manual: `bun run dev chat`, `Ctrl+e`, select an in-flight worker thread, press `w` → green `● TAILING` badge appears and new interactions stream in without blanking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)