### PR TITLE
Give the queue panel its own color (violet)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/tui/components/QueuePanel.tsx
+++ b/src/tui/components/QueuePanel.tsx
@@ -25,11 +25,11 @@ export function QueuePanel({ messages, selectedIndex }: QueuePanelProps) {
     <Box
       flexDirection="column"
       borderStyle="round"
-      borderColor={theme.accent}
+      borderColor={theme.queue}
       paddingX={1}
     >
       <Box justifyContent="space-between">
-        <Text color={theme.accent} bold>
+        <Text color={theme.queue} bold>
           {label}
         </Text>
         <Text dimColor>{hints}</Text>
@@ -42,7 +42,7 @@ export function QueuePanel({ messages, selectedIndex }: QueuePanelProps) {
           // biome-ignore lint/suspicious/noArrayIndexKey: queue items can be duplicates, index is the stable identity
           <Box key={i}>
             <Text
-              color={isSelected ? theme.accent : undefined}
+              color={isSelected ? theme.queue : undefined}
               backgroundColor={isSelected ? theme.selectionBg : undefined}
               bold={isSelected}
             >

--- a/src/tui/theme.ts
+++ b/src/tui/theme.ts
@@ -50,6 +50,7 @@ export const theme = {
   userBg: isDark ? "#2a5a8c" : "#d0e0f0",
   selectionBg: isDark ? "#333" : "#ddd",
   headerBg: isDark ? "#3a4655" : "#f5f7fa",
+  queue: isDark ? "#a78bfa" : "#7c3aed",
   success: "green",
   error: "red",
   info: "cyan",

--- a/test/tui/theme.test.ts
+++ b/test/tui/theme.test.ts
@@ -91,6 +91,7 @@ describe("theme", () => {
     process.env.COLORFGBG = "15;0"; // force dark
     const { theme } = loadTheme();
     expect(theme.accent).toBe("yellow");
+    expect(theme.queue).toBe("#a78bfa");
     expect(theme.userBg).toBe("#2a5a8c");
     expect(theme.selectionBg).toBe("#333");
   });
@@ -99,6 +100,7 @@ describe("theme", () => {
     process.env.COLORFGBG = "0;15"; // force light
     const { theme } = loadTheme();
     expect(theme.accent).toBe("#B8860B");
+    expect(theme.queue).toBe("#7c3aed");
     expect(theme.userBg).toBe("#d0e0f0");
     expect(theme.selectionBg).toBe("#ddd");
   });


### PR DESCRIPTION
The chat TUI's "Queue (N pending)" panel reused `theme.accent` (yellow) — the same color tool-call boxes use — so a queued message visually read as a tool call. This adds a dedicated violet `theme.queue` color (`#a78bfa` dark / `#7c3aed` light), sitting in the unused hue gap between blue and magenta, and points the queue panel's border, label, and selection at it. Includes theme tests for both modes and a patch version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)