### PR TITLE
Guard mcp_exec from routing top-level tools; sharpen large-result hint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.18.5",
+  "version": "0.18.6",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/tools/mcp/exec.ts
+++ b/src/tools/mcp/exec.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { formatCallToolResult } from "../../mcpx/client.ts";
 import { fakeMcpExec, isCaptureMode } from "../../worker/fake-mcp.ts";
-import type { ToolDefinition } from "../tool.ts";
+import { getTool, type ToolDefinition } from "../tool.ts";
 
 const inputSchema = z.object({
   server: z.string().describe("MCP server name"),
@@ -82,6 +82,18 @@ export const mcpExecTool = {
   inputSchema,
   outputSchema,
   execute: async (input, ctx) => {
+    // Guard: the agent sometimes routes a top-level Botholomew tool through
+    // mcp_exec (e.g. read_large_result on a payload that originated from an
+    // MCP server). Bounce with a clear redirect rather than forwarding to a
+    // server that doesn't have the tool.
+    if (getTool(input.tool)) {
+      return {
+        result: `\`${input.tool}\` is a top-level Botholomew tool, not an MCP tool. Call it directly by name instead of routing it through mcp_exec.`,
+        is_error: true,
+        error_kind: "input_error" as const,
+        hint: `Re-emit a tool_use block with name="${input.tool}" and its own input schema. Do not wrap it in mcp_exec.`,
+      };
+    }
     if (isCaptureMode()) {
       const canned = fakeMcpExec(input.server, input.tool, input.args);
       if (canned) {

--- a/src/tools/util/read_large_result.ts
+++ b/src/tools/util/read_large_result.ts
@@ -38,7 +38,7 @@ const outputSchema = z.object({
 
 export const readLargeResultTool = {
   name: "read_large_result",
-  description: `[[ bash equivalent command: sed -n '<page>p' ]] Read one page of a large tool result that was cached because its inline payload exceeded the response budget. Use the id from the "Paginated for LLM" stub. Pages are 1-based and ~${PAGE_SIZE_CHARS} chars each; loop from page=1 to total_pages.`,
+  description: `[[ bash equivalent command: sed -n '<page>p' ]] Read one page of a large tool result that Botholomew cached because its inline payload exceeded the response budget. This is a TOP-LEVEL Botholomew tool — call it directly by name, do NOT route it through mcp_exec (it is not an MCP tool, even if the originating result came from an MCP server). Use the id from the "Paginated for LLM" stub. Pages are 1-based and ~${PAGE_SIZE_CHARS} chars each; loop from page=1 to total_pages.`,
   group: "util",
   inputSchema,
   outputSchema,

--- a/src/worker/large-results.ts
+++ b/src/worker/large-results.ts
@@ -80,7 +80,7 @@ export function buildResultStub(
     preview,
     preview.length < content.length ? "..." : "",
     "",
-    `Use read_large_result with id="${id}" and page=<n> (1–${totalPages}) to read it in ~${PAGE_SIZE_CHARS}-char pages.`,
+    `To read the full result, call the top-level Botholomew tool \`read_large_result\` (NOT via mcp_exec — it is not an MCP tool) with id="${id}" and page=<n> (1–${totalPages}). Each page is ~${PAGE_SIZE_CHARS} chars.`,
   ].join("\n");
 }
 

--- a/test/tools/mcp/exec.test.ts
+++ b/test/tools/mcp/exec.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { McpxClient } from "@evantahler/mcpx";
 import { mcpExecTool } from "../../../src/tools/mcp/exec.ts";
+import { registerAllTools } from "../../../src/tools/registry.ts";
 import { setupToolContext } from "../../helpers.ts";
+
+registerAllTools();
 
 function mockClient(
   response: { content: Array<{ type: string; text?: string }> },
@@ -128,6 +131,23 @@ describe("mcp_exec", () => {
     expect(result.is_error).toBe(true);
     expect(result.error_kind).toBe("permanent");
     expect(result.hint).toContain("alternative tool");
+  });
+
+  test("rejects calls that target a top-level Botholomew tool", async () => {
+    const { ctx } = await setupToolContext();
+    // mcpxClient stays null — the guard should fire before we touch it.
+    const result = await mcpExecTool.execute(
+      {
+        server: "huckleberry-ts",
+        tool: "read_large_result",
+        args: { id: "lr_1", page: 1 },
+      },
+      ctx,
+    );
+    expect(result.is_error).toBe(true);
+    expect(result.error_kind).toBe("input_error");
+    expect(result.result).toContain("top-level Botholomew tool");
+    expect(result.hint).toContain('name="read_large_result"');
   });
 
   test("passes args through to exec", async () => {

--- a/test/worker/large-results.test.ts
+++ b/test/worker/large-results.test.ts
@@ -45,6 +45,8 @@ describe("maybeStoreResult", () => {
     expect(result.text).toContain(`id="${result.stored?.id}"`);
     expect(result.text).toContain("page=<n>");
     expect(result.text).toContain(`(1–${result.stored?.pages})`);
+    expect(result.text).toContain("read_large_result");
+    expect(result.text).toContain("NOT via mcp_exec");
   });
 });
 


### PR DESCRIPTION
## Summary

- Follow-up to #231. When a large result originated from an MCP server (e.g. huckleberry-ts), the agent was calling \`read_large_result\` via \`mcp_exec\` on that server and hitting \`MCP error -32602: Tool read_large_result not found\`.
- \`mcp_exec\` now short-circuits with a clear redirect when its \`tool\` argument is the name of a registered top-level Botholomew tool.
- The "Paginated for LLM" stub and \`read_large_result\`'s description now spell out that it's a top-level Botholomew tool, not an MCP tool. Bumps version to 0.18.6.

## Test plan

- [x] \`bun run lint\` clean
- [x] \`bun test\` — 617 pass, 0 fail (new guard test in \`test/tools/mcp/exec.test.ts\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)