### PR TITLE
Upgrade membot to 0.19.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
         "ink-text-input": "^6.0.0",
         "istextorbinary": "^9.5.0",
         "jsonata": "^2.2.1",
-        "membot": "^0.18.1",
+        "membot": "^0.19.0",
         "nanospinner": "^1.2.2",
         "ollama-ai-provider-v2": "^3.5.1",
         "react": "^19.2.7",
@@ -829,7 +829,7 @@
 
     "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
 
-    "membot": ["membot@0.18.1", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.0", "@duckdb/node-api": "1.5.2-r.1", "@huggingface/transformers": "^4.2.0", "@modelcontextprotocol/sdk": "^1.29.0", "@types/picomatch": "^4.0.3", "@types/turndown": "^5.0.5", "ansis": "^4.2.0", "commander": "^14.0.3", "fast-xml-parser": "^5.7.3", "gray-matter": "^4.0.3", "jszip": "^3.10.1", "macos-ts": "^0.11.0", "mammoth": "^1.8.0", "nanospinner": "^1.2.2", "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c", "picomatch": "^4.0.4", "turndown": "^7.2.0", "unpdf": "^0.12.0", "xlsx": "^0.18.5", "zod": "^4.0.0", "zod-to-json-schema": "^3.23.0" }, "bin": { "membot": "src/cli.ts" } }, "sha512-y3+wEfOYifUJ0AUbk+kVi5nZMVBhSQlFemxviC/YDfFulKP7OugLy00q8pY8o42MaJlrBzdDLCHvNoilqkGBxg=="],
+    "membot": ["membot@0.19.0", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.0", "@duckdb/node-api": "1.5.2-r.1", "@huggingface/transformers": "^4.2.0", "@modelcontextprotocol/sdk": "^1.29.0", "@types/picomatch": "^4.0.3", "@types/turndown": "^5.0.5", "ansis": "^4.2.0", "commander": "^14.0.3", "fast-xml-parser": "^5.7.3", "gray-matter": "^4.0.3", "jszip": "^3.10.1", "macos-ts": "^0.11.0", "mammoth": "^1.8.0", "nanospinner": "^1.2.2", "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c", "picomatch": "^4.0.4", "turndown": "^7.2.0", "unpdf": "^0.12.0", "xlsx": "^0.18.5", "zod": "^4.0.0", "zod-to-json-schema": "^3.23.0" }, "bin": { "membot": "src/cli.ts" } }, "sha512-inzwOeFZ9PIFyP9PkjyXerh1Dbn/4Bwrk0RFECK1TIg1qT2MGnkFMP8y20ybMyChaRLTJoXTBsh2q9TJNcHHVg=="],
 
     "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.24.2",
+  "version": "0.24.3",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {
@@ -41,7 +41,7 @@
     "ink-text-input": "^6.0.0",
     "istextorbinary": "^9.5.0",
     "jsonata": "^2.2.1",
-    "membot": "^0.18.1",
+    "membot": "^0.19.0",
     "nanospinner": "^1.2.2",
     "ollama-ai-provider-v2": "^3.5.1",
     "react": "^19.2.7",

--- a/src/tui/components/ContextPanel.tsx
+++ b/src/tui/components/ContextPanel.tsx
@@ -366,9 +366,9 @@ export const ContextPanel = memo(function ContextPanel({
       const path = row.full_path;
       (async () => {
         try {
-          await withMem((mem) =>
-            mem.remove({ paths: [path], recursive: true }),
-          );
+          // Recursive removal is expressed as a `dir/**` glob (membot >=0.19).
+          const prefix = path.endsWith("/") ? path.slice(0, -1) : path;
+          await withMem((mem) => mem.remove({ paths: [`${prefix}/**`] }));
         } catch {
           // ignore — refresh will reflect any partial state
         }


### PR DESCRIPTION
Bumps `membot` from `0.18.1` → `0.19.0` (and `botholomew` `0.24.2` → `0.24.3`).

## Breaking change handled
membot 0.19.0 removes the `recursive` option on the `remove` operation. Recursive directory deletion is now expressed as a `dir/**` glob. Updated the ContextPanel `d`-`d` delete path (`src/tui/components/ContextPanel.tsx`) to pass `${prefix}/**` instead of `{ recursive: true }`. User-facing behavior (delete a directory recursively from the context panel) is unchanged, so no doc updates are needed.

## Verification
- `bun run lint` ✅ (tsc + biome clean)
- `bun test` ✅ 660 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)