### PR TITLE
Surface membot_pipe → membot_query JSON-reduction pattern to agents

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/chat/agent.ts
+++ b/src/chat/agent.ts
@@ -28,6 +28,7 @@ import { maybeStoreResult } from "../worker/large-results.ts";
 import {
   buildMetaHeader,
   extractKeywords,
+  LARGE_JSON_SECTION,
   loadPersistentContext,
   MEMBOT_PROMPT_SECTION,
   STYLE_RULES,
@@ -64,6 +65,7 @@ const CHAT_TOOL_NAMES = new Set([
   "membot_count_lines",
   "membot_copy",
   "membot_pipe",
+  "membot_query",
   "list_threads",
   "view_thread",
   "search_threads",
@@ -120,6 +122,7 @@ Format your responses using Markdown. Use headings, bold, italic, lists, and cod
 `;
 
   prompt += `\n${MEMBOT_PROMPT_SECTION}`;
+  prompt += `\n${LARGE_JSON_SECTION}`;
 
   if (options?.hasMcpTools) {
     prompt += `

--- a/src/prompts/capabilities.ts
+++ b/src/prompts/capabilities.ts
@@ -339,7 +339,7 @@ function renderFallback(inv: RawInventory, now: Date): string {
     schedule:
       "create and list recurring schedules that automatically generate tasks",
     membot:
-      "add, read, write, edit, move, copy, delete, and search content in the agent's knowledge store; track every version and refresh from URL sources",
+      "add, read, write, edit, move, copy, delete, and search content in the agent's knowledge store; track every version and refresh from URL sources; capture large tool outputs into the store and reduce/reshape stored JSON without loading it into context",
     prompt:
       "list, read, create, edit, and delete the project's prompt files (goals, beliefs, capabilities, plus any agent-authored ones)",
     skill: "list, read, write, edit, delete, and search slash-command skills",

--- a/src/worker/prompt.ts
+++ b/src/worker/prompt.ts
@@ -18,6 +18,20 @@ export const MEMBOT_PROMPT_SECTION = `## Knowledge store (membot)
 ${MEMBOT_INSTRUCTIONS}
 `;
 
+/**
+ * Teaches the `membot_pipe` → `membot_query` pattern for large JSON. Shared
+ * verbatim by the worker and chat prompts (chat imports it). These are core
+ * knowledge-store tools — not MCP-only — so the section renders unconditionally;
+ * without it the model only learns about `membot_query` from its tool schema,
+ * exactly when it's most context-pressured (holding a big blob).
+ */
+export const LARGE_JSON_SECTION = `## Large JSON results
+When a tool would return a large JSON payload (mcp_exec dumps, search results, web fetches) that you don't need to read verbatim, don't pull it into context:
+1. \`membot_pipe\` the call into a \`logical_path\` — the bytes land in the store, you get back only an ack.
+2. \`membot_query\` that \`logical_path\` with a JSONata expression to filter / pluck / group / dedup / sort / aggregate down to the small slice you actually need (pass \`expression="?"\` for the syntax reference). Chain with \`output_logical_path\` to refine in steps.
+This keeps big blobs out of the conversation. Reach for it whenever you expect a result bigger than what you need.
+`;
+
 export const STYLE_RULES = `## Style
 - Open with the result, action, or next step. Skip preambles like "Great question", "You're absolutely right", "Let me…", "I'll go ahead and…".
 - Don't flatter the user or their ideas. If a request is wrong, ambiguous, or risky, say so plainly with the reason.
@@ -136,6 +150,7 @@ When calling complete_task, write a summary that captures your key findings, dec
 `;
 
   prompt += `\n${MEMBOT_PROMPT_SECTION}`;
+  prompt += `\n${LARGE_JSON_SECTION}`;
 
   if (options?.hasMcpTools) {
     prompt += `

--- a/test/chat/agent.test.ts
+++ b/test/chat/agent.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildChatSystemPrompt, getChatTools } from "../../src/chat/agent.ts";
+import { getPromptsDir } from "../../src/constants.ts";
+
+let projectDir: string;
+
+beforeEach(async () => {
+  projectDir = await mkdtemp(join(tmpdir(), "both-chat-"));
+  await mkdir(getPromptsDir(projectDir), { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(projectDir, { recursive: true, force: true });
+});
+
+describe("chat agent tooling", () => {
+  test("exposes the JSON-reduction tools (pipe + query)", () => {
+    const tools = getChatTools();
+    expect(tools).toHaveProperty("membot_pipe");
+    expect(tools).toHaveProperty("membot_query");
+  });
+
+  test("system prompt teaches the pipe -> query pattern", async () => {
+    const prompt = await buildChatSystemPrompt(projectDir, {
+      hasMcpTools: true,
+    });
+    expect(prompt).toContain("## Large JSON results");
+    expect(prompt).toContain("membot_pipe");
+    expect(prompt).toContain("membot_query");
+  });
+});

--- a/test/worker/prompt.test.ts
+++ b/test/worker/prompt.test.ts
@@ -230,6 +230,18 @@ describe("buildSystemPrompt", () => {
     expect(prompt).not.toContain("## External Tools (MCP)");
   });
 
+  test("teaches the pipe -> query pattern regardless of MCP tooling", async () => {
+    const withMcp = await buildSystemPrompt(projectDir, undefined, undefined, {
+      hasMcpTools: true,
+    });
+    const withoutMcp = await buildSystemPrompt(projectDir);
+    for (const prompt of [withMcp, withoutMcp]) {
+      expect(prompt).toContain("## Large JSON results");
+      expect(prompt).toContain("membot_pipe");
+      expect(prompt).toContain("membot_query");
+    }
+  });
+
   test("Style block lands after the MCP block when both are present", async () => {
     const prompt = await buildSystemPrompt(projectDir, undefined, undefined, {
       hasMcpTools: true,


### PR DESCRIPTION
Botholomew's two JSON-reduction tools weren't reliably reachable: chat couldn't call `membot_query` at all (registered but absent from `CHAT_TOOL_NAMES`, so it could `membot_pipe` a blob into the store with no way to reduce it), and neither the worker nor chat prompt taught the `pipe → query` pattern — discovery relied on the model spotting `membot_query`'s schema among ~50 tools while context-pressured. This adds `membot_query` to the chat allowlist, introduces a shared `LARGE_JSON_SECTION` appended to both system prompts that teaches piping large payloads to a `logical_path` then reducing them with JSONata, and extends the (name-free) capabilities fallback summary to mention reducing/reshaping stored JSON without loading it into context. New `test/chat/agent.test.ts` asserts both tools are exposed in chat and the prompt section renders; `test/worker/prompt.test.ts` asserts the section renders with and without MCP tooling. Version bumped to 0.21.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)