### PR TITLE
Report unknown top-level commands instead of "too many arguments"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,9 +74,30 @@ registerPrepareCommand(program);
 registerCheckUpdateCommand(program);
 registerUpgradeCommand(program);
 
-program.action(() => {
-  program.help();
-});
+// Bare `botholomew` (only the global -d/--dir, or nothing) prints help on
+// stdout and exits 0. We do this explicitly instead of via a root .action()
+// handler, because that handler made Commander treat a mistyped command as an
+// excess positional argument ("too many arguments. Expected 0 arguments but
+// got 1: foo.") instead of reporting an unknown command. With no root action, a
+// real typo now reaches Commander's unknownCommand() → "error: unknown command
+// 'foo'" (plus a did-you-mean suggestion).
+function isBareInvocation(argv: string[]): boolean {
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === undefined) continue;
+    if (a === "-d" || a === "--dir") {
+      i++; // skip the option's value
+      continue;
+    }
+    if (a.startsWith("--dir=")) continue;
+    return false; // any operand OR other flag (--help, --version, foo, …)
+  }
+  return true;
+}
+
+if (isBareInvocation(process.argv.slice(2))) {
+  program.help(); // outputs to stdout and exits 0
+}
 
 // Start background update check before parsing (non-blocking)
 const updateNotice = maybeCheckForUpdate();

--- a/test/commands/cli.test.ts
+++ b/test/commands/cli.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { pkg } from "../../src/pkg.ts";
+
+const CLI_PATH = join(import.meta.dir, "..", "..", "src", "cli.ts");
+
+async function runCli(args: string[]): Promise<{
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}> {
+  // A throwaway `-d` keeps the CLI from touching the real project dir; the
+  // dispatch errors we assert on happen before any of these commands read it.
+  const proc = Bun.spawn(["bun", CLI_PATH, "-d", import.meta.dir, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const exitCode = await proc.exited;
+  return { stdout, stderr, exitCode };
+}
+
+describe("CLI command dispatch", () => {
+  test("an unknown top-level command errors with 'unknown command'", async () => {
+    const { stderr, exitCode } = await runCli(["foo"]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("unknown command 'foo'");
+    // The old, confusing message must not resurface.
+    expect(stderr).not.toContain("too many arguments");
+  });
+
+  test("a near-miss typo gets a did-you-mean suggestion", async () => {
+    const { stderr, exitCode } = await runCli(["chta"]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("unknown command 'chta'");
+    expect(stderr).toContain("Did you mean chat?");
+  });
+
+  test("an unknown subcommand of a group errors with 'unknown command'", async () => {
+    const { stderr, exitCode } = await runCli(["task", "foo"]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("unknown command 'foo'");
+    expect(stderr).not.toContain("too many arguments");
+  });
+
+  test("bare invocation prints help to stdout and exits 0", async () => {
+    const { stdout, exitCode } = await runCli([]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Usage:");
+    // The command list should be present.
+    expect(stdout).toContain("chat");
+  });
+
+  test("--version prints the version and exits 0 (guard doesn't swallow it)", async () => {
+    const { stdout, exitCode } = await runCli(["--version"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain(pkg.version);
+  });
+});


### PR DESCRIPTION
A mistyped top-level command (e.g. `botholomew foo`) printed the confusing `error: too many arguments. Expected 0 arguments but got 1: foo.` because the root program carried a fallback `.action(() => program.help())`, which made Commander treat the unknown token as an excess positional argument. This removes that root action so a real typo now reaches Commander's `unknownCommand()` → `error: unknown command 'foo'` (with a did-you-mean suggestion), and replaces it with an explicit bare-invocation guard that preserves today's UX of printing help to stdout and exiting 0. The subcommand groups (`task`, `worker`, …) were already correct, so only the root needed fixing. Adds `test/commands/cli.test.ts` covering unknown commands, the suggestion, group typos, bare-invocation help, and `--version`, and bumps the version to 0.22.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)