### PR TITLE
Default membot and mcpx to shared global stores (~/.membot, ~/.mcpx)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ An AI agent for knowledge work. See `docs/plans/README.md` for the milestone roa
 
 ## On-disk patterns
 
-- **Project root is the cwd.** `botholomew init` writes its tree at `<cwd>/{config,prompts,skills,mcpx,tasks,schedules,threads,workers,logs}` plus `index.duckdb` (membot's knowledge store) — there is no `.botholomew/` wrapper.
+- **Project root is the cwd.** `botholomew init` writes its tree at `<cwd>/{config,prompts,skills,mcpx,tasks,schedules,threads,workers,logs}`. There is no `.botholomew/` wrapper. The membot knowledge store (`index.duckdb`) and the seeded mcpx `servers.json` are only written into `<cwd>` when `membot_scope` / `mcpx_scope` in `config/config.json` is `"project"`; the default is `"global"`, which resolves to `~/.membot/` and `~/.mcpx/` (shared across every project on the machine). Pass `--membot-scope=project` / `--mcpx-scope=project` to `botholomew init` to opt out per project.
 - **Path sandbox is non-negotiable.** Every tool that takes a `path` arg routes through `src/fs/sandbox.ts::resolveInRoot(root, userPath, opts)`. NFC-normalize, reject NUL/`..`/absolute, lstat-walk every component. By default symlink components are rejected. Tasks, schedules, prompts, and skills all depend on this helper. (Membot owns its own path semantics for `logical_path`, which is a DB key — not a filesystem path.)
 - **Atomic-write-via-rename for status mutations.** `src/fs/atomic.ts::atomicWrite` writes a `*.tmp.<wid>` then `fs.rename`s. Reads-before-writes (tasks/schedules/prompts) compare the file's `mtime` between read and write — abort and retry if it changed.
 - **`O_EXCL` lockfiles** for tasks and schedules. Body holds the worker id and `claimed_at`. Release = `unlink`. Reaper walks the lock dirs and unlinks orphans whose owner is dead in `workers/`.
@@ -77,11 +77,11 @@ An AI agent for knowledge work. See `docs/plans/README.md` for the milestone roa
 
 ## Knowledge store (membot)
 
-- **One `MembotClient` per process.** `src/mem/client.ts::openMembot(projectDir)` returns a per-project client pointed at `<projectDir>/index.duckdb` (via membot's `--config <projectDir>` flag — see `node_modules/membot/src/config/loader.ts`). Workers, chat sessions, and TUI panels each open one on startup and close on shutdown.
+- **One `MembotClient` per process.** `src/mem/client.ts::openMembot(dataDir)` takes a resolved data directory. Callers compute it with `resolveMembotDir(projectDir, config)`: `"global"` → `~/.membot`, `"project"` → `<projectDir>`. Workers, chat sessions, TUI panels, and init each call this pair on startup. The default scope is `"global"`, so a fresh project shares knowledge with every other project on the machine unless the user opts out. The same shape exists for mcpx (`createMcpxClient(mcpxDir)` + `resolveMcpxDir(projectDir, config)` in `src/mcpx/client.ts`).
 - **`ToolContext.mem` is the only handle the agent sees.** Every `membot_*` tool routes through it. Membot manages its DuckDB lock per-op so multiple in-process consumers (worker + chat + TUI panel) share the file safely.
 - **No direct DuckDB access from Botholomew.** We don't import `@duckdb/node-api` or `@huggingface/transformers`. Every DB / embedding concern lives behind the membot SDK.
 - **Agent tools live in `src/tools/membot/`.** `adapter.ts` turns each upstream membot `Operation` into a Botholomew `ToolDefinition`; `edit.ts`, `copy.ts`, `exists.ts`, `count_lines.ts`, and `pipe.ts` add the file-shaped UX our agents already know (git-hunk patches, presence checks, etc.) on top of membot's whole-file `write`.
-- **CLI passthrough.** `botholomew context <args…>` spawns `membot <args…> --config <projectDir>` and forwards stdio (mirrors how `botholomew mcpx …` proxies to upstream mcpx). There is no Botholomew-side `context_*` command implementation.
+- **CLI passthrough.** `botholomew context <args…>` spawns `membot <args…> --config <resolvedDir>` (resolved from `membot_scope`); `botholomew mcpx <args…>` spawns `mcpx <args…> -c <resolvedDir>` (from `mcpx_scope`). Both forward stdio. There is no Botholomew-side `context_*` command implementation. The Botholomew-specific `context import-global` / `mcpx import-global` always copy into the **project** dir (so users can seed a project store before flipping scope to `"project"`).
 
 ## Testing
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "botholomew",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.92.0",
-        "@evantahler/mcpx": "0.21.3",
+        "@evantahler/mcpx": "0.21.6",
         "ansis": "^4.2.0",
         "commander": "^14.0.0",
         "gray-matter": "^4.0.3",
@@ -14,7 +14,7 @@
         "ink-spinner": "^5.0.0",
         "ink-text-input": "^6.0.0",
         "istextorbinary": "^9.5.0",
-        "membot": "^0.13.3",
+        "membot": "^0.14.0",
         "nanospinner": "^1.2.2",
         "react": "^19.2.0",
         "uuid": "^14.0.0",
@@ -175,7 +175,7 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
 
-    "@evantahler/mcpx": ["@evantahler/mcpx@0.21.3", "", { "dependencies": { "@huggingface/transformers": "^4.2.0", "@modelcontextprotocol/sdk": "^1.29.0", "@types/picomatch": "^4.0.3", "ajv": "^8.20.0", "ansis": "^4.2.0", "commander": "^14.0.3", "nanospinner": "^1.2.2", "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c", "picomatch": "^4.0.4" }, "peerDependencies": { "typescript": "^6" }, "bin": { "mcpx": "src/cli.ts" } }, "sha512-CdgCCDeIYurqZD4ojk1VVyO2TAkWhvU0iX/qTTXt+0H/C59wZ0EJUwmDsZ6VwLa8zQZ3Qwxl1eHvsDi+4MMnIA=="],
+    "@evantahler/mcpx": ["@evantahler/mcpx@0.21.6", "", { "dependencies": { "@huggingface/transformers": "^4.2.0", "@modelcontextprotocol/sdk": "^1.29.0", "@types/picomatch": "^4.0.3", "ajv": "^8.20.0", "ansis": "^4.2.0", "commander": "^14.0.3", "nanospinner": "^1.2.2", "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c", "picomatch": "^4.0.4" }, "peerDependencies": { "typescript": "^6" }, "bin": { "mcpx": "src/cli.ts" } }, "sha512-OXQNzSlLtT8u+SjspF82vKVp2FBV1ajRYAiMvBP0VgTzP6doS/PNgmrhhSnnvHZQTOcX06//550gsx8rf8Uwww=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
@@ -773,6 +773,8 @@
 
     "lop": ["lop@0.4.2", "", { "dependencies": { "duck": "^0.1.12", "option": "~0.2.1", "underscore": "^1.13.1" } }, "sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw=="],
 
+    "macos-ts": ["macos-ts@0.10.7", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "protobufjs": "^8.0.1" }, "peerDependencies": { "typescript": "^5" }, "bin": { "macos-mcp": "src/mcp-server.ts" } }, "sha512-JIYZRVnuKdELtQFGrwM+2zgA5+aaG0DVkzOfWJ7bCg3MfMpvQiq+6fmpwJ7iRfuS1avbFtDooLqHyFi6x7/1hA=="],
+
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "make-dir": ["make-dir@3.1.0", "", { "dependencies": { "semver": "^6.0.0" } }, "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw=="],
@@ -805,7 +807,7 @@
 
     "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
 
-    "membot": ["membot@0.13.3", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.0", "@duckdb/node-api": "1.5.2-r.1", "@huggingface/transformers": "^4.2.0", "@modelcontextprotocol/sdk": "^1.29.0", "@types/picomatch": "^4.0.3", "@types/turndown": "^5.0.5", "ansis": "^4.2.0", "commander": "^14.0.3", "fast-xml-parser": "^5.7.3", "gray-matter": "^4.0.3", "jszip": "^3.10.1", "mammoth": "^1.8.0", "mustache": "^4.2.0", "nanospinner": "^1.2.2", "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c", "picomatch": "^4.0.4", "playwright": "^1.59.1", "turndown": "^7.2.0", "unpdf": "^0.12.0", "xlsx": "^0.18.5", "zod": "^4.0.0", "zod-to-json-schema": "^3.23.0" }, "peerDependencies": { "typescript": "^6" }, "bin": { "membot": "src/cli.ts" } }, "sha512-O83ZeGO53aXo/YUugDvaVWA0jCQPMJW2/MocmeqULG51kcOqRJeHicoD+PHukXjzEqfTv/pdV4z9LQn3CWhS7w=="],
+    "membot": ["membot@0.14.0", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.0", "@duckdb/node-api": "1.5.2-r.1", "@huggingface/transformers": "^4.2.0", "@modelcontextprotocol/sdk": "^1.29.0", "@types/picomatch": "^4.0.3", "@types/turndown": "^5.0.5", "ansis": "^4.2.0", "commander": "^14.0.3", "fast-xml-parser": "^5.7.3", "gray-matter": "^4.0.3", "jszip": "^3.10.1", "macos-ts": "^0.10.7", "mammoth": "^1.8.0", "mustache": "^4.2.0", "nanospinner": "^1.2.2", "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c", "picomatch": "^4.0.4", "playwright": "^1.59.1", "turndown": "^7.2.0", "unpdf": "^0.12.0", "xlsx": "^0.18.5", "zod": "^4.0.0", "zod-to-json-schema": "^3.23.0" }, "peerDependencies": { "typescript": "^6" }, "bin": { "membot": "src/cli.ts" } }, "sha512-HwdapFdUBjSXIQUjrC82dkCasmZn9c5W90RAjaKUp2pq833Pv5YmU1dmudTfyk4uRsQJxsNAza3ktIVsQ5+Czw=="],
 
     "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
@@ -1232,6 +1234,8 @@
     "ink-text-input/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
+
+    "macos-ts/protobufjs": ["protobufjs@8.2.0", "", { "dependencies": { "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-oI+GC9iPxrQEr6wragljFKH46/r3rNsm6eg7F2fp6kBUMnf6/mesDRdBuF4gK+OyaKJ8N4C1B9s9cCeYdqFikg=="],
 
     "make-dir/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,6 +19,11 @@ tasks/schedules/prompts/skills, CSV for conversation history, JSON for
 worker pidfiles. The agent's *knowledge store* lives in `index.duckdb`,
 managed by the [`membot`](https://github.com/evantahler/membot) library —
 membot owns the schema, the ingestion pipeline, and the search index.
+By default that store is shared across projects at `~/.membot/`; set
+`membot_scope` to `"project"` in `config/config.json` to use a
+project-local `<projectDir>/index.duckdb`. The same toggle exists for
+MCP server config (`mcpx_scope` → `~/.mcpx/` vs. `<projectDir>/mcpx/`).
+See [Configuration](./configuration.md#per-project-vs-global).
 
 Concurrency:
 
@@ -251,9 +256,10 @@ The membot store is opened lazily — every Botholomew process holds one
 - **Chat**: each turn writes thread interactions to CSV; the same
   `ctx.mem` is shared across tool calls in one turn.
 - **CLI invocations**: `botholomew context <verb>` is a passthrough to
-  the `membot` binary — it spawns a fresh process with `--config <projectDir>`,
-  forwards stdio, and exits with the child's code. No long-lived
-  connection in the Botholomew process at all.
+  the `membot` binary — it spawns a fresh process with `--config
+  <resolvedDir>` (where `<resolvedDir>` is `~/.membot` or `<projectDir>`
+  depending on `membot_scope`), forwards stdio, and exits with the
+  child's code. No long-lived connection in the Botholomew process at all.
 - **Cross-process safety**: membot's lock-with-backoff means a worker
   and a `botholomew context add …` running side-by-side serialize on
   DuckDB's file lock automatically — no extra coordination on our side

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -256,10 +256,11 @@ The membot store is opened lazily — every Botholomew process holds one
 - **Chat**: each turn writes thread interactions to CSV; the same
   `ctx.mem` is shared across tool calls in one turn.
 - **CLI invocations**: `botholomew context <verb>` is a passthrough to
-  the `membot` binary — it spawns a fresh process with `--config
-  <resolvedDir>` (where `<resolvedDir>` is `~/.membot` or `<projectDir>`
-  depending on `membot_scope`), forwards stdio, and exits with the
-  child's code. No long-lived connection in the Botholomew process at all.
+  the `membot` binary — it spawns a fresh process with
+  `--config <resolvedDir>` (where `<resolvedDir>` is `~/.membot` or
+  `<projectDir>` depending on `membot_scope`), forwards stdio, and exits
+  with the child's code. No long-lived connection in the Botholomew
+  process at all.
 - **Cross-process safety**: membot's lock-with-backoff means a worker
   and a `botholomew context add …` running side-by-side serialize on
   DuckDB's file lock automatically — no extra coordination on our side

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,7 +21,9 @@ project directory. The full schema lives in `src/config/schemas.ts`.
   "schedule_min_interval_seconds": 60,
   "schedule_claim_stale_seconds": 300,
   "tui_idle_timeout_seconds": 180,
-  "log_level": ""
+  "log_level": "",
+  "membot_scope": "global",
+  "mcpx_scope": "global"
 }
 ```
 
@@ -48,6 +50,8 @@ project directory. The full schema lives in `src/config/schemas.ts`.
 | `schedule_claim_stale_seconds` | `300` | If a worker claimed a schedule but never released it (crash), another worker may steal the claim after this many seconds. |
 | `tui_idle_timeout_seconds` | `180` | Seconds of inactivity (no keystrokes, no streamed agent tokens, no tool events) before the chat TUI freezes its visible animations and pauses the status-bar count refresh. Animations resume on the next activity. Set to `0` to disable (always animate — useful for demo recordings). |
 | `log_level` | `""` | Verbosity for `botholomew` CLI logs. One of `silent`, `error`, `warn`, `info`, `debug`. Empty string falls back to the runtime default (`info` normally, `error` under `NODE_ENV=test`). `BOTHOLOMEW_LOG_LEVEL` env var overrides this. |
+| `membot_scope` | `"global"` | Where this project's knowledge store lives. `"global"` → `~/.membot/index.duckdb` (shared across every Botholomew project on the machine). `"project"` → `<projectDir>/index.duckdb` (isolated). Affects both the agent and the `botholomew context …` CLI passthrough. |
+| `mcpx_scope` | `"global"` | Where this project's MCP server config lives. `"global"` → `~/.mcpx/` (shared). `"project"` → `<projectDir>/mcpx/` (isolated). Affects both the agent and the `botholomew mcpx …` CLI passthrough. |
 
 ---
 
@@ -98,7 +102,37 @@ without confirmation", …).
 
 ## Per-project vs. global
 
-There is no global config — everything is per-project. This is
-deliberate: different projects have different goals, different MCP
-servers, different beliefs. One Botholomew project's config shouldn't
-leak into another's.
+`config.json` itself is always per-project — different projects have
+different goals, beliefs, and tuning. But the two data stores it points
+at (`membot` for knowledge, `mcpx` for MCP servers) default to **shared
+global** locations, because reusing a personal knowledge base and a set
+of authenticated MCP servers across every project is almost always what
+you want.
+
+Defaults for new projects:
+
+| Concern | Default scope | Resolves to |
+|---|---|---|
+| `membot_scope` | `"global"` | `~/.membot/` |
+| `mcpx_scope` | `"global"` | `~/.mcpx/` |
+
+To opt one (or both) into per-project isolation, set the key to
+`"project"` in `config/config.json`, or pass `--membot-scope=project` /
+`--mcpx-scope=project` to `botholomew init`. The agent loop, chat
+session, TUI, and CLI passthroughs (`botholomew context …`, `botholomew
+mcpx …`) all honour the scope on every invocation.
+
+Migrating between scopes:
+
+- **Global → project**: `botholomew context import-global` (copies
+  `~/.membot/` into the project) or `botholomew mcpx import-global`
+  (copies `~/.mcpx/`), then flip the scope key to `"project"`.
+- **Project → global**: copy `<projectDir>/index.duckdb` to
+  `~/.membot/index.duckdb` (or `<projectDir>/mcpx/*.json` to `~/.mcpx/`),
+  then flip the scope key to `"global"`.
+
+Projects initialized before the scope settings existed have no
+`membot_scope` / `mcpx_scope` keys; both default to `"global"`, so the
+agent reads the shared store. Any pre-existing project-local
+`index.duckdb` or `mcpx/servers.json` is left in place but unused until
+you flip the scope back.

--- a/docs/context-and-search.md
+++ b/docs/context-and-search.md
@@ -3,8 +3,10 @@
 Botholomew's knowledge store is the [`membot`](https://github.com/evantahler/membot) library.
 Ingestion (PDF / DOCX / HTML / images → markdown), local WASM embeddings,
 hybrid BM25 + semantic search, append-only versioning, and URL refresh all
-live there. Every project gets its own `<projectDir>/index.duckdb` managed
-by membot.
+live there. By default the store is **shared globally** at `~/.membot/index.duckdb`,
+so every Botholomew project on the machine sees the same knowledge — switch
+`membot_scope` to `"project"` in `config/config.json` to isolate a project at
+`<projectDir>/index.duckdb`. See [Storage scope](#storage-scope) below.
 
 This page is intentionally short — the canonical docs live with membot.
 
@@ -22,9 +24,11 @@ This page is intentionally short — the canonical docs live with membot.
 ## Calling membot from Botholomew
 
 - **CLI**: `botholomew context <verb> …` is a thin passthrough that spawns
-  `membot <verb> … --config <projectDir>`. Run `botholomew context --help` to
-  see the full verb list. `botholomew context import-global` is the only
-  Botholomew-specific subcommand — it copies `~/.membot` into the project.
+  `membot <verb> … --config <resolvedDir>`, where `<resolvedDir>` follows the
+  `membot_scope` setting (see below). Run `botholomew context --help` for the
+  verb list. `botholomew context import-global` is the only Botholomew-specific
+  subcommand — it copies `~/.membot` into `<projectDir>` (useful when migrating
+  global → project).
 - **Chat agent**: the agent calls `membot_add`, `membot_search`, `membot_read`,
   `membot_write`, `membot_edit`, `membot_move`, `membot_delete`,
   `membot_versions`, `membot_diff`, `membot_refresh`, etc. See
@@ -32,17 +36,45 @@ This page is intentionally short — the canonical docs live with membot.
   Botholomew-side wrappers (`membot_edit`, `membot_copy`, `membot_exists`,
   `membot_count_lines`, `membot_pipe`).
 - **In-process**: every Botholomew process opens one `MembotClient` via
-  `src/mem/client.ts::openMembot(projectDir)`. Workers, the chat session, and
-  the TUI Context panel all share that handle through `ToolContext.mem`.
+  `src/mem/client.ts::openMembot(resolveMembotDir(projectDir, config))`. Workers,
+  the chat session, and the TUI Context panel all share that handle through
+  `ToolContext.mem`.
+
+## Storage scope
+
+`membot_scope` in `config/config.json` controls where the knowledge store
+lives:
+
+| Value | Resolves to | Use when |
+|---|---|---|
+| `"global"` (default) | `~/.membot/index.duckdb` | You want one personal knowledge base reused across every Botholomew project. |
+| `"project"` | `<projectDir>/index.duckdb` | You want strict per-project isolation (e.g. client work that shouldn't mix with personal notes). |
+
+Switch with one of:
+
+- `botholomew init --membot-scope=project` (new project)
+- Edit `config/config.json` and set `"membot_scope": "project"` (existing project)
+- Run `botholomew context import-global` to seed the project-local store from
+  `~/.membot` before flipping the scope.
 
 ## On-disk layout
 
+When `membot_scope` is `"global"` (the default):
+
+```
+~/.membot/
+  index.duckdb     ← shared membot knowledge store
+  config.json      ← membot's own config
+```
+
+When `membot_scope` is `"project"`:
+
 ```
 <projectDir>/
-  index.duckdb     ← membot's knowledge store
+  index.duckdb     ← project-local membot knowledge store
   config.json      ← membot config (separate from <projectDir>/config/config.json)
 ```
 
 Everything else under `<projectDir>` — `tasks/`, `schedules/`, `threads/`,
 `prompts/`, `skills/`, `workers/`, `logs/`, `mcpx/`, `config/` — is still
-Botholomew-owned and lives as real files on disk.
+Botholomew-owned and always lives in the project regardless of scope.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -49,21 +49,27 @@ the agent or worker touches is a real file you can `vim`, `grep`, and
 
 ```
 my-project/
-  config/config.json                # models, tick interval, API keys
+  config/config.json                # models, tick interval, API keys, scope settings
   prompts/                          # markdown loaded into every system prompt (or keyword-loaded)
     goals.md                        #   identity + current goals (agent-editable)
     beliefs.md                      #   agent-editable priors
     capabilities.md                 #   auto-generated tool inventory
   skills/                           # slash commands (built-ins + user-defined)
-  mcpx/servers.json                 # external MCP servers (Gmail, Slack, …)
   tasks/<id>.md                     # tasks (status in frontmatter)
   schedules/<id>.md                 # schedules
   threads/<YYYY-MM-DD>/<id>.csv     # conversation history
   workers/<id>.json                 # worker pidfile + heartbeat
   logs/<YYYY-MM-DD>/<id>.log        # per-worker logs
-  index.duckdb                      # knowledge store (managed by membot)
-  config.json                       # membot config
 ```
+
+By default the knowledge store (`membot`) and MCP server config (`mcpx`)
+are **shared globally** at `~/.membot/` and `~/.mcpx/`, so personal
+knowledge and authenticated MCP servers carry across every Botholomew
+project on the machine. Pass `--membot-scope=project` or
+`--mcpx-scope=project` to `botholomew init` (or flip the corresponding
+key in `config/config.json` later) to use project-local
+`<projectDir>/index.duckdb` and `<projectDir>/mcpx/` instead. See
+[Configuration → Per-project vs. global](./configuration.md#per-project-vs-global).
 
 The agent has no shell and no filesystem-path surface to its knowledge
 store — every entry is addressed by `logical_path` (an opaque DB key).

--- a/docs/mcpx.md
+++ b/docs/mcpx.md
@@ -5,10 +5,14 @@ own. Everything external — reading email, searching the web, talking to
 GitHub — comes from MCP servers, managed per project via
 [**MCPX**](https://github.com/evantahler/mcpx).
 
-Think of MCPX as the `package.json` of the agent's tools: a
-project-local manifest (`mcpx/servers.json`) lists the MCP
-servers this project can use, and workers and the chat session connect
-to them at startup.
+Think of MCPX as the `package.json` of the agent's tools: a manifest
+(`servers.json`) lists the MCP servers a project can use, and workers
+and the chat session connect to them at startup. By default that
+manifest is **shared globally** at `~/.mcpx/`, so the OAuth tokens and
+server list you configure once carry over to every project — switch
+`mcpx_scope` to `"project"` in `config/config.json` to use a
+per-project `<projectDir>/mcpx/` directory instead. See
+[Storage scope](#storage-scope) below.
 
 You have two options for *how* those servers run:
 
@@ -97,9 +101,28 @@ your shell doesn't split them (e.g. `--args "-y,@scope/pkg"`).
 
 ---
 
+## Storage scope
+
+`mcpx_scope` in `config/config.json` controls where MCPX reads/writes:
+
+| Value | Resolves to | Use when |
+|---|---|---|
+| `"global"` (default) | `~/.mcpx/` | You want one set of authenticated MCP servers reused across every Botholomew project. |
+| `"project"` | `<projectDir>/mcpx/` | You want strict per-project isolation (different OAuth identities, gateway endpoints, or tool surfaces per project). |
+
+Switch with one of:
+
+- `botholomew init --mcpx-scope=project` (new project)
+- Edit `config/config.json` and set `"mcpx_scope": "project"` (existing project)
+- Run `botholomew mcpx import-global` to seed `<projectDir>/mcpx/` from
+  `~/.mcpx/` before flipping the scope.
+
+---
+
 ## Lifecycle
 
-`createMcpxClient(projectDir)` in `src/mcpx/client.ts`:
+`createMcpxClient(mcpxDir)` in `src/mcpx/client.ts` (called with the dir
+returned by `resolveMcpxDir(projectDir, config)`):
 
 1. Reads `servers.json`.
 2. Connects to every server.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.92.0",
-    "@evantahler/mcpx": "0.21.3",
+    "@evantahler/mcpx": "0.21.6",
     "ansis": "^4.2.0",
     "commander": "^14.0.0",
     "gray-matter": "^4.0.3",
@@ -36,7 +36,7 @@
     "ink-spinner": "^5.0.0",
     "ink-text-input": "^6.0.0",
     "istextorbinary": "^9.5.0",
-    "membot": "^0.13.3",
+    "membot": "^0.14.0",
     "nanospinner": "^1.2.2",
     "react": "^19.2.0",
     "uuid": "^14.0.0",

--- a/src/chat/session.ts
+++ b/src/chat/session.ts
@@ -3,8 +3,8 @@ import type { MessageParam } from "@anthropic-ai/sdk/resources/messages";
 import type { MembotClient } from "membot";
 import { loadConfig } from "../config/loader.ts";
 import type { BotholomewConfig } from "../config/schemas.ts";
-import { createMcpxClient } from "../mcpx/client.ts";
-import { openMembot } from "../mem/client.ts";
+import { createMcpxClient, resolveMcpxDir } from "../mcpx/client.ts";
+import { openMembot, resolveMembotDir } from "../mem/client.ts";
 import { loadSkills } from "../skills/loader.ts";
 import type { SkillDefinition } from "../skills/parser.ts";
 import {
@@ -60,7 +60,7 @@ export async function startChatSession(
     );
   }
 
-  const mem = openMembot(projectDir);
+  const mem = openMembot(resolveMembotDir(projectDir, config));
   await mem.connect();
   await ensureThreadsDir(projectDir);
 
@@ -101,7 +101,7 @@ export async function startChatSession(
     );
   }
 
-  const mcpxClient = await createMcpxClient(projectDir);
+  const mcpxClient = await createMcpxClient(resolveMcpxDir(projectDir, config));
   const skills = await loadSkills(projectDir);
 
   const cleanup = async () => {

--- a/src/commands/capabilities.ts
+++ b/src/commands/capabilities.ts
@@ -1,7 +1,7 @@
 import type { Command } from "commander";
 import { createSpinner } from "nanospinner";
 import { loadConfig } from "../config/loader.ts";
-import { createMcpxClient } from "../mcpx/client.ts";
+import { createMcpxClient, resolveMcpxDir } from "../mcpx/client.ts";
 import { writeCapabilitiesFile } from "../prompts/capabilities.ts";
 import { registerAllTools } from "../tools/registry.ts";
 
@@ -19,7 +19,9 @@ export function registerCapabilitiesCommand(program: Command) {
       const spinner = createSpinner("Loading config").start();
       const config = await loadConfig(dir);
       spinner.update({ text: "Connecting to MCPX servers" });
-      const mcpxClient = includeMcp ? await createMcpxClient(dir) : null;
+      const mcpxClient = includeMcp
+        ? await createMcpxClient(resolveMcpxDir(dir, config))
+        : null;
       try {
         const result = await writeCapabilitiesFile(
           dir,

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -5,6 +5,8 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Command } from "commander";
 import { defaultCliName, OPERATIONS } from "membot";
+import { loadConfig } from "../config/loader.ts";
+import { resolveMembotDir } from "../mem/client.ts";
 import { logger } from "../utils/logger.ts";
 
 const require = createRequire(import.meta.url);
@@ -36,11 +38,14 @@ function getRawContextArgs(): string[] {
 }
 
 async function runMembot(projectDir: string, args: string[]): Promise<number> {
-  // Point membot at <projectDir> as its data dir via the `--config` flag —
-  // each Botholomew project gets its own membot store at
-  // `<projectDir>/index.duckdb`. Forward stdio so the user sees the same
-  // output they would running `membot` directly.
-  const proc = Bun.spawn(["bun", MEMBOT_CLI, "--config", projectDir, ...args], {
+  // Resolve membot's data dir from `membot_scope`:
+  //   - "global"  → ~/.membot (default, shared)
+  //   - "project" → <projectDir>
+  // Forward stdio so the user sees the same output they would running
+  // `membot` directly.
+  const config = await loadConfig(projectDir);
+  const membotDir = resolveMembotDir(projectDir, config);
+  const proc = Bun.spawn(["bun", MEMBOT_CLI, "--config", membotDir, ...args], {
     stdout: "inherit",
     stderr: "inherit",
     stdin: "inherit",
@@ -66,7 +71,7 @@ function registerImportGlobal(parent: Command, program: Command): void {
       "Overwrite an existing index.duckdb in the project",
       false,
     )
-    .action((opts: { force: boolean }) => {
+    .action(async (opts: { force: boolean }) => {
       const globalDir = join(homedir(), ".membot");
       if (!existsSync(globalDir)) {
         logger.error("No global membot data found at ~/.membot");
@@ -74,6 +79,12 @@ function registerImportGlobal(parent: Command, program: Command): void {
       }
 
       const projectDir = getDir(program);
+      const config = await loadConfig(projectDir);
+      if (config.membot_scope !== "project") {
+        logger.warn(
+          `membot_scope is "${config.membot_scope}" — Botholomew currently reads from ~/.membot. After this import, set membot_scope to "project" in ${getDir(program)}/config/config.json for the project-local copy to take effect.`,
+        );
+      }
       const dest = (name: string) => join(projectDir, name);
       const destDb = dest("index.duckdb");
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -2,6 +2,13 @@ import type { Command } from "commander";
 import { initProject } from "../init/index.ts";
 import { logger } from "../utils/logger.ts";
 
+function parseScope(value: string): "global" | "project" {
+  if (value !== "global" && value !== "project") {
+    throw new Error(`scope must be "global" or "project" (got "${value}")`);
+  }
+  return value;
+}
+
 export function registerInitCommand(program: Command) {
   program
     .command("init")
@@ -10,10 +17,24 @@ export function registerInitCommand(program: Command) {
       "--force",
       "overwrite existing project files; also bypass the unsupported-filesystem check (iCloud/Dropbox/etc)",
     )
+    .option(
+      "--membot-scope <scope>",
+      'where this project reads/writes its knowledge store: "global" (default; shared ~/.membot) or "project" (per-project index.duckdb)',
+      parseScope,
+    )
+    .option(
+      "--mcpx-scope <scope>",
+      'where this project reads its MCPX config: "global" (default; shared ~/.mcpx) or "project" (per-project mcpx/)',
+      parseScope,
+    )
     .action(async (opts) => {
       const dir = program.opts().dir;
       try {
-        await initProject(dir, { force: opts.force });
+        await initProject(dir, {
+          force: opts.force,
+          membotScope: opts.membotScope,
+          mcpxScope: opts.mcpxScope,
+        });
       } catch (err) {
         logger.error(String(err instanceof Error ? err.message : err));
         process.exit(1);

--- a/src/commands/mcpx.ts
+++ b/src/commands/mcpx.ts
@@ -7,7 +7,7 @@ import type { Command } from "commander";
 import { createSpinner } from "nanospinner";
 import { loadConfig } from "../config/loader.ts";
 import { getMcpxDir } from "../constants.ts";
-import { createMcpxClient } from "../mcpx/client.ts";
+import { createMcpxClient, resolveMcpxDir } from "../mcpx/client.ts";
 import { writeCapabilitiesFile } from "../prompts/capabilities.ts";
 import { registerAllTools } from "../tools/registry.ts";
 import { logger } from "../utils/logger.ts";
@@ -29,7 +29,11 @@ export async function runMcpx(
   args: (string | undefined)[],
   opts?: { inherit?: boolean },
 ): Promise<string> {
-  const mcpxDir = getMcpxDir(projectDir);
+  // Resolve mcpx config dir from `mcpx_scope`:
+  //   - "global"  → ~/.mcpx (default, shared)
+  //   - "project" → <projectDir>/mcpx
+  const config = await loadConfig(projectDir);
+  const mcpxDir = resolveMcpxDir(projectDir, config);
   const filteredArgs = args.filter((a): a is string => a !== undefined);
   const proc = Bun.spawn(["bun", MCPX_CLI, ...filteredArgs, "-c", mcpxDir], {
     stdout: opts?.inherit ? "inherit" : "pipe",
@@ -124,7 +128,15 @@ export function registerMcpxCommand(program: Command) {
         process.exit(1);
       }
 
-      const projectMcpxDir = getMcpxDir(getDir(program));
+      const projectDir = getDir(program);
+      const cfg = await loadConfig(projectDir);
+      if (cfg.mcpx_scope !== "project") {
+        logger.warn(
+          `mcpx_scope is "${cfg.mcpx_scope}" — Botholomew currently reads from ~/.mcpx. After this import, set mcpx_scope to "project" in ${projectDir}/config/config.json for the project-local copy to take effect.`,
+        );
+      }
+
+      const projectMcpxDir = getMcpxDir(projectDir);
       if (!existsSync(projectMcpxDir)) {
         mkdirSync(projectMcpxDir, { recursive: true });
       }
@@ -149,16 +161,17 @@ export function registerMcpxCommand(program: Command) {
         `Imported ${copied} file(s) from ~/.mcpx into ${projectMcpxDir}`,
       );
 
-      const projectDir = getDir(program);
       registerAllTools();
-      const config = await loadConfig(projectDir);
-      const mcpxClient = await createMcpxClient(projectDir);
+      // After import-global, the freshly-copied files live in the project's
+      // mcpx dir — read them from there so `capabilities.md` reflects what was
+      // just imported, regardless of the user's current `mcpx_scope` setting.
+      const mcpxClient = await createMcpxClient(projectMcpxDir);
       const spinner = createSpinner("Rebuilding capabilities.md").start();
       try {
         const result = await writeCapabilitiesFile(
           projectDir,
           mcpxClient,
-          config,
+          cfg,
           (phase) => spinner.update({ text: phase }),
         );
         spinner.success({

--- a/src/commands/nuke.ts
+++ b/src/commands/nuke.ts
@@ -2,8 +2,9 @@ import { rm } from "node:fs/promises";
 import { join } from "node:path";
 import ansis from "ansis";
 import type { Command } from "commander";
+import { loadConfig } from "../config/loader.ts";
 import { SCHEDULES_DIR, TASKS_DIR, THREADS_DIR } from "../constants.ts";
-import { openMembot } from "../mem/client.ts";
+import { openMembot, resolveMembotDir } from "../mem/client.ts";
 import { deleteAllSchedules } from "../schedules/store.ts";
 import { deleteAllTasks } from "../tasks/store.ts";
 import { deleteAllThreads } from "../threads/store.ts";
@@ -34,9 +35,16 @@ async function ensureNoRunningWorkers(projectDir: string): Promise<boolean> {
  * we fall back to deleting it outright.
  */
 async function nukeKnowledge(projectDir: string): Promise<void> {
-  const indexPath = join(projectDir, "index.duckdb");
+  const config = await loadConfig(projectDir);
+  const membotDir = resolveMembotDir(projectDir, config);
+  const indexPath = join(membotDir, "index.duckdb");
+  if (config.membot_scope !== "project") {
+    logger.warn(
+      `membot_scope is "${config.membot_scope}"; this will erase the SHARED knowledge store at ${membotDir}`,
+    );
+  }
   try {
-    const mem = openMembot(projectDir);
+    const mem = openMembot(membotDir);
     try {
       const list = await mem.list({ limit: 100_000 });
       const paths = list.entries.map((e) => e.logical_path);

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander";
 import { loadConfig } from "../config/loader.ts";
-import { openMembot } from "../mem/client.ts";
+import { openMembot, resolveMembotDir } from "../mem/client.ts";
 import { logger } from "../utils/logger.ts";
 
 export function registerPrepareCommand(program: Command) {
@@ -13,8 +13,7 @@ export function registerPrepareCommand(program: Command) {
       const projectDir = program.opts().dir as string;
       logger.info("Preparing Botholomew...");
       const config = await loadConfig(projectDir);
-      void config;
-      const mem = openMembot(projectDir);
+      const mem = openMembot(resolveMembotDir(projectDir, config));
       try {
         await mem.connect();
         logger.success("membot knowledge store opened successfully");

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -1,3 +1,5 @@
+export type Scope = "global" | "project";
+
 export interface BotholomewConfig {
   anthropic_api_key?: string;
   model?: string;
@@ -16,6 +18,8 @@ export interface BotholomewConfig {
   schedule_claim_stale_seconds?: number;
   tui_idle_timeout_seconds?: number;
   log_level?: string;
+  membot_scope?: Scope;
+  mcpx_scope?: Scope;
 }
 
 export const DEFAULT_CONFIG: Required<BotholomewConfig> = {
@@ -36,4 +40,6 @@ export const DEFAULT_CONFIG: Required<BotholomewConfig> = {
   schedule_claim_stale_seconds: 300,
   tui_idle_timeout_seconds: 180,
   log_level: "",
+  membot_scope: "global",
+  mcpx_scope: "global",
 };

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -21,8 +21,8 @@ import {
   TASKS_DIR,
 } from "../constants.ts";
 import { assertCompatibleFilesystem } from "../fs/compat.ts";
-import { createMcpxClient } from "../mcpx/client.ts";
-import { openMembot } from "../mem/client.ts";
+import { createMcpxClient, resolveMcpxDir } from "../mcpx/client.ts";
+import { openMembot, resolveMembotDir } from "../mem/client.ts";
 import { writeCapabilitiesFile } from "../prompts/capabilities.ts";
 import { registerAllTools } from "../tools/registry.ts";
 import { logger } from "../utils/logger.ts";
@@ -37,9 +37,17 @@ import {
   SUMMARIZE_SKILL,
 } from "./templates.ts";
 
+export interface InitOptions {
+  force?: boolean;
+  /** Override the default `membot_scope` written into config/config.json. */
+  membotScope?: "global" | "project";
+  /** Override the default `mcpx_scope` written into config/config.json. */
+  mcpxScope?: "global" | "project";
+}
+
 export async function initProject(
   projectDir: string,
-  opts: { force?: boolean } = {},
+  opts: InitOptions = {},
 ): Promise<void> {
   // Refuse to operate inside iCloud/Dropbox/etc unless --force is passed.
   // Sync overlays break atomic rename / O_EXCL semantics that tasks and
@@ -79,43 +87,63 @@ export async function initProject(
   await Bun.write(join(skillsDir, "standup.md"), STANDUP_SKILL);
   await Bun.write(join(skillsDir, "capabilities.md"), CAPABILITIES_SKILL);
 
-  // Config
-  await Bun.write(configPath, `${JSON.stringify(DEFAULT_CONFIG, null, 2)}\n`);
+  // Config — apply scope overrides from caller (CLI flags / tests) on top of
+  // the seeded defaults so tests and `botholomew init --membot-scope=project`
+  // can pick a per-project layout up front.
+  const initialConfig = {
+    ...DEFAULT_CONFIG,
+    ...(opts.membotScope ? { membot_scope: opts.membotScope } : {}),
+    ...(opts.mcpxScope ? { mcpx_scope: opts.mcpxScope } : {}),
+  };
+  await Bun.write(configPath, `${JSON.stringify(initialConfig, null, 2)}\n`);
+  const config = await loadConfig(projectDir);
 
-  // mcpx servers config
-  await Bun.write(
-    join(getMcpxDir(projectDir), MCPX_SERVERS_FILENAME),
-    `${JSON.stringify(DEFAULT_MCPX_SERVERS, null, 2)}\n`,
-  );
+  // mcpx servers config — only seed a project-local servers.json when the
+  // project is opting out of the shared `~/.mcpx`. The empty `mcpx/` directory
+  // is still created above so flipping `mcpx_scope` later is a one-line edit.
+  if (config.mcpx_scope === "project") {
+    await Bun.write(
+      join(getMcpxDir(projectDir), MCPX_SERVERS_FILENAME),
+      `${JSON.stringify(DEFAULT_MCPX_SERVERS, null, 2)}\n`,
+    );
+  }
 
   // Initialize the membot knowledge store. Opening + closing the client
-  // triggers membot's first-run migration so the project ships with a
-  // ready-to-use index.duckdb.
-  const mem = openMembot(projectDir);
+  // triggers membot's first-run migration. When `membot_scope` is "global"
+  // (the default) we point at `~/.membot` so the shared store is ready;
+  // when "project" we seed `<projectDir>/index.duckdb`.
+  const mem = openMembot(resolveMembotDir(projectDir, config));
   await mem.connect();
   await mem.close();
 
   // Populate capabilities.md with the real tool inventory.
   registerAllTools();
-  const config = await loadConfig(projectDir);
-  const mcpxClient = await createMcpxClient(projectDir);
+  const mcpxClient = await createMcpxClient(resolveMcpxDir(projectDir, config));
   try {
     await writeCapabilitiesFile(projectDir, mcpxClient, config);
   } finally {
     await mcpxClient?.close();
   }
 
+  const membotScopeDesc =
+    config.membot_scope === "project"
+      ? `${projectDir}/index.duckdb (project-local)`
+      : `~/.membot (shared across projects — set membot_scope to "project" in ${CONFIG_DIR}/${CONFIG_FILENAME} to isolate)`;
+  const mcpxScopeDesc =
+    config.mcpx_scope === "project"
+      ? `${projectDir}/mcpx/ (project-local)`
+      : `~/.mcpx (shared across projects — set mcpx_scope to "project" in ${CONFIG_DIR}/${CONFIG_FILENAME} to isolate)`;
   logger.success("Initialized Botholomew project");
-  logger.dim(`  Project root: ${projectDir}`);
-  logger.dim(`  Config:       ${CONFIG_DIR}/${CONFIG_FILENAME}`);
-  logger.dim(`  Knowledge:    index.duckdb (managed by membot)`);
+  logger.dim(`  Project root:  ${projectDir}`);
+  logger.dim(`  Config:        ${CONFIG_DIR}/${CONFIG_FILENAME}`);
+  logger.dim(`  Knowledge:     ${membotScopeDesc}`);
+  logger.dim(`  MCPX:          ${mcpxScopeDesc}`);
   logger.dim("");
   logger.dim("Layout:");
   logger.dim(`  ${CONFIG_DIR}/         settings`);
   logger.dim(
     `  prompts/         goals, beliefs, capabilities (and any you add)`,
   );
-  logger.dim(`  index.duckdb     agent's knowledge store (membot)`);
   logger.dim(`  ${TASKS_DIR}/          one markdown file per task`);
   logger.dim(`    ${LOCKS_SUBDIR}/        worker claim lockfiles`);
   logger.dim(`  ${SCHEDULES_DIR}/      one markdown file per schedule`);

--- a/src/mcpx/client.ts
+++ b/src/mcpx/client.ts
@@ -1,16 +1,33 @@
 import { existsSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import { type CallToolResult, McpxClient } from "@evantahler/mcpx";
+import type { BotholomewConfig } from "../config/schemas.ts";
 import { getMcpxDir, MCPX_SERVERS_FILENAME } from "../constants.ts";
 
 /**
- * Create an McpxClient from the project's mcpx/servers.json.
- * Returns null if the file is missing or has no servers configured.
+ * Resolve the mcpx config directory for a project, honoring `mcpx_scope`:
+ *   - "global"  → `~/.mcpx` (shared across all Botholomew projects)
+ *   - "project" → `<projectDir>/mcpx` (isolated per project)
+ */
+export function resolveMcpxDir(
+  projectDir: string,
+  config: Pick<BotholomewConfig, "mcpx_scope">,
+): string {
+  return config.mcpx_scope === "project"
+    ? getMcpxDir(projectDir)
+    : join(homedir(), ".mcpx");
+}
+
+/**
+ * Create an McpxClient from `<mcpxDir>/servers.json`. Returns null if the
+ * file is missing or has no servers configured. The caller is responsible
+ * for resolving `mcpxDir` via `resolveMcpxDir`.
  */
 export async function createMcpxClient(
-  projectDir: string,
+  mcpxDir: string,
 ): Promise<McpxClient | null> {
-  const serversPath = join(getMcpxDir(projectDir), MCPX_SERVERS_FILENAME);
+  const serversPath = join(mcpxDir, MCPX_SERVERS_FILENAME);
   if (!existsSync(serversPath)) return null;
 
   const raw = await Bun.file(serversPath).text();
@@ -20,7 +37,6 @@ export async function createMcpxClient(
     return null;
   }
 
-  const mcpxDir = getMcpxDir(projectDir);
   const authPath = join(mcpxDir, "auth.json");
   const auth = existsSync(authPath)
     ? JSON.parse(await Bun.file(authPath).text())

--- a/src/mem/client.ts
+++ b/src/mem/client.ts
@@ -1,17 +1,33 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { MembotClient } from "membot";
+import type { BotholomewConfig } from "../config/schemas.ts";
 
 /**
- * Open a per-project membot client. Each Botholomew project gets its own
- * membot data dir (`<projectDir>/config.json` + `<projectDir>/index.duckdb`)
- * so projects don't share knowledge. The caller is responsible for `close()`
- * on shutdown.
+ * Resolve the membot data directory for a project, honoring `membot_scope`:
+ *   - "global"  → `~/.membot` (shared across all Botholomew projects)
+ *   - "project" → `<projectDir>` (isolated per project)
  *
  * Membot's `configFlag` doubles as its data-dir flag (see
- * `membot/src/config/loader.ts::resolveDataDir`): an explicit value wins over
- * `$MEMBOT_HOME` and the `~/.membot` default. We pass the project directory
- * unconditionally so a stray `MEMBOT_HOME` in the user's environment cannot
- * redirect Botholomew at a different store.
+ * `node_modules/membot/src/config/loader.ts::resolveDataDir`): an explicit
+ * value wins over `$MEMBOT_HOME` and the `~/.membot` default. We always pass
+ * an explicit value so a stray `MEMBOT_HOME` cannot redirect Botholomew at a
+ * different store.
  */
-export function openMembot(projectDir: string): MembotClient {
-  return new MembotClient({ configFlag: projectDir });
+export function resolveMembotDir(
+  projectDir: string,
+  config: Pick<BotholomewConfig, "membot_scope">,
+): string {
+  return config.membot_scope === "project"
+    ? projectDir
+    : join(homedir(), ".membot");
+}
+
+/**
+ * Open a membot client rooted at `dataDir`. The caller is responsible for
+ * resolving the directory (via `resolveMembotDir`) and for `close()` on
+ * shutdown.
+ */
+export function openMembot(dataDir: string): MembotClient {
+  return new MembotClient({ configFlag: dataDir });
 }

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,8 +1,8 @@
 import { hostname } from "node:os";
 import ansis from "ansis";
 import { loadConfig } from "../config/loader.ts";
-import { createMcpxClient } from "../mcpx/client.ts";
-import { openMembot } from "../mem/client.ts";
+import { createMcpxClient, resolveMcpxDir } from "../mcpx/client.ts";
+import { openMembot, resolveMembotDir } from "../mem/client.ts";
 import { logger } from "../utils/logger.ts";
 import { uuidv7 } from "../utils/uuid.ts";
 import { markWorkerStopped, registerWorker } from "../workers/store.ts";
@@ -87,12 +87,12 @@ export async function startWorker(
   const evalSchedules = options.evalSchedules ?? !taskId;
 
   const config = await loadConfig(projectDir);
-  const mem = openMembot(projectDir);
+  const mem = openMembot(resolveMembotDir(projectDir, config));
   // Surface init-time failures (bad config, locked DB) up front rather than
   // letting the first tool call do it.
   await mem.connect();
 
-  const mcpxClient = await createMcpxClient(projectDir);
+  const mcpxClient = await createMcpxClient(resolveMcpxDir(projectDir, config));
   if (mcpxClient) {
     logger.info("MCPX client initialized with external tools");
   }

--- a/test/commands/mcpx.test.ts
+++ b/test/commands/mcpx.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { runMcpx } from "../../src/commands/mcpx.ts";
@@ -6,6 +6,16 @@ import { runMcpx } from "../../src/commands/mcpx.ts";
 const TMP_DIR = join(import.meta.dir, ".tmp-mcpx-cmd-test");
 const MCPX_DIR = join(TMP_DIR, "mcpx");
 const CLI_PATH = join(import.meta.dir, "..", "..", "src", "cli.ts");
+
+// Force project-local mcpx for these tests — the default is "global", which
+// would point runMcpx at ~/.mcpx and pollute / leak real user state.
+beforeEach(async () => {
+  mkdirSync(join(TMP_DIR, "config"), { recursive: true });
+  await Bun.write(
+    join(TMP_DIR, "config", "config.json"),
+    JSON.stringify({ mcpx_scope: "project", membot_scope: "project" }),
+  );
+});
 
 afterEach(() => {
   if (existsSync(TMP_DIR)) {

--- a/test/config/schemas.test.ts
+++ b/test/config/schemas.test.ts
@@ -50,4 +50,9 @@ describe("DEFAULT_CONFIG", () => {
       DEFAULT_CONFIG.max_tick_duration_seconds,
     );
   });
+
+  test("membot_scope and mcpx_scope default to global so new projects share ~/.membot and ~/.mcpx", () => {
+    expect(DEFAULT_CONFIG.membot_scope).toBe("global");
+    expect(DEFAULT_CONFIG.mcpx_scope).toBe("global");
+  });
 });

--- a/test/init/index.test.ts
+++ b/test/init/index.test.ts
@@ -131,18 +131,51 @@ describe("initProject", () => {
     expect(text).toContain("capabilities_refresh");
   });
 
-  test("creates index.duckdb (membot store) with migrations applied", async () => {
-    await initProject(projectDir);
+  test("creates index.duckdb (membot store) with migrations applied when membot_scope=project", async () => {
+    await initProject(projectDir, { membotScope: "project" });
     const dbPath = join(projectDir, "index.duckdb");
     expect(await Bun.file(dbPath).exists()).toBe(true);
   });
 
-  test("writes mcpx/servers.json with default content", async () => {
+  test("does NOT create a project-local index.duckdb under the default (global) scope", async () => {
     await initProject(projectDir);
+    const dbPath = join(projectDir, "index.duckdb");
+    expect(await Bun.file(dbPath).exists()).toBe(false);
+  });
+
+  test("writes mcpx/servers.json with default content when mcpx_scope=project", async () => {
+    await initProject(projectDir, { mcpxScope: "project" });
     const path = join(getMcpxDir(projectDir), MCPX_SERVERS_FILENAME);
     expect(await Bun.file(path).exists()).toBe(true);
     const cfg = JSON.parse(await fileText(path));
     expect(cfg).toBeDefined();
+  });
+
+  test("does NOT seed a project-local mcpx/servers.json under the default (global) scope", async () => {
+    await initProject(projectDir);
+    const path = join(getMcpxDir(projectDir), MCPX_SERVERS_FILENAME);
+    expect(await Bun.file(path).exists()).toBe(false);
+  });
+
+  test("config.json records the scope choices that were applied", async () => {
+    await initProject(projectDir);
+    const cfg = JSON.parse(
+      await fileText(join(projectDir, CONFIG_DIR, CONFIG_FILENAME)),
+    );
+    expect(cfg.membot_scope).toBe("global");
+    expect(cfg.mcpx_scope).toBe("global");
+
+    await rm(projectDir, { recursive: true, force: true });
+    projectDir = await mkdtemp(join(tmpdir(), "both-init-"));
+    await initProject(projectDir, {
+      membotScope: "project",
+      mcpxScope: "project",
+    });
+    const cfg2 = JSON.parse(
+      await fileText(join(projectDir, CONFIG_DIR, CONFIG_FILENAME)),
+    );
+    expect(cfg2.membot_scope).toBe("project");
+    expect(cfg2.mcpx_scope).toBe("project");
   });
 
   test("refuses to re-init without --force", async () => {

--- a/test/mcpx/client.test.ts
+++ b/test/mcpx/client.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import {
   createMcpxClient,
   formatCallToolResult,
+  resolveMcpxDir,
 } from "../../src/mcpx/client.ts";
 
 const TMP_DIR = join(import.meta.dir, ".tmp-mcpx-test");
@@ -22,13 +24,13 @@ afterEach(() => {
 
 describe("createMcpxClient", () => {
   test("returns null when servers.json does not exist", async () => {
-    const client = await createMcpxClient(TMP_DIR);
+    const client = await createMcpxClient(MCPX_DIR);
     expect(client).toBeNull();
   });
 
   test("returns null when mcpServers is empty", async () => {
     await writeTmpServers({ mcpServers: {} });
-    const client = await createMcpxClient(TMP_DIR);
+    const client = await createMcpxClient(MCPX_DIR);
     expect(client).toBeNull();
   });
 
@@ -38,7 +40,7 @@ describe("createMcpxClient", () => {
         echo: { command: "echo", args: ["hello"] },
       },
     });
-    const client = await createMcpxClient(TMP_DIR);
+    const client = await createMcpxClient(MCPX_DIR);
     expect(client).not.toBeNull();
     await client?.close();
   });
@@ -85,5 +87,23 @@ describe("formatCallToolResult", () => {
   test("handles missing content array", () => {
     const result = formatCallToolResult({} as never);
     expect(typeof result).toBe("string");
+  });
+});
+
+describe("resolveMcpxDir", () => {
+  test('"global" resolves to ~/.mcpx', () => {
+    expect(resolveMcpxDir("/tmp/project", { mcpx_scope: "global" })).toBe(
+      join(homedir(), ".mcpx"),
+    );
+  });
+
+  test('"project" resolves to <projectDir>/mcpx', () => {
+    expect(resolveMcpxDir("/tmp/project", { mcpx_scope: "project" })).toBe(
+      "/tmp/project/mcpx",
+    );
+  });
+
+  test("missing scope falls back to global", () => {
+    expect(resolveMcpxDir("/tmp/proj", {})).toBe(join(homedir(), ".mcpx"));
   });
 });

--- a/test/mem/client.test.ts
+++ b/test/mem/client.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { resolveMembotDir } from "../../src/mem/client.ts";
+
+describe("resolveMembotDir", () => {
+  test('"global" resolves to ~/.membot regardless of projectDir', () => {
+    expect(resolveMembotDir("/tmp/project-a", { membot_scope: "global" })).toBe(
+      join(homedir(), ".membot"),
+    );
+    expect(resolveMembotDir("/tmp/project-b", { membot_scope: "global" })).toBe(
+      join(homedir(), ".membot"),
+    );
+  });
+
+  test('"project" resolves to the project dir', () => {
+    expect(
+      resolveMembotDir("/tmp/project-a", { membot_scope: "project" }),
+    ).toBe("/tmp/project-a");
+  });
+
+  test("missing scope falls back to global (so existing projects opt into the new default)", () => {
+    expect(resolveMembotDir("/tmp/proj", {})).toBe(join(homedir(), ".membot"));
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `membot_scope` and `mcpx_scope` config keys (each `"global"` | `"project"`, defaulting to `"global"`) so the knowledge store and MCP server config can be shared across all Botholomew projects on a machine, with per-project isolation as an opt-in via `botholomew init --membot-scope=project` / `--mcpx-scope=project` or a config edit.
- Workers, chat, init, capabilities, prepare, nuke, and the `botholomew context` / `botholomew mcpx` CLI passthroughs all resolve the right data dir at runtime via new `resolveMembotDir` / `resolveMcpxDir` helpers; `import-global` keeps copying into the project so users can stage data before flipping scope, and warns when the active scope is still global.
- Bumps `membot` 0.13.3 → 0.14.0 and `@evantahler/mcpx` 0.21.3 → 0.21.6.

## Test plan

- [x] `bun run lint` (tsc + biome) clean
- [x] `bun test` — 605 / 605 pass, including new coverage for scope resolution (`test/mem/client.test.ts`, `test/mcpx/client.test.ts`), default config (`test/config/schemas.test.ts`), and init under both scopes (`test/init/index.test.ts`)
- [ ] Smoke: `botholomew init` in a fresh dir confirms no `index.duckdb` / `mcpx/servers.json` is seeded under default scope; `botholomew context list` and `botholomew mcpx servers` read from `~/.membot` / `~/.mcpx`
- [ ] Smoke: `botholomew init --membot-scope=project --mcpx-scope=project` does seed both, and the agent reads/writes them

🤖 Generated with [Claude Code](https://claude.com/claude-code)