### PR TITLE
TUI: fix detail-pane header bg clobbering the right-pane top border

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.18.4",
+  "version": "0.18.5",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/tui/components/ContextPanel.tsx
+++ b/src/tui/components/ContextPanel.tsx
@@ -317,21 +317,26 @@ function formatSize(bytes: number | null): string {
 
 function ContextDetailHeader({ entry }: { entry: ContextEntry }) {
   return (
-    <Box flexDirection="column" width="100%" backgroundColor={theme.headerBg}>
+    <Box flexDirection="column" width="100%">
       <Box>
-        <Text bold color="cyan" wrap="truncate-end">
+        <Text
+          bold
+          color="cyan"
+          backgroundColor={theme.headerBg}
+          wrap="truncate-end"
+        >
           📄 {entry.logical_path}
         </Text>
       </Box>
       <Box>
-        <Text dimColor wrap="truncate-end">
+        <Text dimColor backgroundColor={theme.headerBg} wrap="truncate-end">
           {entry.mime_type ?? "?"} · {formatSize(entry.size_bytes)} · v=
           {entry.version_id}
         </Text>
       </Box>
       {entry.description ? (
         <Box>
-          <Text dimColor wrap="truncate-end">
+          <Text dimColor backgroundColor={theme.headerBg} wrap="truncate-end">
             {entry.description}
           </Text>
         </Box>

--- a/src/tui/components/SchedulePanel.tsx
+++ b/src/tui/components/SchedulePanel.tsx
@@ -350,14 +350,19 @@ export const SchedulePanel = memo(function SchedulePanel({
 function ScheduleDetailHeader({ schedule }: { schedule: Schedule }) {
   const enabledKey = String(schedule.enabled);
   return (
-    <Box flexDirection="column" width="100%" backgroundColor={theme.headerBg}>
+    <Box flexDirection="column" width="100%">
       <Box>
-        <Text bold color={theme.info} wrap="truncate-end">
+        <Text
+          bold
+          color={theme.info}
+          backgroundColor={theme.headerBg}
+          wrap="truncate-end"
+        >
           {schedule.name}
         </Text>
       </Box>
       <Box>
-        <Text wrap="truncate-end">
+        <Text backgroundColor={theme.headerBg} wrap="truncate-end">
           <Text color={ENABLED_COLORS[enabledKey]}>
             {ENABLED_ICONS[enabledKey]} {ENABLED_LABELS[enabledKey]}
           </Text>

--- a/src/tui/components/TaskPanel.tsx
+++ b/src/tui/components/TaskPanel.tsx
@@ -387,14 +387,19 @@ export const TaskPanel = memo(function TaskPanel({
 
 function TaskDetailHeader({ task }: { task: Task }) {
   return (
-    <Box flexDirection="column" width="100%" backgroundColor={theme.headerBg}>
+    <Box flexDirection="column" width="100%">
       <Box>
-        <Text bold color={theme.info} wrap="truncate-end">
+        <Text
+          bold
+          color={theme.info}
+          backgroundColor={theme.headerBg}
+          wrap="truncate-end"
+        >
           {task.name}
         </Text>
       </Box>
       <Box>
-        <Text wrap="truncate-end">
+        <Text backgroundColor={theme.headerBg} wrap="truncate-end">
           <Text color={STATUS_COLORS[task.status]}>
             {STATUS_ICONS[task.status]} {task.status}
           </Text>

--- a/src/tui/components/ThreadPanel.tsx
+++ b/src/tui/components/ThreadPanel.tsx
@@ -594,9 +594,9 @@ function ThreadDetailHeader({
   isActiveThread: boolean;
 }) {
   return (
-    <Box flexDirection="column" width="100%" backgroundColor={theme.headerBg}>
+    <Box flexDirection="column" width="100%">
       <Box>
-        <Text wrap="truncate-end">
+        <Text backgroundColor={theme.headerBg} wrap="truncate-end">
           <Text bold italic color={theme.info}>
             {thread.title || "(untitled)"}
           </Text>
@@ -608,7 +608,7 @@ function ThreadDetailHeader({
         </Text>
       </Box>
       <Box>
-        <Text wrap="truncate-end">
+        <Text backgroundColor={theme.headerBg} wrap="truncate-end">
           <Text color={TYPE_COLORS[thread.type]}>
             {TYPE_ICONS[thread.type]} {TYPE_LABELS[thread.type]}
           </Text>


### PR DESCRIPTION
## Summary
- The detail-pane header `<Box width="100%" backgroundColor={theme.headerBg}>` was overpainting the parent bordered Box's top border row — most visible on the membot tab with long `logical_path` titles.
- Move the bg color off the outer header Box and onto its `<Text>` children in Context/Schedule/Task/Thread detail headers, so the fill only paints behind the glyphs.
- Bump version to 0.18.5.

## Test plan
- [x] \`bun run lint\`
- [x] \`bun test\` (607/607)
- [ ] \`bun run dev chat\` — confirm membot tab right-pane border draws cleanly on long-titled entries; spot-check Tasks/Schedules/Threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)