### PR TITLE
Fix worker marking abandoned task complete instead of failed (#255)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,6 +88,15 @@ If no task is claimable and no schedule is due, `tick()` returns
 `false`. A `--persist` worker then sleeps `tick_interval_seconds` before
 trying again; a `--once` worker exits immediately.
 
+The agent loop ends the tick by calling exactly one terminal status tool —
+`complete_task`, `fail_task`, or `wait_task` — which maps to the task's
+final status (the `complete_task` summary becomes the task's `output`; a
+`fail_task`/`wait_task` reason becomes its `waiting_reason`). If the model
+stops emitting tool calls **without** declaring a terminal status, the loop
+nudges it once to call one; if it still doesn't, the task is recorded as
+`failed` (not `complete`) — an implicit tick-end is treated as unfinished
+work, never silent success.
+
 See `src/worker/tick.ts`.
 
 ### Log format

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/worker/llm.ts
+++ b/src/worker/llm.ts
@@ -114,6 +114,7 @@ export async function runAgentLoop(input: {
   const maxInputTokens = await getMaxInputTokens(config.llm);
 
   const maxTurns = config.max_turns;
+  let nudgeCount = 0;
   for (let turn = 0; !maxTurns || turn < maxTurns; turn++) {
     const startTime = Date.now();
     fitToContextWindow(messages, systemPrompt, maxInputTokens);
@@ -188,9 +189,29 @@ export async function runAgentLoop(input: {
     }
 
     if (collectedToolCalls.length === 0) {
+      // An implicit tick-end (the model stopped emitting tool calls) is
+      // ambiguous evidence — it usually means the agent hit a dead end,
+      // exhausted its output budget mid-thought, or forgot to declare a
+      // terminal status. Don't treat it as success. Nudge once to give the
+      // agent a chance to recover (e.g. emit the final tool call it was about
+      // to make, or fail_task on a capability gap); fail if it still doesn't.
+      if (nudgeCount === 0) {
+        nudgeCount++;
+        const nudge =
+          "You ended your turn without calling a terminal status tool. Every tick must end with exactly one of: complete_task (only if the required deliverable truly exists — verify it), fail_task (if you are blocked or a required tool/capability is unavailable — state the gap), or wait_task (if you must wait on something external). Call the appropriate one now.";
+        messages.push({ role: "user", content: nudge });
+        await logInteraction(projectDir, threadId, {
+          role: "system",
+          kind: "status_change",
+          content:
+            "Agent ended its turn without a terminal status tool; nudging to call complete_task/fail_task/wait_task.",
+        });
+        continue;
+      }
       return {
-        status: "complete",
-        reason: "Agent completed without explicit status tool call",
+        status: "failed",
+        reason:
+          "Agent ended its tick without calling a terminal status tool (complete_task/fail_task/wait_task)",
       };
     }
 

--- a/src/worker/prompt.ts
+++ b/src/worker/prompt.ts
@@ -132,6 +132,8 @@ export async function buildSystemPrompt(
   prompt += `## Instructions
 You are Botholomew, a wise-owl worker that works through tasks. Use available tools to complete your assigned task, then call complete_task, fail_task, or wait_task. Use create_task for subtasks and update_task to refine pending tasks. Batch independent tool calls in a single response for parallel execution.
 
+Always end your tick by calling exactly one terminal status tool — never just stop. Call complete_task ONLY if the required deliverable actually exists (verify it). If you are blocked or a required tool/capability is unavailable (e.g. no way to produce the requested output), call fail_task and state the gap — do not pretend success. If you must wait on something external, call wait_task.
+
 When calling complete_task, write a summary that captures your key findings, decisions, and outputs. This summary becomes the task's output and is provided to any downstream tasks that depend on this one. Include specific results (data, names, paths, conclusions) rather than vague descriptions of what you did — downstream tasks will rely on this information to do their work.
 `;
 

--- a/test/worker/llm.test.ts
+++ b/test/worker/llm.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { sharedWithMem } from "../../src/mem/client.ts";
+import type { Task } from "../../src/tasks/schema.ts";
+import { createThread } from "../../src/threads/store.ts";
+import { runAgentLoop } from "../../src/worker/llm.ts";
+import { setupTestMembot, TEST_CONFIG } from "../helpers.ts";
+
+// runAgentLoop reads the model via getLanguageModel, which returns the fake
+// MockLanguageModelV3 whenever BOTHOLOMEW_FAKE_LLM=1. The fake replays the
+// turns from BOTHOLOMEW_FAKE_LLM_FIXTURE.
+
+let mem: Awaited<ReturnType<typeof setupTestMembot>>["mem"];
+let projectDir: string;
+let cleanup: () => Promise<void>;
+
+beforeEach(async () => {
+  ({ mem, projectDir, cleanup } = await setupTestMembot());
+  process.env.BOTHOLOMEW_FAKE_LLM = "1";
+});
+
+afterEach(async () => {
+  delete process.env.BOTHOLOMEW_FAKE_LLM;
+  delete process.env.BOTHOLOMEW_FAKE_LLM_FIXTURE;
+  await cleanup();
+});
+
+async function writeFixture(turns: unknown[]): Promise<void> {
+  const path = join(projectDir, "fixture.json");
+  await writeFile(path, JSON.stringify({ turns }));
+  process.env.BOTHOLOMEW_FAKE_LLM_FIXTURE = path;
+}
+
+function makeTask(): Task {
+  const now = new Date().toISOString();
+  return {
+    id: "task-test",
+    name: "Test task",
+    description: "Do a thing",
+    priority: "medium",
+    status: "in_progress",
+    blocked_by: [],
+    context_paths: [],
+    output: null,
+    waiting_reason: null,
+    claimed_by: "worker-1",
+    claimed_at: now,
+    created_at: now,
+    updated_at: now,
+    mtimeMs: 0,
+    body: "",
+  };
+}
+
+async function run(): Promise<Awaited<ReturnType<typeof runAgentLoop>>> {
+  const threadId = await createThread(
+    projectDir,
+    "worker_tick",
+    "task-test",
+    "Working: Test task",
+  );
+  return runAgentLoop({
+    systemPrompt: "You are a test worker.",
+    task: makeTask(),
+    config: TEST_CONFIG,
+    withMem: sharedWithMem(mem),
+    threadId,
+    projectDir,
+    workerId: "worker-1",
+  });
+}
+
+describe("runAgentLoop implicit tick-end (issue #255)", () => {
+  test("fails (not completes) when the agent never calls a terminal tool", async () => {
+    // Both turns emit text but no tool calls: the first triggers the nudge,
+    // the second still has no terminal call, so the loop must fail.
+    await writeFixture([
+      { text: "I pulled the data.", delayMs: 0 },
+      { text: "Still thinking.", delayMs: 0 },
+    ]);
+
+    const result = await run();
+
+    expect(result.status).toBe("failed");
+    expect(result.reason).toContain("terminal status tool");
+  });
+
+  test("nudge lets the agent recover to complete on the next turn", async () => {
+    // First turn forgets the terminal call; after the nudge, the agent calls
+    // complete_task — which must map to a legitimate complete.
+    await writeFixture([
+      { text: "Done with the work.", delayMs: 0 },
+      {
+        text: "Wrapping up.",
+        toolCalls: [
+          { name: "complete_task", input: { summary: "All finished" } },
+        ],
+        delayMs: 0,
+      },
+    ]);
+
+    const result = await run();
+
+    expect(result.status).toBe("complete");
+    expect(result.reason).toBe("All finished");
+  });
+
+  test("nudge lets the agent recover by failing on a capability gap", async () => {
+    await writeFixture([
+      { text: "No tool can render a PNG here.", delayMs: 0 },
+      {
+        text: "Reporting the gap.",
+        toolCalls: [
+          {
+            name: "fail_task",
+            input: { reason: "No code/plotting tool available" },
+          },
+        ],
+        delayMs: 0,
+      },
+    ]);
+
+    const result = await run();
+
+    expect(result.status).toBe("failed");
+    expect(result.reason).toBe("No code/plotting tool available");
+  });
+});


### PR DESCRIPTION
Fixes #255. A background worker that ended its tick without calling a terminal status tool (`complete_task`/`fail_task`/`wait_task`) was defaulting the task to `complete` with reason "Agent completed without explicit status tool call", silently hiding incomplete or blocked work. Now an implicit tick-end nudges the agent once to declare a terminal status, and if it still doesn't, the task is recorded as `failed` rather than `complete`. Also strengthens the worker prompt to always end with a terminal tool and to `fail_task` on capability gaps instead of pretending success. Adds `test/worker/llm.test.ts` covering the fail-after-nudge, recover-to-complete, and recover-to-fail paths via the fake LLM, and documents the behavior in `docs/architecture.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)