### PR TITLE
Fix botholomew membot passthrough dropping commands and swallowing --version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.24.4",
+  "version": "0.24.5",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,6 +47,12 @@ program
   .description(ansis.bold(pkg.description))
   .version(pkg.version)
   .option("-d, --dir <path>", "project directory", process.cwd())
+  // Stop the root command from consuming options that appear *after* a
+  // subcommand (notably `--version`). Combined with `passThroughOptions()` on
+  // the `membot`/`mcpx` passthroughs, this lets those wrappers forward flags
+  // like `--version <timestamp>` to the upstream CLI verbatim instead of having
+  // the root version handler swallow them.
+  .enablePositionalOptions()
   .configureHelp({
     styleTitle: (str) => ansis.bold(str),
     styleUsage: (str) => ansis.cyan(str),

--- a/src/commands/membot.ts
+++ b/src/commands/membot.ts
@@ -4,7 +4,6 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Command } from "commander";
-import { defaultCliName, OPERATIONS } from "membot";
 import { loadConfig } from "../config/loader.ts";
 import { resolveMembotDir } from "../mem/client.ts";
 import { pkg as ourPkg } from "../pkg.ts";
@@ -156,36 +155,30 @@ function registerImportGlobal(parent: Command, program: Command): void {
 }
 
 export function registerMembotCommand(program: Command) {
+  // The `membot` group is a thin passthrough: every token after `membot`
+  // (subcommand, flags, and positional args) is forwarded verbatim to the
+  // upstream membot CLI, which owns the canonical schema. We do NOT enumerate
+  // membot's subcommands here — doing so (a) silently dropped membot's
+  // management commands that aren't agent Operations (`config`, `reindex`,
+  // `router`, `login`, `logs`, `check-update`, …) and (b) gave a misleading
+  // "too many arguments" error for them. `passThroughOptions()` (paired with
+  // `enablePositionalOptions()` on the root) keeps Commander from swallowing
+  // flags meant for membot — notably `--version <timestamp>`, which the root
+  // `--version` would otherwise intercept.
   const membot = program
     .command("membot")
     .description(
-      "Manage the project's knowledge store (passthrough to membot: add, search, ls, read, …)",
-    );
+      "Manage the project's knowledge store (passthrough to membot: add, search, ls, read, …). Run `botholomew membot <command> --help` for upstream command help.",
+    )
+    .allowUnknownOption(true)
+    .passThroughOptions()
+    .argument("[args...]", "arguments forwarded to membot")
+    .action(async () => {
+      const exitCode = await runMembot(getDir(program), getRawMembotArgs());
+      if (exitCode !== 0) process.exit(exitCode);
+    });
 
-  // Botholomew-specific helpers first so they show up before the membot
-  // passthrough subcommands in --help.
+  // Botholomew-specific helper. Registered as a real subcommand so it's matched
+  // before the passthrough action and shows up in `botholomew membot --help`.
   registerImportGlobal(membot, program);
-
-  // One Commander subcommand per membot Operation. We don't redeclare any
-  // flags — Commander hands the raw argv slice to membot, which owns the
-  // canonical schema.
-  for (const op of OPERATIONS) {
-    const name = defaultCliName(op);
-    membot
-      .command(name)
-      .description(op.description.split("\n")[0] ?? op.description)
-      .allowUnknownOption(true)
-      .helpOption(false)
-      .argument("[args...]", "arguments forwarded to membot")
-      .action(async () => {
-        const exitCode = await runMembot(getDir(program), getRawMembotArgs());
-        if (exitCode !== 0) process.exit(exitCode);
-      });
-  }
-
-  // `botholomew membot` (no subcommand) → membot's default action.
-  membot.action(async () => {
-    const exitCode = await runMembot(getDir(program), getRawMembotArgs());
-    if (exitCode !== 0) process.exit(exitCode);
-  });
 }

--- a/test/commands/membot.test.ts
+++ b/test/commands/membot.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+import { pkg } from "../../src/pkg.ts";
+
+const require = createRequire(import.meta.url);
+const membotVersion = require("membot/package.json").version as string;
+
+const TMP_DIR = join(import.meta.dir, ".tmp-membot-cmd-test");
+const CLI_PATH = join(import.meta.dir, "..", "..", "src", "cli.ts");
+
+// Force project-local membot for these tests — the default is "global", which
+// would point the passthrough at ~/.membot and pollute / leak real user state.
+beforeEach(async () => {
+  mkdirSync(join(TMP_DIR, "config"), { recursive: true });
+  await Bun.write(
+    join(TMP_DIR, "config", "config.json"),
+    JSON.stringify({ mcpx_scope: "project", membot_scope: "project" }),
+  );
+});
+
+afterEach(() => {
+  if (existsSync(TMP_DIR)) {
+    rmSync(TMP_DIR, { recursive: true });
+  }
+});
+
+async function runBotholomewCli(args: string[]): Promise<{
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}> {
+  const proc = Bun.spawn(["bun", CLI_PATH, "-d", TMP_DIR, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const exitCode = await proc.exited;
+  return { stdout, stderr, exitCode };
+}
+
+describe("membot CLI passthrough (end-to-end)", () => {
+  // Regression for the "passthrough only forwards membot Operations" bug: the
+  // wrapper enumerated one subcommand per membot Operation, so membot's
+  // management commands (config, reindex, router, …) fell through to the parent
+  // and errored with a misleading "too many arguments for 'membot'". They must
+  // now forward to upstream membot like any other subcommand.
+  test("forwards a management subcommand that is not an Operation (reindex)", async () => {
+    const result = await runBotholomewCli(["membot", "reindex"]);
+    expect(result.exitCode).toBe(0);
+    const combined = result.stdout + result.stderr;
+    expect(combined).not.toContain("too many arguments");
+    expect(combined).not.toContain("unknown command");
+  });
+
+  test("forwards `config get` (multi-token management subcommand)", async () => {
+    const result = await runBotholomewCli([
+      "membot",
+      "config",
+      "get",
+      "search.max_per_file",
+    ]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout + result.stderr).not.toContain("too many arguments");
+  });
+
+  // Regression for the "--version is swallowed by the root version option" bug.
+  // After enabling positional options + pass-through, `--version` reaches
+  // upstream membot (which prints its own version) instead of botholomew's root
+  // `--version` printing botholomew's package version.
+  test("forwards --version to upstream membot, not botholomew's root", async () => {
+    const result = await runBotholomewCli(["membot", "--version"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe(membotVersion);
+    expect(result.stdout.trim()).not.toBe(pkg.version);
+  });
+
+  // The botholomew-specific helper must stay a real Commander subcommand so it
+  // is matched before the pass-through action (and shows up in --help).
+  test("import-global remains a real subcommand", async () => {
+    const result = await runBotholomewCli([
+      "membot",
+      "import-global",
+      "--help",
+    ]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Copy system-wide membot data");
+  });
+});


### PR DESCRIPTION
The `botholomew membot` group registered one Commander subcommand per membot
Operation, so membot's management commands (config, reindex, router, login,
logs, check-update, …) were unreachable and errored with a misleading "too
many arguments for 'membot'" (#268). Separately, the root `--version` option
consumed `--version` anywhere in the args before it could be forwarded,
printing botholomew's version instead of reaching membot (#269).

Make the `membot` group a true passthrough: a single variadic command with
`allowUnknownOption` + `passThroughOptions`, paired with
`enablePositionalOptions()` on the root program so flags after the subcommand
(notably `--version`) flow through to upstream membot verbatim. `import-global`
stays a real subcommand (matched before the passthrough action). Drops the
per-Operation subcommand loop, which added no execution value (every variant
already forwarded the raw argv slice).

Adds end-to-end tests covering management-command forwarding, --version
forwarding, and the import-global subcommand.

https://claude.ai/code/session_01ALsGDzibXmYc8iNtUMPtGM