### PR TITLE
Strip ANSI color codes from worker log files

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -93,8 +93,13 @@ See `src/worker/tick.ts`.
 ### Log format
 
 Worker logs prefix every line with a local `HH:MM:SS` timestamp. Lifecycle
-phases render as `[[phase-name]]` in bold magenta so they're easy to scan
-and grep (`grep '\[\[' logs/*/<id>.log`). Phases emitted each tick:
+phases render as `[[phase-name]]` so they're easy to scan and grep
+(`grep '\[\[' logs/*/<id>.log`). Background worker **log files** are written
+colorless — the worker is spawned with `NO_COLOR` set (see `colorlessEnv` in
+`src/worker/spawn.ts`), so the file is plain text with no ANSI escape codes,
+even when launched from a terminal that forces color. The coloring (e.g. bold
+magenta phase tags) only applies to foreground terminal output. Phases emitted
+each tick:
 
 - `[[tick-start]] #N`
 - `[[evaluating-schedules]]` (only when any are enabled)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/worker/spawn.ts
+++ b/src/worker/spawn.ts
@@ -12,6 +12,24 @@ export interface SpawnWorkerOptions {
 }
 
 /**
+ * Env for a detached worker whose stdout/stderr is a log file: force no ANSI
+ * color. `ansis` (and other color libs) read these vars at import time, and
+ * `FORCE_COLOR` overrides `NO_COLOR`, so we must remove the forcing vars in
+ * addition to setting `NO_COLOR`. Without this, an interactive shell's inherited
+ * `FORCE_COLOR`/`COLORTERM` would make ansis emit escape codes into the log file
+ * even though the child's stdout is a file, not a TTY.
+ */
+export function colorlessEnv(
+  base: Record<string, string | undefined> = process.env,
+): Record<string, string | undefined> {
+  const env: Record<string, string | undefined> = { ...base };
+  env.NO_COLOR = "1";
+  delete env.FORCE_COLOR;
+  delete env.CLICOLOR_FORCE;
+  return env;
+}
+
+/**
  * Spawn a worker as a detached background process. Unlike the old daemon
  * model, multiple workers per project are allowed and expected — this just
  * launches a new one.
@@ -52,7 +70,7 @@ export async function spawnWorker(
 
   const proc = Bun.spawn(args, {
     stdio: ["ignore", logFile, logFile],
-    env: { ...process.env },
+    env: colorlessEnv(),
   });
   proc.unref();
 

--- a/test/worker/spawn.test.ts
+++ b/test/worker/spawn.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { colorlessEnv } from "../../src/worker/spawn.ts";
+
+// A control byte can't appear literally in the test source (biome rejects it
+// in regex/string literals), so construct it via char code.
+const ESC = String.fromCharCode(0x1b);
+
+describe("colorlessEnv", () => {
+  test("forces NO_COLOR and removes color-forcing vars while preserving the rest", () => {
+    const env = colorlessEnv({
+      FORCE_COLOR: "1",
+      COLORTERM: "truecolor",
+      CLICOLOR_FORCE: "1",
+      FOO: "bar",
+    });
+
+    expect(env.NO_COLOR).toBe("1");
+    expect(env.FORCE_COLOR).toBeUndefined();
+    expect(env.CLICOLOR_FORCE).toBeUndefined();
+    // Non-color env is passed through untouched.
+    expect(env.FOO).toBe("bar");
+    // COLORTERM is harmless once NO_COLOR wins, so we leave it as-is.
+    expect(env.COLORTERM).toBe("truecolor");
+  });
+
+  test("does not mutate the base env", () => {
+    const base: Record<string, string | undefined> = { FORCE_COLOR: "1" };
+    colorlessEnv(base);
+    expect(base.FORCE_COLOR).toBe("1");
+  });
+
+  test("ansis emits no escape codes under this env, even when the parent forces color", async () => {
+    // End-to-end: this is the env we hand a detached worker. Run a child that
+    // prints ansis-colored text with stdout piped (not a TTY) and confirm the
+    // bytes contain no ANSI escape sequences — i.e. ansis resolves to level 0.
+    const proc = Bun.spawn(
+      [
+        "bun",
+        "-e",
+        'import ansis from "ansis"; process.stdout.write(ansis.blue("X") + ansis.green("Y") + "\\n");',
+      ],
+      {
+        cwd: import.meta.dir,
+        env: colorlessEnv({
+          ...process.env,
+          FORCE_COLOR: "1",
+          COLORTERM: "truecolor",
+          TERM: "xterm-256color",
+        }),
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+
+    const out = await new Response(proc.stdout).text();
+    await proc.exited;
+
+    expect(out).not.toContain(ESC);
+    expect(out.trim()).toBe("XY");
+  });
+});


### PR DESCRIPTION
Detached workers spawned by `worker start` inherited the parent terminal's environment, so `ansis` — which resolves its color level from `FORCE_COLOR`/`COLORTERM` at import time, overriding `NO_COLOR` — wrote escape codes into `logs/<date>/<id>.log` even though the worker's stdout is a file, not a TTY. This sanitizes the spawned worker's env via a new `colorlessEnv` helper (sets `NO_COLOR=1`, drops `FORCE_COLOR`/`CLICOLOR_FORCE`) so log files are plain text regardless of the launching terminal. Foreground `worker run` is unaffected and keeps its colored streaming UX. Adds unit + end-to-end tests proving ansis emits zero escape bytes under the produced env, updates `docs/architecture.md`, and bumps the version to 0.20.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)