### PR TITLE
Bump membot to 0.15.4 and mcpx to 0.21.8 to silence install-time peer-dep warning

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "botholomew",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.95.2",
-        "@evantahler/mcpx": "0.21.7",
+        "@evantahler/mcpx": "0.21.8",
         "ansis": "^4.3.0",
         "commander": "^14.0.0",
         "gray-matter": "^4.0.3",
@@ -14,7 +14,7 @@
         "ink-spinner": "^5.0.0",
         "ink-text-input": "^6.0.0",
         "istextorbinary": "^9.5.0",
-        "membot": "^0.15.0",
+        "membot": "^0.15.4",
         "nanospinner": "^1.2.2",
         "react": "^19.2.6",
         "uuid": "^14.0.0",
@@ -175,7 +175,7 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
 
-    "@evantahler/mcpx": ["@evantahler/mcpx@0.21.7", "", { "dependencies": { "@huggingface/transformers": "^4.2.0", "@modelcontextprotocol/sdk": "^1.29.0", "@types/picomatch": "^4.0.3", "ajv": "^8.20.0", "ansis": "^4.2.0", "commander": "^14.0.3", "nanospinner": "^1.2.2", "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c", "picomatch": "^4.0.4" }, "peerDependencies": { "typescript": "^6" }, "bin": { "mcpx": "src/cli.ts" } }, "sha512-hkLZgT/kWAX4bq0agYKHX6JlyXvUDVHmM4uicTywoRQhkNRYjcHY7s5CNeV6r6BzynEsi8diF1PF4cGaIVHiIQ=="],
+    "@evantahler/mcpx": ["@evantahler/mcpx@0.21.8", "", { "dependencies": { "@huggingface/transformers": "^4.2.0", "@modelcontextprotocol/sdk": "^1.29.0", "@types/picomatch": "^4.0.3", "ajv": "^8.20.0", "ansis": "^4.2.0", "commander": "^14.0.3", "nanospinner": "^1.2.2", "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c", "picomatch": "^4.0.4" }, "bin": { "mcpx": "src/cli.ts" } }, "sha512-G8tSalZlsvhTW0ZNGU7HmzL998zzU6FWv512fVICnwoytqZBC4isHN+dAWBlTCgC3E45JmurUXbsCjfXPjc9bg=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
@@ -777,7 +777,7 @@
 
     "lop": ["lop@0.4.2", "", { "dependencies": { "duck": "^0.1.12", "option": "~0.2.1", "underscore": "^1.13.1" } }, "sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw=="],
 
-    "macos-ts": ["macos-ts@0.10.7", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "protobufjs": "^8.0.1" }, "peerDependencies": { "typescript": "^5" }, "bin": { "macos-mcp": "src/mcp-server.ts" } }, "sha512-JIYZRVnuKdELtQFGrwM+2zgA5+aaG0DVkzOfWJ7bCg3MfMpvQiq+6fmpwJ7iRfuS1avbFtDooLqHyFi6x7/1hA=="],
+    "macos-ts": ["macos-ts@0.11.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "protobufjs": "^8.0.1" }, "bin": { "macos-mcp": "src/mcp-server.ts" } }, "sha512-IJYAeZa/dTzCSys6cUE9RvpLRF7cKCTZEbAruZBBNzGt4+a5EHVEdZE9gpAJeIO3wEBRr3TNHxKwDLd4WPlL6w=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -811,7 +811,7 @@
 
     "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
 
-    "membot": ["membot@0.15.0", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.0", "@duckdb/node-api": "1.5.2-r.1", "@huggingface/transformers": "^4.2.0", "@modelcontextprotocol/sdk": "^1.29.0", "@types/picomatch": "^4.0.3", "@types/turndown": "^5.0.5", "ansis": "^4.2.0", "commander": "^14.0.3", "fast-xml-parser": "^5.7.3", "gray-matter": "^4.0.3", "jszip": "^3.10.1", "macos-ts": "^0.10.7", "mammoth": "^1.8.0", "mustache": "^4.2.0", "nanospinner": "^1.2.2", "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c", "picomatch": "^4.0.4", "playwright": "^1.59.1", "turndown": "^7.2.0", "unpdf": "^0.12.0", "xlsx": "^0.18.5", "zod": "^4.0.0", "zod-to-json-schema": "^3.23.0" }, "peerDependencies": { "typescript": "^6" }, "bin": { "membot": "src/cli.ts" } }, "sha512-IG527U9bfcr4SXCyooob/kn2tg1cAe/niHjymRtBeEbNIHz5DOmBeUQsM74sJcg9muDFPKFygNISngrNX4GOCw=="],
+    "membot": ["membot@0.15.4", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.0", "@duckdb/node-api": "1.5.2-r.1", "@huggingface/transformers": "^4.2.0", "@modelcontextprotocol/sdk": "^1.29.0", "@types/picomatch": "^4.0.3", "@types/turndown": "^5.0.5", "ansis": "^4.2.0", "commander": "^14.0.3", "fast-xml-parser": "^5.7.3", "gray-matter": "^4.0.3", "jszip": "^3.10.1", "macos-ts": "^0.11.0", "mammoth": "^1.8.0", "mustache": "^4.2.0", "nanospinner": "^1.2.2", "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c", "picomatch": "^4.0.4", "playwright": "^1.59.1", "turndown": "^7.2.0", "unpdf": "^0.12.0", "xlsx": "^0.18.5", "zod": "^4.0.0", "zod-to-json-schema": "^3.23.0" }, "bin": { "membot": "src/cli.ts" } }, "sha512-fiv5/IDlNY/it3n22qUaJR8+9F8hP5aGAzvxSJtB2nxp5ilJTTlfJ2BNEN9rnrdOr0RX9fi/F4TiallWAOnXDw=="],
 
     "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,7 +36,7 @@ Concurrency:
   check, so a user editing the same file in `vim` mid-claim makes the
   worker abort cleanly rather than clobber the edit.
 - **Knowledge-store writes** (`membot_add`, `membot_write`,
-  `membot_edit`, `membot_move`, `membot_delete`, `membot_refresh`) go
+  `membot_edit`, `membot_move`, `membot_remove`, `membot_refresh`) go
   through membot's `MembotClient`. Membot manages its own DuckDB lock
   per-operation with exponential backoff, so multiple in-process
   consumers (worker, chat session, TUI Context panel) share the file

--- a/docs/context-and-search.md
+++ b/docs/context-and-search.md
@@ -30,7 +30,7 @@ This page is intentionally short — the canonical docs live with membot.
   subcommand — it copies `~/.membot` into `<projectDir>` (useful when migrating
   global → project).
 - **Chat agent**: the agent calls `membot_add`, `membot_search`, `membot_read`,
-  `membot_write`, `membot_edit`, `membot_move`, `membot_delete`,
+  `membot_write`, `membot_edit`, `membot_move`, `membot_remove`,
   `membot_versions`, `membot_diff`, `membot_refresh`, etc. See
   [`docs/files.md`](./files.md) for the full tool surface and the
   Botholomew-side wrappers (`membot_edit`, `membot_copy`, `membot_exists`,

--- a/docs/files.md
+++ b/docs/files.md
@@ -43,7 +43,7 @@ exactly so reading membot's docs gives you the same vocabulary the agent uses.
 | `membot_diff` | Unified diff between two versions of an entry. |
 | `membot_write` | Write inline content as a new version. Whole-file replace. |
 | `membot_move` | Rename a `logical_path` (creates a new version, tombstones the old). |
-| `membot_delete` | Tombstone one or more entries. Use `membot_prune` to GC. |
+| `membot_remove` | Tombstone one or more entries. Use `membot_prune` to GC. |
 | `membot_refresh` | Re-fetch a URL-backed entry (if its source supports refresh). |
 | `membot_prune` | Permanently drop history older than a cutoff. |
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.18.6",
+  "version": "0.18.7",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.95.2",
-    "@evantahler/mcpx": "0.21.7",
+    "@evantahler/mcpx": "0.21.8",
     "ansis": "^4.3.0",
     "commander": "^14.0.0",
     "gray-matter": "^4.0.3",
@@ -36,7 +36,7 @@
     "ink-spinner": "^5.0.0",
     "ink-text-input": "^6.0.0",
     "istextorbinary": "^9.5.0",
-    "membot": "^0.15.0",
+    "membot": "^0.15.4",
     "nanospinner": "^1.2.2",
     "react": "^19.2.6",
     "uuid": "^14.0.0",

--- a/src/tools/membot/adapter.ts
+++ b/src/tools/membot/adapter.ts
@@ -34,13 +34,14 @@ type MembotMethodName =
   | "move"
   | "remove"
   | "refresh"
-  | "prune";
+  | "prune"
+  | "sources";
 
 /**
- * Map an Operation's exposed name (`membot_add`, `membot_delete`, …) to the
- * `MembotClient` method that actually runs it. The two diverge in a couple
- * of spots — `membot_delete` calls `client.remove`, `membot_move` calls
- * `client.move` — so we keep the routing explicit rather than guessing.
+ * Map an Operation's exposed name (`membot_add`, `membot_remove`, …) to the
+ * `MembotClient` method that actually runs it. Mostly 1:1 with the op name
+ * minus the `membot_` prefix; kept explicit so a renamed/added op fails
+ * loudly at registration instead of silently misrouting.
  */
 const METHOD_BY_OP_NAME: Record<string, MembotMethodName> = {
   membot_add: "add",
@@ -54,9 +55,10 @@ const METHOD_BY_OP_NAME: Record<string, MembotMethodName> = {
   membot_diff: "diff",
   membot_write: "write",
   membot_move: "move",
-  membot_delete: "remove",
+  membot_remove: "remove",
   membot_refresh: "refresh",
   membot_prune: "prune",
+  membot_sources: "sources",
 };
 
 /**

--- a/src/tools/membot/edit.ts
+++ b/src/tools/membot/edit.ts
@@ -32,7 +32,7 @@ const outputSchema = z.object({
 export const membotEditTool = {
   name: "membot_edit",
   description:
-    "[[ bash equivalent command: patch ]] Apply line-range edits to a stored file: reads the current version, applies bottom-up patches, and writes the result back as a new version. Prefer this over membot_write when you only need to change part of a file — the diff is small and the change_note travels with the new version. To replace the whole body, use membot_write. To delete the file, use membot_delete.",
+    "[[ bash equivalent command: patch ]] Apply line-range edits to a stored file: reads the current version, applies bottom-up patches, and writes the result back as a new version. Prefer this over membot_write when you only need to change part of a file — the diff is small and the change_note travels with the new version. To replace the whole body, use membot_write. To delete the file, use membot_remove.",
   group: "membot",
   inputSchema,
   outputSchema,


### PR DESCRIPTION
## Summary

- `bun install -g botholomew` was emitting `warn: incorrect peer dependency "typescript@5.9.3"` because `membot`, `@evantahler/mcpx`, and (transitively) `macos-ts` each declared `typescript` as a required peer. None of them actually require consumers to have a specific typescript version installed — bun runs `.ts` natively, and npm consumers using `tsc` are flexible. All three upstreams (macos-ts#45, mcpx#91, membot#72) dropped the peer; this bump pulls them in.
- `membot@0.15.4` also renamed the `membot_delete` op to `membot_remove` (membot#77) so the op.name → SDK method convention is clean. Updated `METHOD_BY_OP_NAME` in `src/tools/membot/adapter.ts`, the description prose in `src/tools/membot/edit.ts`, and the three doc files that listed `membot_delete`.
- `membot@0.15.4` also adds the `membot_sources` op + `MembotClient.sources()` wrapper (membot#77, fixes the bug filed in membot#76). Registered in `METHOD_BY_OP_NAME` so the registration loop adapts it like every other op.

## Test plan

- [x] `bun install` — no peer warnings
- [x] `bun run lint` — clean
- [x] `bun test` — 631 pass, 0 fail
- [ ] After merge + auto-release: `bun install -g botholomew` should be silent

🤖 Generated with [Claude Code](https://claude.com/claude-code)