### PR TITLE
Implement read_large_result tool to back the pagination hint

### DIFF
--- a/docs/tui.md
+++ b/docs/tui.md
@@ -286,7 +286,9 @@ through the large-results cache and shows a stub instead:
     ⚡ Paginated for LLM [42K, 8pg]
 ```
 
-The agent sees paged access to the result via dedicated tools; the TUI
+The agent reads the full payload back via the `read_large_result` tool
+— `read_large_result(id="lr_1", page=1)` returns one ~8 KB page at a
+time along with `total_pages` so the agent knows when to stop. The TUI
 just shows the summary to keep the chat view compact.
 
 ### Sleep progress bar

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.18.4",
+  "version": "0.18.5",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -40,6 +40,7 @@ import { searchThreadsTool } from "./thread/search.ts";
 import { viewThreadTool } from "./thread/view.ts";
 import { registerTool } from "./tool.ts";
 // Util tools
+import { readLargeResultTool } from "./util/read_large_result.ts";
 import { sleepTool } from "./util/sleep.ts";
 // Worker tools
 import { spawnWorkerTool } from "./worker/spawn.ts";
@@ -95,6 +96,7 @@ export function registerAllTools(): void {
 
   // Util
   registerTool(sleepTool);
+  registerTool(readLargeResultTool);
 
   // Worker
   registerTool(spawnWorkerTool);

--- a/src/tools/util/read_large_result.ts
+++ b/src/tools/util/read_large_result.ts
@@ -1,0 +1,84 @@
+import { z } from "zod";
+import {
+  PAGE_SIZE_CHARS,
+  peekLargeResult,
+  readLargeResultPage,
+} from "../../worker/large-results.ts";
+import type { ToolDefinition } from "../tool.ts";
+
+const ID_PATTERN = /^lr_\d+$/;
+
+const inputSchema = z.object({
+  id: z
+    .string()
+    .regex(ID_PATTERN)
+    .describe(
+      'Large-result id from the "Paginated for LLM" stub, e.g. "lr_1".',
+    ),
+  page: z
+    .number()
+    .int()
+    .min(1)
+    .default(1)
+    .describe(
+      `1-based page number. Each page is ~${PAGE_SIZE_CHARS} chars. Start at 1; the response includes total_pages so you know when to stop.`,
+    ),
+});
+
+const outputSchema = z.object({
+  content: z.string(),
+  id: z.string(),
+  page: z.number(),
+  total_pages: z.number(),
+  total_chars: z.number(),
+  is_error: z.boolean(),
+  error_type: z.string().optional(),
+  next_action_hint: z.string().optional(),
+});
+
+export const readLargeResultTool = {
+  name: "read_large_result",
+  description: `[[ bash equivalent command: sed -n '<page>p' ]] Read one page of a large tool result that was cached because its inline payload exceeded the response budget. Use the id from the "Paginated for LLM" stub. Pages are 1-based and ~${PAGE_SIZE_CHARS} chars each; loop from page=1 to total_pages.`,
+  group: "util",
+  inputSchema,
+  outputSchema,
+  execute: async (input, _ctx): Promise<z.infer<typeof outputSchema>> => {
+    const meta = peekLargeResult(input.id);
+    if (!meta) {
+      return {
+        content: "",
+        id: input.id,
+        page: input.page,
+        total_pages: 0,
+        total_chars: 0,
+        is_error: true,
+        error_type: "unknown_id",
+        next_action_hint:
+          "Large-result entries live only for the current worker tick or chat session and are cleared between worker tasks. Re-run the originating tool to regenerate the result.",
+      };
+    }
+
+    const result = readLargeResultPage(input.id, input.page);
+    if (!result) {
+      return {
+        content: "",
+        id: input.id,
+        page: input.page,
+        total_pages: meta.totalPages,
+        total_chars: meta.totalChars,
+        is_error: true,
+        error_type: "page_out_of_range",
+        next_action_hint: `page=${input.page} is past the end. Valid pages are 1–${meta.totalPages}.`,
+      };
+    }
+
+    return {
+      content: result.content,
+      id: input.id,
+      page: result.page,
+      total_pages: result.totalPages,
+      total_chars: meta.totalChars,
+      is_error: false,
+    };
+  },
+} satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/src/worker/large-results.ts
+++ b/src/worker/large-results.ts
@@ -52,6 +52,19 @@ export function readLargeResultPage(
   return { content, page, totalPages: entry.totalPages };
 }
 
+/** Inspect a stored result without consuming a page. Returns null if unknown. */
+export function peekLargeResult(
+  id: string,
+): { toolName: string; totalChars: number; totalPages: number } | null {
+  const entry = store.get(id);
+  if (!entry) return null;
+  return {
+    toolName: entry.toolName,
+    totalChars: entry.totalChars,
+    totalPages: entry.totalPages,
+  };
+}
+
 /** Build the inline stub that replaces the full result in the conversation */
 export function buildResultStub(
   id: string,
@@ -67,7 +80,7 @@ export function buildResultStub(
     preview,
     preview.length < content.length ? "..." : "",
     "",
-    `Use read_large_result with id="${id}" to read page-by-page (pages 1–${totalPages}).`,
+    `Use read_large_result with id="${id}" and page=<n> (1–${totalPages}) to read it in ~${PAGE_SIZE_CHARS}-char pages.`,
   ].join("\n");
 }
 

--- a/test/worker/large-results.test.ts
+++ b/test/worker/large-results.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { ToolContext } from "../../src/tools/tool.ts";
+import { readLargeResultTool } from "../../src/tools/util/read_large_result.ts";
+import {
+  clearLargeResults,
+  MAX_INLINE_CHARS,
+  maybeStoreResult,
+  PAGE_SIZE_CHARS,
+  peekLargeResult,
+  readLargeResultPage,
+} from "../../src/worker/large-results.ts";
+
+function makeCtx(): ToolContext {
+  return {
+    withMem: undefined as unknown as ToolContext["withMem"],
+    projectDir: "/tmp/lr-test",
+    // biome-ignore lint/suspicious/noExplicitAny: tests don't exercise config
+    config: {} as any,
+    mcpxClient: null,
+  };
+}
+
+afterEach(() => {
+  clearLargeResults();
+});
+
+describe("maybeStoreResult", () => {
+  test("passes through small outputs unchanged", () => {
+    const small = "hello";
+    const result = maybeStoreResult("any_tool", small);
+    expect(result.text).toBe(small);
+    expect(result.stored).toBeUndefined();
+  });
+
+  test("stores oversized outputs and returns a stub with the new hint", () => {
+    const huge = "x".repeat(MAX_INLINE_CHARS + 5_000);
+    const result = maybeStoreResult("big_tool", huge);
+
+    expect(result.stored).toBeDefined();
+    expect(result.stored?.id).toMatch(/^lr_\d+$/);
+    expect(result.stored?.chars).toBe(huge.length);
+    expect(result.stored?.pages).toBe(Math.ceil(huge.length / PAGE_SIZE_CHARS));
+
+    expect(result.text).toContain("stored as");
+    expect(result.text).toContain(`id="${result.stored?.id}"`);
+    expect(result.text).toContain("page=<n>");
+    expect(result.text).toContain(`(1–${result.stored?.pages})`);
+  });
+});
+
+describe("read_large_result tool", () => {
+  test("round-trips a stored payload across pages", async () => {
+    const a = "a".repeat(PAGE_SIZE_CHARS);
+    const b = "b".repeat(PAGE_SIZE_CHARS);
+    const c = "c".repeat(1_000);
+    const payload = a + b + c;
+    expect(payload.length).toBeGreaterThan(MAX_INLINE_CHARS);
+
+    const stored = maybeStoreResult("big_tool", payload);
+    const id = stored.stored?.id ?? "";
+    expect(id).toMatch(/^lr_\d+$/);
+
+    const meta = peekLargeResult(id);
+    expect(meta).not.toBeNull();
+    expect(meta?.totalPages).toBe(3);
+    expect(meta?.totalChars).toBe(payload.length);
+
+    const page1 = await readLargeResultTool.execute({ id, page: 1 }, makeCtx());
+    expect(page1.is_error).toBe(false);
+    expect(page1.content).toBe(a);
+    expect(page1.page).toBe(1);
+    expect(page1.total_pages).toBe(3);
+    expect(page1.total_chars).toBe(payload.length);
+
+    const page2 = await readLargeResultTool.execute({ id, page: 2 }, makeCtx());
+    expect(page2.is_error).toBe(false);
+    expect(page2.content).toBe(b);
+
+    const page3 = await readLargeResultTool.execute({ id, page: 3 }, makeCtx());
+    expect(page3.is_error).toBe(false);
+    expect(page3.content).toBe(c);
+  });
+
+  test("unknown id returns a recoverable error", async () => {
+    const result = await readLargeResultTool.execute(
+      { id: "lr_99999", page: 1 },
+      makeCtx(),
+    );
+    expect(result.is_error).toBe(true);
+    expect(result.error_type).toBe("unknown_id");
+    expect(result.total_pages).toBe(0);
+    expect(result.next_action_hint).toMatch(/Re-run/i);
+  });
+
+  test("page past end reports the real total_pages", async () => {
+    const payload = "z".repeat(MAX_INLINE_CHARS + 100);
+    const stored = maybeStoreResult("big_tool", payload);
+    const id = stored.stored?.id ?? "";
+
+    const total = stored.stored?.pages ?? 0;
+    const result = await readLargeResultTool.execute(
+      { id, page: total + 5 },
+      makeCtx(),
+    );
+    expect(result.is_error).toBe(true);
+    expect(result.error_type).toBe("page_out_of_range");
+    expect(result.total_pages).toBe(total);
+    expect(result.next_action_hint).toContain(`1–${total}`);
+  });
+
+  test("rejects ids that don't match lr_<n> at the schema layer", () => {
+    const parsed = readLargeResultTool.inputSchema.safeParse({
+      id: "not-an-id",
+      page: 1,
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  test("defaults page to 1 when omitted", () => {
+    const parsed = readLargeResultTool.inputSchema.safeParse({ id: "lr_1" });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.page).toBe(1);
+    }
+  });
+});
+
+describe("clearLargeResults", () => {
+  test("removes entries so subsequent reads miss", async () => {
+    const payload = "y".repeat(MAX_INLINE_CHARS + 100);
+    const stored = maybeStoreResult("big_tool", payload);
+    const id = stored.stored?.id ?? "";
+
+    expect(peekLargeResult(id)).not.toBeNull();
+    clearLargeResults();
+    expect(peekLargeResult(id)).toBeNull();
+
+    const result = await readLargeResultTool.execute(
+      { id, page: 1 },
+      makeCtx(),
+    );
+    expect(result.is_error).toBe(true);
+    expect(result.error_type).toBe("unknown_id");
+  });
+
+  test("readLargeResultPage returns null for missing entries", () => {
+    expect(readLargeResultPage("lr_does_not_exist" as string, 1)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Large tool outputs were cached as `lr_<n>` with a stub telling the agent to call `read_large_result`, but no such tool was registered — calls failed with `Unknown tool` and the agent fell back to manual `membot_pipe` workarounds.
- Adds `read_large_result` (util group) on top of the existing in-memory store, plus a `peekLargeResult` helper, a tightened stub hint (`page=<n>`, 1-based range), tests for the round-trip / unknown-id / out-of-range / clear paths, a docs/tui.md fix, and a version bump to 0.18.5.
- Closes evantahler/membot#70 — the issue was filed against membot but the dangling hint and store live entirely in botholomew.

## Test plan

- [x] \`bun run lint\` (tsc + biome) clean
- [x] \`bun test\` — 616 pass, 0 fail (new file: 9/9)
- [ ] End-to-end in chat: trigger a >10K-char tool result, confirm the next agent turn calls \`read_large_result\` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)