### PR TITLE
TUI: flush completed tool calls into Static when text resumes mid-turn

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.18.3",
+  "version": "0.18.4",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/tui/hooks/useMessageQueue.ts
+++ b/src/tui/hooks/useMessageQueue.ts
@@ -123,6 +123,13 @@ export function useMessageQueue({
       try {
         await sendMessage(sessionRef.current, entry.content, {
           onToken: (token) => {
+            // Mirror the text→tool flush in onToolStart: when text begins
+            // streaming after one or more completed tool calls, push the
+            // pending tools into Static so the dynamic frame doesn't
+            // re-reconcile their boxes on every token flush.
+            if (!currentText && pendingToolCalls.length > 0) {
+              finalizeSegment();
+            }
             currentText += token;
             const now = Date.now();
             if (now - lastStreamFlush >= 50) {


### PR DESCRIPTION
## Summary
- Mirror the text→tool finalize in `onToolStart` so the tools→text transition also flushes completed tool-call boxes into `<Static>`.
- Without this, the boxes stayed in the dynamic frame and were re-reconciled on every 50 ms token flush, making large streamed responses after tool calls visibly sluggish.

## Test plan
- [x] `bun run lint`
- [x] `bun test`
- [ ] Manual TUI: trigger tool → big text and confirm streaming is smooth, tool box settles into scrollback before text streams
- [ ] Manual TUI: text → tool → text still produces correctly ordered bubbles

🤖 Generated with [Claude Code](https://claude.com/claude-code)