### PR TITLE
Upgrade membot to 0.19.4

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
         "ink-text-input": "^6.0.0",
         "istextorbinary": "^9.5.0",
         "jsonata": "^2.2.1",
-        "membot": "^0.19.1",
+        "membot": "^0.19.4",
         "nanospinner": "^1.2.2",
         "ollama-ai-provider-v2": "^3.5.1",
         "react": "^19.2.7",
@@ -829,7 +829,7 @@
 
     "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
 
-    "membot": ["membot@0.19.1", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.0", "@duckdb/node-api": "1.5.2-r.1", "@huggingface/transformers": "^4.2.0", "@modelcontextprotocol/sdk": "^1.29.0", "@types/picomatch": "^4.0.3", "@types/turndown": "^5.0.5", "ansis": "^4.2.0", "commander": "^14.0.3", "fast-xml-parser": "^5.7.3", "gray-matter": "^4.0.3", "jszip": "^3.10.1", "macos-ts": "^0.11.0", "mammoth": "^1.8.0", "nanospinner": "^1.2.2", "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c", "picomatch": "^4.0.4", "turndown": "^7.2.0", "unpdf": "^0.12.0", "xlsx": "^0.18.5", "zod": "^4.0.0", "zod-to-json-schema": "^3.23.0" }, "bin": { "membot": "src/cli.ts" } }, "sha512-G7OSsSJbaNwGPee+BuzSBbGYGqYnwUIFJRgNX4ry3ez1DrrlsGFT/UrWAOhijtqarSunPDAanl9lt6vgQ1m7yg=="],
+    "membot": ["membot@0.19.4", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.0", "@duckdb/node-api": "1.5.2-r.1", "@huggingface/transformers": "^4.2.0", "@modelcontextprotocol/sdk": "^1.29.0", "@types/picomatch": "^4.0.3", "@types/turndown": "^5.0.5", "ansis": "^4.2.0", "commander": "^14.0.3", "fast-xml-parser": "^5.7.3", "gray-matter": "^4.0.3", "jszip": "^3.10.1", "macos-ts": "^0.11.0", "mammoth": "^1.8.0", "nanospinner": "^1.2.2", "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c", "picomatch": "^4.0.4", "turndown": "^7.2.0", "unpdf": "^0.12.0", "xlsx": "^0.18.5", "zod": "^4.0.0", "zod-to-json-schema": "^3.23.0" }, "bin": { "membot": "src/cli.ts" } }, "sha512-mB/djPaur+S/AIx7dJqHuogxt4sWFhGnnbzdNP+EhyG9DQjO1K29WAXPU0hrx2zjYINf2Yn+Dl1l3/vhof95YA=="],
 
     "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.24.5",
+  "version": "0.24.6",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {
@@ -41,7 +41,7 @@
     "ink-text-input": "^6.0.0",
     "istextorbinary": "^9.5.0",
     "jsonata": "^2.2.1",
-    "membot": "^0.19.1",
+    "membot": "^0.19.4",
     "nanospinner": "^1.2.2",
     "ollama-ai-provider-v2": "^3.5.1",
     "react": "^19.2.7",


### PR DESCRIPTION
Upgrades the `membot` dependency from 0.19.1 to 0.19.4. These are patch-only releases: a `membot tree <prefix>` doubled-prefix fix, improved Apple Notes Full Disk Access error messaging, and a model-download progress bar — no SDK/client API changes, so no Botholomew code changes were needed. Bumped the botholomew version to 0.24.6 per the auto-release convention. Lint (tsc + biome) and the full test suite (664 pass) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)