### PR TITLE
Fix biome useOptionalChain warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/approvals/decide.ts
+++ b/src/approvals/decide.ts
@@ -20,7 +20,7 @@ export async function decideAndRequeue(
   decidedBy: string,
 ): Promise<Approval | null> {
   const existing = await getApproval(projectDir, id);
-  if (!existing || existing.status !== "pending") return null;
+  if (existing?.status !== "pending") return null;
   const decided = await decideApproval(projectDir, id, decision, decidedBy);
   if (decided.task_id) {
     const task = await getTask(projectDir, decided.task_id);

--- a/src/tui/components/ApprovalPanel.tsx
+++ b/src/tui/components/ApprovalPanel.tsx
@@ -77,7 +77,7 @@ export const ApprovalPanel = memo(function ApprovalPanel({
   const decide = useCallback(
     (decision: "approved" | "denied") => {
       const a = selectedRef.current;
-      if (!a || a.status !== "pending") return;
+      if (a?.status !== "pending") return;
       void decideAndRequeue(projectDir, a.id, decision, "tui").then(() => {
         setNotice(
           `${decision === "approved" ? "Approved" : "Denied"} ${a.server}/${a.tool}`,


### PR DESCRIPTION
Collapse two null-or-status guards to optional chaining
(approvals/decide.ts and tui/ApprovalPanel.tsx), clearing the
two lint/complexity/useOptionalChain warnings from biome check.

https://claude.ai/code/session_01D7Y9wmfmYywvXKTsqxvuNy