### PR TITLE
CLI: light up more colors in --help output

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,9 +29,13 @@ program
   .configureHelp({
     styleTitle: (str) => ansis.bold(str),
     styleUsage: (str) => ansis.cyan(str),
-    styleCommandText: (str) => ansis.green(str),
+    styleCommandText: (str) => ansis.cyan.bold(str),
+    styleSubcommandTerm: (str) => ansis.green(str),
+    styleSubcommandDescription: (str) => ansis.dim(str),
     styleOptionTerm: (str) => ansis.yellow(str),
-    styleDescriptionText: (str) => ansis.dim(str),
+    styleOptionDescription: (str) => ansis.dim(str),
+    styleArgumentTerm: (str) => ansis.magenta(str),
+    styleArgumentDescription: (str) => ansis.dim(str),
   });
 
 registerInitCommand(program);


### PR DESCRIPTION
## Summary
- Set the per-kind Commander 14 style hooks so the `Commands:` list (subcommand names + their `[options]`/`<arg>` tokens) is green instead of plain, and the program name in the usage line is cyan+bold.
- Replaced the blanket `styleDescriptionText: dim` with per-kind dim styling for option/subcommand/argument descriptions only — top-level program description is no longer muted.

## Test plan
- [ ] `bun run dev --help` — subcommand list is colored
- [ ] `bun run dev task --help` / `worker --help` — same styling inherited
- [ ] `NO_COLOR=1 bun run dev --help` — plain output

🤖 Generated with [Claude Code](https://claude.com/claude-code)