### PR TITLE
Cache embedding model weights in CI to fix HuggingFace 429s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
+      # Cache the embedding model weights so the suite doesn't re-download them
+      # from HuggingFace every run. Without this, repeated CI traffic from
+      # GitHub's runner IP range trips HF's 429 rate limit and every
+      # embedder-touching test fails. Keyed on package.json so a membot bump
+      # (which owns the model name) busts the cache. MEMBOT_MODEL_CACHE_DIR
+      # redirects the tests' cache dir (see test/setup.ts) to this one shared,
+      # cached location.
+      - uses: actions/cache@v4
+        with:
+          path: ~/.membot/models
+          key: membot-models-${{ hashFiles('package.json') }}
       - run: bun install --frozen-lockfile
-      - run: bun test --timeout 30000
+      - name: bun test
+        run: |
+          export MEMBOT_MODEL_CACHE_DIR="$HOME/.membot/models"
+          mkdir -p "$MEMBOT_MODEL_CACHE_DIR"
+          bun test --timeout 30000
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   docs-build:
     runs-on: ubuntu-latest

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
         "ink-text-input": "^6.0.0",
         "istextorbinary": "^9.5.0",
         "jsonata": "^2.2.1",
-        "membot": "^0.19.0",
+        "membot": "^0.19.1",
         "nanospinner": "^1.2.2",
         "ollama-ai-provider-v2": "^3.5.1",
         "react": "^19.2.7",
@@ -829,7 +829,7 @@
 
     "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
 
-    "membot": ["membot@0.19.0", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.0", "@duckdb/node-api": "1.5.2-r.1", "@huggingface/transformers": "^4.2.0", "@modelcontextprotocol/sdk": "^1.29.0", "@types/picomatch": "^4.0.3", "@types/turndown": "^5.0.5", "ansis": "^4.2.0", "commander": "^14.0.3", "fast-xml-parser": "^5.7.3", "gray-matter": "^4.0.3", "jszip": "^3.10.1", "macos-ts": "^0.11.0", "mammoth": "^1.8.0", "nanospinner": "^1.2.2", "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c", "picomatch": "^4.0.4", "turndown": "^7.2.0", "unpdf": "^0.12.0", "xlsx": "^0.18.5", "zod": "^4.0.0", "zod-to-json-schema": "^3.23.0" }, "bin": { "membot": "src/cli.ts" } }, "sha512-inzwOeFZ9PIFyP9PkjyXerh1Dbn/4Bwrk0RFECK1TIg1qT2MGnkFMP8y20ybMyChaRLTJoXTBsh2q9TJNcHHVg=="],
+    "membot": ["membot@0.19.1", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.0", "@duckdb/node-api": "1.5.2-r.1", "@huggingface/transformers": "^4.2.0", "@modelcontextprotocol/sdk": "^1.29.0", "@types/picomatch": "^4.0.3", "@types/turndown": "^5.0.5", "ansis": "^4.2.0", "commander": "^14.0.3", "fast-xml-parser": "^5.7.3", "gray-matter": "^4.0.3", "jszip": "^3.10.1", "macos-ts": "^0.11.0", "mammoth": "^1.8.0", "nanospinner": "^1.2.2", "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c", "picomatch": "^4.0.4", "turndown": "^7.2.0", "unpdf": "^0.12.0", "xlsx": "^0.18.5", "zod": "^4.0.0", "zod-to-json-schema": "^3.23.0" }, "bin": { "membot": "src/cli.ts" } }, "sha512-G7OSsSJbaNwGPee+BuzSBbGYGqYnwUIFJRgNX4ry3ez1DrrlsGFT/UrWAOhijtqarSunPDAanl9lt6vgQ1m7yg=="],
 
     "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.24.3",
+  "version": "0.24.4",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {
@@ -41,7 +41,7 @@
     "ink-text-input": "^6.0.0",
     "istextorbinary": "^9.5.0",
     "jsonata": "^2.2.1",
-    "membot": "^0.19.0",
+    "membot": "^0.19.1",
     "nanospinner": "^1.2.2",
     "ollama-ai-provider-v2": "^3.5.1",
     "react": "^19.2.7",

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,5 +1,14 @@
-// No global test setup is needed now that the embedding pipeline lives in
-// membot and is warmed lazily per-test (via setupTestMembot in test/helpers.ts).
-// The previous setup pre-loaded a shared @huggingface/transformers cache;
-// that responsibility now belongs to membot's own test harness.
-export {};
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setEmbeddingCacheDir } from "membot";
+
+// Redirect transformers' model-weights cache so the suite reuses one copy of
+// the embedding model instead of re-downloading it. `MEMBOT_MODEL_CACHE_DIR`
+// (set in CI to an actions/cache-restored dir) overrides this default; locally
+// it's a throwaway dir. Weights are identical regardless of directory, so a
+// single global call here covers every test — the per-test temp dirs from
+// setupTestMembot only isolate the DuckDB store.
+//
+// Without this, every embedder-touching test fetches Xenova/bge-small-en-v1.5
+// from HuggingFace, and CI's shared runner IP trips HF's 429 rate limit.
+setEmbeddingCacheDir(join(tmpdir(), "botholomew-test-models"));


### PR DESCRIPTION
## Problem

CI has been red on `main` since the membot 0.19.0 bump (#266). The `test` job fails 6 `membot_query` tests — and the root cause hits every embedder-touching test:

```
error: Error (429) occurred while trying to load file:
"https://huggingface.co/Xenova/bge-small-en-v1.5/resolve/main/config.json".
```

Every test that writes to membot triggers an embedding, which downloads `Xenova/bge-small-en-v1.5` from HuggingFace. CI's shared runner IP range trips HF's **unauthenticated 429 rate limit**, so the download — and the test — fails. The tests are correct; the model fetch is the problem.

## Fix

Cache the model weights across CI runs so they're fetched at most once, mirroring [membot's own CI](https://github.com/evantahler/membot/blob/main/.github/workflows/ci.yml):

- **`ci.yml`** (`test` job): `actions/cache` on `~/.membot/models` (keyed on `package.json` so a membot bump busts it), `MEMBOT_MODEL_CACHE_DIR` redirecting the model cache there, and `GITHUB_TOKEN` passed through.
- **`test/setup.ts`**: the env var only takes effect when `setEmbeddingCacheDir()` is called. Botholomew's tests go through `MembotClient`, which never calls it, so the preload now calls it once. `MEMBOT_MODEL_CACHE_DIR` overrides the default; locally it's a throwaway tmpdir. Weights are dir-independent, so one global call covers every test (per-test temp dirs only isolate the DuckDB store).
- **`package.json`**: bump `membot` `^0.19.0` → `^0.19.1`. 0.19.1 newly exports `setEmbeddingCacheDir` from the SDK (evantahler/membot#90, closes evantahler/membot#89) — it wasn't reachable before (not in membot's `exports` map; Botholomew is barred from importing `@huggingface/transformers` directly). Also bumps Botholomew `version` → 0.24.4.

## Verification

- `bun run lint` ✓
- `bun test --timeout 30000` with `MEMBOT_MODEL_CACHE_DIR=$HOME/.membot/models`: **660 pass, 0 fail** (the 6 `membot_query` tests that were failing now pass).

First CI run after merge populates the cache (one HF fetch); subsequent runs restore it and make zero HF requests for weights.

🤖 Generated with [Claude Code](https://claude.com/claude-code)