### PR TITLE
Upgrade membot to 0.18.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
         "ink-text-input": "^6.0.0",
         "istextorbinary": "^9.5.0",
         "jsonata": "^2.2.1",
-        "membot": "^0.17.2",
+        "membot": "^0.18.0",
         "nanospinner": "^1.2.2",
         "ollama-ai-provider-v2": "^3.5.1",
         "react": "^19.2.7",
@@ -829,7 +829,7 @@
 
     "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
 
-    "membot": ["membot@0.17.2", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.0", "@duckdb/node-api": "1.5.2-r.1", "@huggingface/transformers": "^4.2.0", "@modelcontextprotocol/sdk": "^1.29.0", "@types/picomatch": "^4.0.3", "@types/turndown": "^5.0.5", "ansis": "^4.2.0", "commander": "^14.0.3", "fast-xml-parser": "^5.7.3", "gray-matter": "^4.0.3", "jszip": "^3.10.1", "macos-ts": "^0.11.0", "mammoth": "^1.8.0", "nanospinner": "^1.2.2", "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c", "picomatch": "^4.0.4", "turndown": "^7.2.0", "unpdf": "^0.12.0", "xlsx": "^0.18.5", "zod": "^4.0.0", "zod-to-json-schema": "^3.23.0" }, "bin": { "membot": "src/cli.ts" } }, "sha512-dbEKc3TUNLiX6TFNaEvBV/pyue4zu0Ui+48y1wgVv94kJUcOj1uh2bd6f40zoRbV4iNB1fUPxPHiRWHzYKsxsQ=="],
+    "membot": ["membot@0.18.0", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.0", "@duckdb/node-api": "1.5.2-r.1", "@huggingface/transformers": "^4.2.0", "@modelcontextprotocol/sdk": "^1.29.0", "@types/picomatch": "^4.0.3", "@types/turndown": "^5.0.5", "ansis": "^4.2.0", "commander": "^14.0.3", "fast-xml-parser": "^5.7.3", "gray-matter": "^4.0.3", "jszip": "^3.10.1", "macos-ts": "^0.11.0", "mammoth": "^1.8.0", "nanospinner": "^1.2.2", "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c", "picomatch": "^4.0.4", "turndown": "^7.2.0", "unpdf": "^0.12.0", "xlsx": "^0.18.5", "zod": "^4.0.0", "zod-to-json-schema": "^3.23.0" }, "bin": { "membot": "src/cli.ts" } }, "sha512-93gx1rh8MSj4q3g+rn4SRaCRzcC+BrTsOyD5HkNcqY26bZrxvNjvKtJfgFJFnP7Q7WNnuV1h5tdmjCN5nwqi+A=="],
 
     "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 

--- a/docs/context-and-search.md
+++ b/docs/context-and-search.md
@@ -40,6 +40,39 @@ This page is intentionally short — the canonical docs live with membot.
   the chat session, and the TUI Context panel all share that handle through
   `ToolContext.mem`.
 
+## Search quality & reranking
+
+membot 0.18.0 reworked the embedding and search pipeline. Two things are worth
+knowing from Botholomew's side:
+
+- **Optional cross-encoder reranker.** `membot_search` (and `botholomew membot
+  search`) now accepts `rerank=true` to rescore the top hybrid candidates with a
+  local cross-encoder (ms-marco-MiniLM by default) for higher precision at the
+  cost of latency — the first reranked query downloads the model. Hits then carry
+  a `rerank_score` and the result reports `reranked: true`. Leave it off for the
+  fast hybrid path. The default is configurable in membot's own `config.json`
+  (`search.rerank`, `search.rerank_model`), and `search.max_per_file` caps how
+  many chunks a single `logical_path` contributes to a result set.
+- **Heading-aware chunking** (`chunker.markdown_aware`, on by default) splits
+  markdown at heading boundaries and embeds a breadcrumb per chunk, so snippets
+  carry their section context.
+
+### Re-embed after upgrading
+
+The 0.18.0 embedding fixes (CLS pooling for BGE models, smaller chunks that fit
+the 512-token window) change the embedding revision. **Existing stores built
+under an older membot keep their old vectors and silently degrade semantic
+search until they are re-embedded** — membot prints a stale-revision warning on
+search when this is the case. Re-embed once per store with:
+
+```sh
+botholomew membot reindex --embeddings
+```
+
+(Run it for each scope you use — the global `~/.membot` store and any
+`membot_scope: "project"` stores.) Fresh stores created on 0.18.0+ need no
+action.
+
 ## Storage scope
 
 `membot_scope` in `config/config.json` controls where the knowledge store

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {
@@ -41,7 +41,7 @@
     "ink-text-input": "^6.0.0",
     "istextorbinary": "^9.5.0",
     "jsonata": "^2.2.1",
-    "membot": "^0.17.2",
+    "membot": "^0.18.0",
     "nanospinner": "^1.2.2",
     "ollama-ai-provider-v2": "^3.5.1",
     "react": "^19.2.7",


### PR DESCRIPTION
Bumps membot 0.17.2 → 0.18.0, which reworks the embedding/search pipeline
(PR #86): CLS pooling for BGE models, smaller chunks sized to the 512-token
window, heading-aware markdown chunking, per-file diversity caps, and an
optional local cross-encoder reranker.

The new per-query `rerank` param and `rerank_score`/`reranked` output fields
flow through the passthrough adapter automatically — no adapter change needed.
tsc and the tool tests pass unchanged.

Documents the new reranker and, importantly, the one-time
`botholomew membot reindex --embeddings` re-embed that existing stores need
after upgrading (membot prints a stale-revision warning otherwise).

https://claude.ai/code/session_0152vhmZrzXmhAk4ykRk5NNL