### PR TITLE
Add `botholomew status` project dashboard (#250)

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ semantic search, append-only versioning, and URL refresh all live there.
 | Command | Purpose |
 |---|---|
 | `botholomew init` | Initialize the current directory as a project (refuses on iCloud/Dropbox/NFS without `--force`) |
+| `botholomew status` | One-command dashboard: workers, task counts/claims, schedules (with a live "due?" check), quarantined files, store info. `--json` for scripting, `--no-evaluate` to skip the LLM schedule check |
 | `botholomew worker run\|start` | Run a worker (foreground or background); `--persist` for long-running, `--task-id <id>` to target one task |
 | `botholomew worker list\|status\|stop\|kill\|reap` | Inspect and manage running workers |
 | `botholomew chat` | Interactive Ink/React TUI |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -157,6 +157,29 @@ Persist workers also run a reaper interval
 
 ---
 
+## Project status
+
+`botholomew status` is a read-only dashboard that renders the whole
+project in one ASCII view — workers (alive/dead counts + last heartbeat),
+tasks (counts by state plus currently-claimed tasks and their owners),
+schedules, files quarantined for invalid frontmatter, and the resolved
+membot/mcpx scope + directories. It mutates nothing: data-gathering lives
+in `src/status/collect.ts` (`collectStatus` → a serializable
+`StatusReport`), and `src/commands/status.ts` renders it.
+
+The collector parses task/schedule files directly (`parseTaskFile` /
+`parseScheduleFile`) rather than going through `getTask`/`listTasks`, so
+malformed files land in a `quarantined` bucket without spraying warnings
+over the output. Because schedules have no deterministic next-fire (they
+use a natural-language `frequency` evaluated by an LLM — see
+[tasks & schedules](./tasks-and-schedules.md)), `status` runs that same
+`evaluateSchedule` per enabled schedule to show a live "due now?" verdict.
+That evaluation is the only slow part, so `--no-evaluate` skips it for
+fast/offline runs, and `--json` emits the `StatusReport` verbatim for
+scripting.
+
+---
+
 ## The chat TUI
 
 `botholomew chat` is a separate agent with its own system prompt and tool

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.21.1",
+  "version": "0.22.0",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@ import { registerPrepareCommand } from "./commands/prepare.ts";
 import { registerPromptsCommand } from "./commands/prompts.ts";
 import { registerScheduleCommand } from "./commands/schedule.ts";
 import { registerSkillCommand } from "./commands/skill.ts";
+import { registerStatusCommand } from "./commands/status.ts";
 import { registerTaskCommand } from "./commands/task.ts";
 import { registerThreadCommand } from "./commands/thread.ts";
 import { registerUpgradeCommand } from "./commands/upgrade.ts";
@@ -57,6 +58,7 @@ program
   });
 
 registerInitCommand(program);
+registerStatusCommand(program);
 registerWorkerCommand(program);
 registerTaskCommand(program);
 registerThreadCommand(program);

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,0 +1,194 @@
+import ansis from "ansis";
+import type { Command } from "commander";
+import { loadConfig } from "../config/loader.ts";
+import {
+  collectStatus,
+  type ScheduleEntry,
+  type StatusReport,
+  type WorkerSummary,
+} from "../status/collect.ts";
+import type { TaskStatus } from "../tasks/schema.ts";
+import type { WorkerStatus } from "../workers/store.ts";
+
+function formatAge(fromIso: string | null, to = new Date()): string {
+  if (!fromIso) return "never";
+  const from = new Date(fromIso);
+  const secs = Math.max(0, Math.floor((to.getTime() - from.getTime()) / 1000));
+  if (secs < 60) return `${secs}s ago`;
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+function padColored(colored: string, raw: string, width: number): string {
+  return colored + " ".repeat(Math.max(0, width - raw.length));
+}
+
+function workerStatusColor(status: WorkerStatus): string {
+  switch (status) {
+    case "running":
+      return ansis.green(status);
+    case "stopped":
+      return ansis.dim(status);
+    case "dead":
+      return ansis.red(status);
+  }
+}
+
+function taskStatusColor(status: TaskStatus, label: string): string {
+  switch (status) {
+    case "pending":
+      return ansis.yellow(label);
+    case "in_progress":
+      return ansis.blue(label);
+    case "complete":
+      return ansis.green(label);
+    case "failed":
+      return ansis.red(label);
+    case "waiting":
+      return ansis.magenta(label);
+  }
+}
+
+function section(title: string): void {
+  console.log(`\n${ansis.bold.underline(title)}`);
+}
+
+function renderWorkers(w: WorkerSummary): void {
+  section("Workers");
+  const parts = [
+    `${ansis.green(`${w.running} running`)}`,
+    `${ansis.dim(`${w.stopped} stopped`)}`,
+    `${w.dead > 0 ? ansis.red(`${w.dead} dead`) : ansis.dim("0 dead")}`,
+  ];
+  console.log(
+    `  ${w.total} total — ${parts.join(", ")}   latest heartbeat: ${formatAge(w.latest_heartbeat_at)}`,
+  );
+  if (w.list.length === 0) {
+    console.log(ansis.dim("  (none)"));
+    return;
+  }
+  for (const wk of w.list) {
+    const short = ansis.bold(wk.id.slice(0, 8));
+    const status = workerStatusColor(wk.status);
+    const task = wk.task_id ? `  task=${wk.task_id.slice(0, 8)}` : "";
+    console.log(
+      `  ${short}  ${status}  mode=${wk.mode}  pid=${wk.pid}  heartbeat ${formatAge(wk.last_heartbeat_at)}${task}`,
+    );
+  }
+}
+
+function renderTasks(t: StatusReport["tasks"]): void {
+  section("Tasks");
+  const order: TaskStatus[] = [
+    "pending",
+    "in_progress",
+    "waiting",
+    "complete",
+    "failed",
+  ];
+  const counts = order
+    .map((s) => taskStatusColor(s, `${t.by_status[s]} ${s}`))
+    .join(", ");
+  console.log(`  ${t.total} total — ${counts}`);
+
+  if (t.claimed.length > 0) {
+    console.log(ansis.bold("\n  Claimed:"));
+    for (const c of t.claimed) {
+      console.log(
+        `  ${ansis.dim(c.id.slice(0, 8))}  ${c.name}  ${ansis.dim(`by ${c.claimed_by.slice(0, 8)} (${formatAge(c.claimed_at)})`)}`,
+      );
+    }
+  }
+}
+
+function dueLabel(entry: ScheduleEntry): string {
+  if (!entry.evaluation) return ansis.dim("—");
+  return entry.evaluation.is_due
+    ? ansis.green.bold("due")
+    : ansis.dim("not due");
+}
+
+function renderSchedules(s: StatusReport["schedules"]): void {
+  section("Schedules");
+  console.log(
+    `  ${s.total} total — ${ansis.green(`${s.enabled} enabled`)}, ${ansis.dim(`${s.disabled} disabled`)}`,
+  );
+  if (s.list.length === 0) {
+    console.log(ansis.dim("  (none)"));
+    return;
+  }
+  for (const e of s.list) {
+    const name = e.enabled ? e.name : ansis.dim(e.name);
+    const freq = ansis.cyan(e.frequency);
+    const last = ansis.dim(`last run ${formatAge(e.last_run_at)}`);
+    let line = `  ${name}  (${freq})  ${last}  ${dueLabel(e)}`;
+    if (e.evaluation?.is_due && e.evaluation.tasks_to_create > 0) {
+      line += ansis.dim(` → ${e.evaluation.tasks_to_create} task(s)`);
+    }
+    console.log(line);
+    if (e.evaluation?.is_due) {
+      console.log(ansis.dim(`      ${e.evaluation.reasoning}`));
+    }
+  }
+}
+
+function renderQuarantined(report: StatusReport): void {
+  const items = [
+    ...report.tasks.quarantined.map((q) => ({ kind: "task", ...q })),
+    ...report.schedules.quarantined.map((q) => ({ kind: "schedule", ...q })),
+  ];
+  if (items.length === 0) return;
+  section("Quarantined (invalid frontmatter)");
+  for (const q of items) {
+    console.log(
+      `  ${ansis.red(q.kind)} ${ansis.dim(q.id)} — ${ansis.yellow(q.reason)}`,
+    );
+  }
+}
+
+function renderStore(store: StatusReport["store"]): void {
+  section("Store");
+  console.log(
+    `  membot: ${ansis.cyan(store.membot_scope)}  ${ansis.dim(store.membot_dir)}`,
+  );
+  console.log(
+    `  mcpx:   ${ansis.cyan(store.mcpx_scope)}  ${ansis.dim(store.mcpx_dir)}`,
+  );
+}
+
+function renderText(report: StatusReport): void {
+  console.log(ansis.bold(`Project: ${report.project_dir}`));
+  renderWorkers(report.workers);
+  renderTasks(report.tasks);
+  renderSchedules(report.schedules);
+  renderQuarantined(report);
+  renderStore(report.store);
+}
+
+export function registerStatusCommand(program: Command): void {
+  program
+    .command("status")
+    .description(
+      "One-command project dashboard: workers, tasks, schedules, quarantined files, and store info",
+    )
+    .option("--json", "output a serialized StatusReport as JSON", false)
+    .option(
+      "--no-evaluate",
+      "skip the LLM evaluation of enabled schedules (faster / offline)",
+    )
+    .action(async (opts: { json?: boolean; evaluate?: boolean }) => {
+      const dir = program.opts().dir;
+      const config = await loadConfig(dir);
+      const report = await collectStatus(dir, config, {
+        evaluateSchedules: opts.evaluate !== false,
+      });
+      if (opts.json) {
+        console.log(JSON.stringify(report, null, 2));
+        return;
+      }
+      renderText(report);
+    });
+}

--- a/src/status/collect.ts
+++ b/src/status/collect.ts
@@ -1,0 +1,241 @@
+import type { BotholomewConfig, Scope } from "../config/schemas.ts";
+import { readWithMtime } from "../fs/atomic.ts";
+import { resolveMcpxDir } from "../mcpx/client.ts";
+import { resolveMembotDir } from "../mem/client.ts";
+import type { Schedule } from "../schedules/schema.ts";
+import {
+  listScheduleFiles,
+  parseScheduleFile,
+  scheduleFilePath,
+} from "../schedules/store.ts";
+import { TASK_STATUSES, type TaskStatus } from "../tasks/schema.ts";
+import { listTaskFiles, parseTaskFile, taskFilePath } from "../tasks/store.ts";
+import { evaluateSchedule } from "../worker/schedules.ts";
+import { listWorkers, type Worker } from "../workers/store.ts";
+
+export interface QuarantinedFile {
+  id: string;
+  reason: string;
+}
+
+export interface WorkerSummary {
+  total: number;
+  running: number;
+  stopped: number;
+  dead: number;
+  /** Most recent heartbeat across all workers, or null if none. */
+  latest_heartbeat_at: string | null;
+  list: Array<
+    Pick<
+      Worker,
+      "id" | "status" | "mode" | "pid" | "last_heartbeat_at" | "task_id"
+    >
+  >;
+}
+
+export interface TaskSummary {
+  /** Count of valid (parseable) tasks. */
+  total: number;
+  by_status: Record<TaskStatus, number>;
+  claimed: Array<{
+    id: string;
+    name: string;
+    claimed_by: string;
+    claimed_at: string | null;
+  }>;
+  quarantined: QuarantinedFile[];
+}
+
+export interface ScheduleEntry {
+  id: string;
+  name: string;
+  frequency: string;
+  enabled: boolean;
+  last_run_at: string | null;
+  /** Present only when schedule evaluation ran (enabled schedules, --evaluate). */
+  evaluation?: {
+    is_due: boolean;
+    reasoning: string;
+    tasks_to_create: number;
+  };
+}
+
+export interface ScheduleSummary {
+  total: number;
+  enabled: number;
+  disabled: number;
+  list: ScheduleEntry[];
+  quarantined: QuarantinedFile[];
+}
+
+export interface StoreSummary {
+  membot_scope: Scope;
+  membot_dir: string;
+  mcpx_scope: Scope;
+  mcpx_dir: string;
+}
+
+export interface StatusReport {
+  project_dir: string;
+  workers: WorkerSummary;
+  tasks: TaskSummary;
+  schedules: ScheduleSummary;
+  store: StoreSummary;
+}
+
+export interface CollectStatusOptions {
+  /** Run the LLM schedule evaluator for each enabled schedule. */
+  evaluateSchedules: boolean;
+}
+
+async function collectWorkers(projectDir: string): Promise<WorkerSummary> {
+  const workers = await listWorkers(projectDir);
+  let running = 0;
+  let stopped = 0;
+  let dead = 0;
+  let latest: string | null = null;
+  for (const w of workers) {
+    if (w.status === "running") running++;
+    else if (w.status === "stopped") stopped++;
+    else dead++;
+    if (!latest || w.last_heartbeat_at > latest) latest = w.last_heartbeat_at;
+  }
+  return {
+    total: workers.length,
+    running,
+    stopped,
+    dead,
+    latest_heartbeat_at: latest,
+    list: workers.map((w) => ({
+      id: w.id,
+      status: w.status,
+      mode: w.mode,
+      pid: w.pid,
+      last_heartbeat_at: w.last_heartbeat_at,
+      task_id: w.task_id,
+    })),
+  };
+}
+
+/**
+ * Single-pass task scan. Parses each `tasks/<id>.md` directly via
+ * `parseTaskFile` (rather than `getTask`/`listTasks`) so malformed files land
+ * in `quarantined` without spraying `logger.warn` over the dashboard output.
+ */
+async function collectTasks(projectDir: string): Promise<TaskSummary> {
+  const by_status = Object.fromEntries(
+    TASK_STATUSES.map((s) => [s, 0]),
+  ) as Record<TaskStatus, number>;
+  const claimed: TaskSummary["claimed"] = [];
+  const quarantined: QuarantinedFile[] = [];
+  let total = 0;
+
+  for (const id of await listTaskFiles(projectDir)) {
+    const file = await readWithMtime(taskFilePath(projectDir, id));
+    if (!file) continue;
+    const parsed = parseTaskFile(file.content, file.mtimeMs);
+    if (!parsed.ok) {
+      quarantined.push({ id, reason: parsed.reason });
+      continue;
+    }
+    const t = parsed.task;
+    total++;
+    by_status[t.status]++;
+    if (t.status === "in_progress" && t.claimed_by) {
+      claimed.push({
+        id: t.id,
+        name: t.name,
+        claimed_by: t.claimed_by,
+        claimed_at: t.claimed_at,
+      });
+    }
+  }
+
+  return { total, by_status, claimed, quarantined };
+}
+
+async function collectSchedules(
+  projectDir: string,
+  config: BotholomewConfig,
+  evaluateSchedules: boolean,
+): Promise<ScheduleSummary> {
+  const quarantined: QuarantinedFile[] = [];
+  // Keep each entry paired with its full parsed Schedule so the evaluator
+  // receives the real description, last_run_at, etc.
+  const parsed: Array<{ entry: ScheduleEntry; schedule: Schedule }> = [];
+  let enabled = 0;
+  let disabled = 0;
+
+  for (const id of await listScheduleFiles(projectDir)) {
+    const file = await readWithMtime(scheduleFilePath(projectDir, id));
+    if (!file) continue;
+    const result = parseScheduleFile(file.content, file.mtimeMs);
+    if (!result.ok) {
+      quarantined.push({ id, reason: result.reason });
+      continue;
+    }
+    const s = result.schedule;
+    if (s.enabled) enabled++;
+    else disabled++;
+    parsed.push({
+      entry: {
+        id: s.id,
+        name: s.name,
+        frequency: s.frequency,
+        enabled: s.enabled,
+        last_run_at: s.last_run_at,
+      },
+      schedule: s,
+    });
+  }
+
+  // Evaluate enabled schedules in parallel. evaluateSchedule has no disk
+  // side-effects and already degrades gracefully on LLM error.
+  if (evaluateSchedules) {
+    await Promise.all(
+      parsed
+        .filter((p) => p.schedule.enabled)
+        .map(async ({ entry, schedule }) => {
+          const evaluation = await evaluateSchedule(config, schedule);
+          entry.evaluation = {
+            is_due: evaluation.isDue,
+            reasoning: evaluation.reasoning,
+            tasks_to_create: evaluation.tasksToCreate.length,
+          };
+        }),
+    );
+  }
+
+  const list = parsed.map((p) => p.entry);
+  return { total: list.length, enabled, disabled, list, quarantined };
+}
+
+/**
+ * Gather a read-only snapshot of project state for `botholomew status`. Pure
+ * data-gathering: no disk mutation (schedule evaluation is read-only). The
+ * returned object is fully serializable for `--json`.
+ */
+export async function collectStatus(
+  projectDir: string,
+  config: BotholomewConfig,
+  opts: CollectStatusOptions,
+): Promise<StatusReport> {
+  const [workers, tasks, schedules] = await Promise.all([
+    collectWorkers(projectDir),
+    collectTasks(projectDir),
+    collectSchedules(projectDir, config, opts.evaluateSchedules),
+  ]);
+
+  return {
+    project_dir: projectDir,
+    workers,
+    tasks,
+    schedules,
+    store: {
+      membot_scope: config.membot_scope,
+      membot_dir: resolveMembotDir(projectDir, config),
+      mcpx_scope: config.mcpx_scope,
+      mcpx_dir: resolveMcpxDir(projectDir, config),
+    },
+  };
+}

--- a/test/status/collect.test.ts
+++ b/test/status/collect.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadConfig } from "../../src/config/loader.ts";
+import {
+  getSchedulesDir,
+  getSchedulesLockDir,
+  getTasksDir,
+  getTasksLockDir,
+  getWorkersDir,
+} from "../../src/constants.ts";
+import { createSchedule } from "../../src/schedules/store.ts";
+import { collectStatus } from "../../src/status/collect.ts";
+import {
+  claimNextTask,
+  createTask,
+  taskFilePath,
+  updateTaskStatus,
+} from "../../src/tasks/store.ts";
+import { registerWorker } from "../../src/workers/store.ts";
+
+let projectDir: string;
+
+beforeEach(async () => {
+  projectDir = await mkdtemp(join(tmpdir(), "both-status-"));
+  for (const dir of [
+    getTasksDir(projectDir),
+    getTasksLockDir(projectDir),
+    getSchedulesDir(projectDir),
+    getSchedulesLockDir(projectDir),
+    getWorkersDir(projectDir),
+  ]) {
+    await mkdir(dir, { recursive: true });
+  }
+});
+
+afterEach(async () => {
+  await rm(projectDir, { recursive: true, force: true });
+});
+
+async function collect() {
+  const config = await loadConfig(projectDir);
+  return collectStatus(projectDir, config, { evaluateSchedules: false });
+}
+
+describe("collectStatus — workers", () => {
+  test("buckets workers by status and reports the latest heartbeat", async () => {
+    await registerWorker(projectDir, {
+      id: "w-running",
+      pid: process.pid,
+      hostname: "test",
+      mode: "persist",
+    });
+    await registerWorker(projectDir, {
+      id: "w-once",
+      pid: process.pid,
+      hostname: "test",
+      mode: "once",
+    });
+
+    const report = await collect();
+    expect(report.workers.total).toBe(2);
+    expect(report.workers.running).toBe(2);
+    expect(report.workers.stopped).toBe(0);
+    expect(report.workers.dead).toBe(0);
+    expect(report.workers.latest_heartbeat_at).not.toBeNull();
+    expect(report.workers.list.map((w) => w.id).sort()).toEqual([
+      "w-once",
+      "w-running",
+    ]);
+  });
+
+  test("no workers → zeros and null heartbeat", async () => {
+    const report = await collect();
+    expect(report.workers.total).toBe(0);
+    expect(report.workers.latest_heartbeat_at).toBeNull();
+  });
+});
+
+describe("collectStatus — tasks", () => {
+  test("counts by status and surfaces claimed in_progress tasks with owners", async () => {
+    await createTask(projectDir, { name: "pending-1" });
+    const done = await createTask(projectDir, { name: "done-1" });
+    await updateTaskStatus(projectDir, done.id, "complete");
+
+    const claimed = await claimNextTask(projectDir, "worker-xyz");
+    expect(claimed).not.toBeNull();
+
+    const report = await collect();
+    expect(report.tasks.total).toBe(2);
+    expect(report.tasks.by_status.complete).toBe(1);
+    expect(report.tasks.by_status.in_progress).toBe(1);
+    expect(report.tasks.by_status.pending).toBe(0);
+
+    expect(report.tasks.claimed).toHaveLength(1);
+    expect(report.tasks.claimed[0]?.claimed_by).toBe("worker-xyz");
+    expect(report.tasks.claimed[0]?.id).toBe(claimed?.id);
+  });
+
+  test("malformed task files are quarantined, not counted", async () => {
+    await createTask(projectDir, { name: "good" });
+    await writeFile(
+      taskFilePath(projectDir, "broken"),
+      "---\nthis: [is not valid frontmatter\n---\nbody",
+    );
+
+    const report = await collect();
+    expect(report.tasks.total).toBe(1);
+    expect(report.tasks.quarantined).toHaveLength(1);
+    expect(report.tasks.quarantined[0]?.id).toBe("broken");
+    expect(report.tasks.quarantined[0]?.reason).toBeTruthy();
+  });
+});
+
+describe("collectStatus — schedules", () => {
+  test("counts enabled vs disabled; no evaluation when evaluateSchedules is false", async () => {
+    await createSchedule(projectDir, {
+      name: "daily",
+      frequency: "every day",
+      enabled: true,
+    });
+    await createSchedule(projectDir, {
+      name: "off",
+      frequency: "weekly",
+      enabled: false,
+    });
+
+    const report = await collect();
+    expect(report.schedules.total).toBe(2);
+    expect(report.schedules.enabled).toBe(1);
+    expect(report.schedules.disabled).toBe(1);
+    for (const e of report.schedules.list) {
+      expect(e.evaluation).toBeUndefined();
+    }
+  });
+});
+
+describe("collectStatus — store", () => {
+  test("resolves membot/mcpx scope and dirs from config", async () => {
+    const report = await collect();
+    const config = await loadConfig(projectDir);
+    expect(report.store.membot_scope).toBe(config.membot_scope);
+    expect(report.store.mcpx_scope).toBe(config.mcpx_scope);
+    expect(report.store.membot_dir).toBeTruthy();
+    expect(report.store.mcpx_dir).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #250. Adds `botholomew status` — one read-only command that renders the whole project in a single ASCII view, so you no longer need to stitch together `worker list` + `task list` + `schedule list` + log spelunking.

It surfaces:
- **Workers** — alive/dead counts and the most recent heartbeat
- **Tasks** — counts by state, plus currently-claimed tasks and their owners
- **Schedules** — frequency + last-run, plus a live LLM **"due?"** verdict
- **Quarantined** — task/schedule files with invalid frontmatter (and the reason)
- **Store** — resolved membot/mcpx scope + directories

Flags: `--json` (serialized `StatusReport` for scripting) and `--no-evaluate` (skip the LLM schedule check for fast/offline runs).

## Design

- `src/status/collect.ts` — `collectStatus()` returns a pure, serializable `StatusReport` (the thing `--json` dumps and tests assert on). It parses task/schedule files directly via `parseTaskFile`/`parseScheduleFile` rather than `getTask`/`listTasks`, so malformed files land in a `quarantined` bucket without spraying `logger.warn` over the dashboard.
- `src/commands/status.ts` — ASCII renderer reusing the existing `ansis`/`padEnd` style from the `worker`/`task` commands.
- Schedules have **no deterministic next-fire** — they use a natural-language `frequency` evaluated by an LLM at tick time. Per discussion, `status` reuses `evaluateSchedule` per enabled schedule to show "due now?" (it has no disk side-effects and already degrades gracefully on LLM error).

## Example

```
Workers
  0 total — 0 running, 0 stopped, 0 dead   latest heartbeat: never

Tasks
  2 total — 2 pending, 0 in_progress, 0 waiting, 0 complete, 0 failed

Schedules
  1 total — 1 enabled, 0 disabled
  Morning digest  (every morning at 9am)  last run never  not due

Quarantined (invalid frontmatter)
  task broken-task — frontmatter parse error: YAMLException: ...

Store
  membot: global  ~/.membot
  mcpx:   global  ~/.mcpx
```

## Testing

- New `test/status/collect.test.ts` covers workers, task counts/claims, quarantine, schedule counts, and store resolution (LLM-free via `evaluateSchedules: false`).
- `bun run lint` clean; full `bun test` passes (602).
- Manually exercised `status`, `status --json`, and `status --no-evaluate` against a fresh `init`.

Docs: README CLI table row + an architecture.md "Project status" section. Version bumped to 0.22.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)