### PR TITLE
Upgrade membot to 0.18.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
         "ink-text-input": "^6.0.0",
         "istextorbinary": "^9.5.0",
         "jsonata": "^2.2.1",
-        "membot": "^0.18.0",
+        "membot": "^0.18.1",
         "nanospinner": "^1.2.2",
         "ollama-ai-provider-v2": "^3.5.1",
         "react": "^19.2.7",
@@ -829,7 +829,7 @@
 
     "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
 
-    "membot": ["membot@0.18.0", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.0", "@duckdb/node-api": "1.5.2-r.1", "@huggingface/transformers": "^4.2.0", "@modelcontextprotocol/sdk": "^1.29.0", "@types/picomatch": "^4.0.3", "@types/turndown": "^5.0.5", "ansis": "^4.2.0", "commander": "^14.0.3", "fast-xml-parser": "^5.7.3", "gray-matter": "^4.0.3", "jszip": "^3.10.1", "macos-ts": "^0.11.0", "mammoth": "^1.8.0", "nanospinner": "^1.2.2", "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c", "picomatch": "^4.0.4", "turndown": "^7.2.0", "unpdf": "^0.12.0", "xlsx": "^0.18.5", "zod": "^4.0.0", "zod-to-json-schema": "^3.23.0" }, "bin": { "membot": "src/cli.ts" } }, "sha512-93gx1rh8MSj4q3g+rn4SRaCRzcC+BrTsOyD5HkNcqY26bZrxvNjvKtJfgFJFnP7Q7WNnuV1h5tdmjCN5nwqi+A=="],
+    "membot": ["membot@0.18.1", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.0", "@duckdb/node-api": "1.5.2-r.1", "@huggingface/transformers": "^4.2.0", "@modelcontextprotocol/sdk": "^1.29.0", "@types/picomatch": "^4.0.3", "@types/turndown": "^5.0.5", "ansis": "^4.2.0", "commander": "^14.0.3", "fast-xml-parser": "^5.7.3", "gray-matter": "^4.0.3", "jszip": "^3.10.1", "macos-ts": "^0.11.0", "mammoth": "^1.8.0", "nanospinner": "^1.2.2", "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c", "picomatch": "^4.0.4", "turndown": "^7.2.0", "unpdf": "^0.12.0", "xlsx": "^0.18.5", "zod": "^4.0.0", "zod-to-json-schema": "^3.23.0" }, "bin": { "membot": "src/cli.ts" } }, "sha512-y3+wEfOYifUJ0AUbk+kVi5nZMVBhSQlFemxviC/YDfFulKP7OugLy00q8pY8o42MaJlrBzdDLCHvNoilqkGBxg=="],
 
     "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {
@@ -41,7 +41,7 @@
     "ink-text-input": "^6.0.0",
     "istextorbinary": "^9.5.0",
     "jsonata": "^2.2.1",
-    "membot": "^0.18.0",
+    "membot": "^0.18.1",
     "nanospinner": "^1.2.2",
     "ollama-ai-provider-v2": "^3.5.1",
     "react": "^19.2.7",


### PR DESCRIPTION
## What

Bumps `membot` `^0.18.0` → `^0.18.1` and Botholomew `0.24.1` → `0.24.2`.

membot 0.18.1 ([release notes](https://github.com/evantahler/membot/releases/tag/v0.18.1)) is a patch release with a single change: `reindex --recovery` to repair a corrupted chunks index (fixes a reindex panic). It's reachable today through the existing `botholomew membot reindex --recovery` passthrough.

## Why low-risk

- **No dependency changes** — 0.18.0 and 0.18.1 have identical dependency trees (same `@huggingface/transformers@^4.2.0`, `onnxruntime-web` pin, DuckDB).
- **No SDK-surface changes** consumed by Botholomew's `MembotClient` / `membot_*` adapters.
- The standalone-build transformers patch (`scripts/build.ts`) targets transformers 4.2.x, which is unchanged — patch guard still matches.

## Verification

- `bun run lint` — clean (tsc + biome)
- `bun test` — 660 pass
- No docs change required (membot CLI is a generic passthrough; changelog auto-pulls from GitHub releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)