### PR TITLE
Loud-fail when config.json is a dangling symlink

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,3 +1,4 @@
+import { lstat, readlink, stat } from "node:fs/promises";
 import { getConfigPath } from "../constants.ts";
 import { setLogLevel } from "../utils/logger.ts";
 import {
@@ -44,6 +45,9 @@ export async function loadConfig(
   projectDir: string,
 ): Promise<BotholomewConfig> {
   const configPath = getConfigPath(projectDir);
+
+  await assertNotDanglingSymlink(configPath);
+
   const file = Bun.file(configPath);
 
   let userConfig: DeepPartial<BotholomewConfig> = {};
@@ -63,6 +67,31 @@ export async function loadConfig(
   setLogLevel(config.log_level);
 
   return config;
+}
+
+async function assertNotDanglingSymlink(configPath: string): Promise<void> {
+  let lst: Awaited<ReturnType<typeof lstat>>;
+  try {
+    lst = await lstat(configPath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw err;
+  }
+  if (!lst.isSymbolicLink()) return;
+  try {
+    await stat(configPath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      const target = await readlink(configPath).catch(() => "<unreadable>");
+      throw new Error(
+        `Config file is a symlink to a missing target: ${configPath} -> ${target}. ` +
+          `Symlink targets are resolved relative to the symlink's own directory, ` +
+          `not the current working directory — use an absolute path or a target ` +
+          `relative to ${configPath.replace(/\/[^/]+$/, "")}.`,
+      );
+    }
+    throw err;
+  }
 }
 
 export async function saveConfig(

--- a/test/config/loader.test.ts
+++ b/test/config/loader.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, symlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { loadConfig, saveConfig } from "../../src/config/loader.ts";
@@ -115,6 +115,38 @@ describe("loadConfig", () => {
         delete process.env.ANTHROPIC_API_KEY;
       }
     }
+  });
+
+  test("follows a valid relative symlink", async () => {
+    await Bun.write(
+      join(projectDir, "config", "config.json.anthropic"),
+      JSON.stringify({ llm: { provider: "anthropic", api_key: "sk-linked" } }),
+    );
+    await symlink(
+      "config.json.anthropic",
+      join(projectDir, "config", "config.json"),
+    );
+
+    const originalEnv = process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    try {
+      const config = await loadConfig(projectDir);
+      expect(config.llm.api_key).toBe("sk-linked");
+    } finally {
+      if (originalEnv !== undefined)
+        process.env.ANTHROPIC_API_KEY = originalEnv;
+    }
+  });
+
+  test("throws a clear error when config.json is a dangling symlink", async () => {
+    await symlink(
+      "config.json.anthropic",
+      join(projectDir, "config", "config.json"),
+    );
+
+    await expect(loadConfig(projectDir)).rejects.toThrow(
+      /symlink to a missing target/,
+    );
   });
 
   test("OLLAMA_HOST env var fills in base_url for ollama provider when unset", async () => {


### PR DESCRIPTION
## Summary
- `loadConfig` now `lstat`s the config path and throws with a clear message if `config.json` is a symlink whose target doesn't resolve — no more silent fallback to `DEFAULT_CONFIG`.
- The error names the link path, the readlink target, and reminds the user that symlink targets resolve relative to the symlink's own directory (the foot-gun behind the original report).
- Tests cover both a valid relative symlink and a dangling one.
- Version bump 0.19.3 → 0.19.4.

## Test plan
- [x] `bun test test/config/loader.test.ts`
- [x] `bunx tsc --noEmit`
- [x] `bunx biome check src/config/loader.ts test/config/loader.test.ts`
- [ ] Smoke: `ln -sf missing-target .botholomew/config/config.json && bun dev chat` surfaces the new error instead of the misleading api_key error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)