### PR TITLE
Redraw the chat TUI on terminal resize

### DIFF
--- a/docs/tui.md
+++ b/docs/tui.md
@@ -475,6 +475,11 @@ A few choices worth knowing if you're reading or modifying the TUI:
   terminal scrollback once and never re-rendered — essential for
   performance in long sessions, and it means the chat history survives
   in your terminal buffer after you exit.
+- **Resize triggers a full redraw.** Ink's incremental renderer can leave
+  stale, overlapping frames after the window is resized, and it can't
+  reflow `<Static>` scrollback to the new width. On resize (debounced so a
+  click-drag doesn't thrash), `useResizeRedraw` clears the terminal and
+  remounts `<Static>` so the whole history re-flushes at the new size.
 - **Input handlers are ref-stable.** `InputBar` and `App` both install
   a single `useInput` handler wrapped in `useCallback` with
   `useRef`-backed state reads. A prior bug caused 100 % CPU under fast
@@ -502,9 +507,9 @@ A few choices worth knowing if you're reading or modifying the TUI:
   `botholomew worker list --status running`. If nothing is alive, start
   one with `botholomew worker start --persist` or have the chat agent
   call `spawn_worker`.
-- **Weird layout in tmux / split panes.** Ink needs a stable terminal
-  width; if the pane resizes mid-render, large tool-call boxes can
-  wrap oddly. A fresh `Ctrl+L` usually sorts it.
+- **Weird layout in tmux / split panes.** The TUI redraws itself when the
+  terminal resizes, but if a pane resizes *mid-render* large tool-call boxes
+  can still wrap oddly for a frame. A fresh `Ctrl+L` usually sorts it.
 - **`⌥+Enter` inserts the literal character `¬` or similar.** Your
   terminal is sending Option as Meta. Enable "Use Option as Meta key"
   in your terminal profile (Terminal.app, iTerm2, Ghostty all support

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.24.6",
+  "version": "0.24.7",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -24,10 +24,12 @@ import { useCaptureTabCycle } from "./hooks/useCaptureTabCycle.ts";
 import { useChatSession } from "./hooks/useChatSession.ts";
 import { useChatTitlePolling } from "./hooks/useChatTitlePolling.ts";
 import { useMessageQueue } from "./hooks/useMessageQueue.ts";
+import { useResizeRedraw } from "./hooks/useResizeRedraw.ts";
 import { useTerminalRows } from "./hooks/useTerminalRows.ts";
 import { IdleProvider, useIdle } from "./idle.tsx";
 import { FOOTER_RESERVE } from "./messages.ts";
 import { buildSlashCommands } from "./slashCompletion.ts";
+import { clearTerminal } from "./terminal.ts";
 
 interface AppProps {
   projectDir: string;
@@ -88,6 +90,14 @@ function AppInner({
 
   const markActivityRef = useRef(markActivity);
   markActivityRef.current = markActivity;
+
+  // Redraw everything on terminal resize. Ink's incremental renderer leaves
+  // stale/duplicate frames after a resize and can't reflow <Static> scrollback,
+  // so wipe the terminal and bump the epoch to re-flush history at the new size.
+  useResizeRedraw(() => {
+    clearTerminal();
+    setMessagesEpoch((n) => n + 1);
+  });
 
   const { sessionRef, ready, splashDone, performShutdown } = useChatSession({
     projectDir,

--- a/src/tui/handleSubmit.ts
+++ b/src/tui/handleSubmit.ts
@@ -14,6 +14,7 @@ import { handleSlashCommand } from "../skills/commands.ts";
 import type { ChatMessage } from "./components/MessageList.tsx";
 import type { QueueEntry } from "./hooks/useMessageQueue.ts";
 import { msgId } from "./messages.ts";
+import { clearTerminal } from "./terminal.ts";
 
 interface UseChatSubmitParams {
   sessionRef: MutableRefObject<ChatSession | null>;
@@ -147,7 +148,7 @@ export function useChatSubmit({
                 // can't un-write them, so setMessages alone leaves the old
                 // lines visible. Clear the terminal (including scrollback)
                 // and bump the epoch key on <Static> to force a fresh mount.
-                process.stdout.write("\x1b[2J\x1b[3J\x1b[H");
+                clearTerminal();
                 setMessages([
                   {
                     id: msgId(),

--- a/src/tui/hooks/useResizeRedraw.ts
+++ b/src/tui/hooks/useResizeRedraw.ts
@@ -1,0 +1,82 @@
+import { useStdout } from "ink";
+import { useEffect } from "react";
+import { useLatestRef } from "../useLatestRef.ts";
+
+interface ResizeRedrawController {
+  /** Feed the current terminal dimensions; schedules a debounced redraw when
+   *  a dimension actually changed since the last call. */
+  onResize(cols: number, rows: number): void;
+  /** Cancel any pending redraw timer. */
+  dispose(): void;
+}
+
+interface ResizeRedrawOptions {
+  debounceMs?: number;
+}
+
+/**
+ * Test-friendly (no-React) core of {@link useResizeRedraw}: remembers the last
+ * seen `{cols, rows}` and, when either changes, schedules a single *trailing*
+ * debounced `redraw()`. Rapid resize events (a click-drag) coalesce into one
+ * redraw once the drag settles. Mirrors the controller/hook split used by
+ * `createDeleteConfirmController`.
+ */
+export function createResizeRedrawController(
+  redraw: () => void,
+  { debounceMs = 80 }: ResizeRedrawOptions = {},
+): ResizeRedrawController {
+  let lastCols: number | null = null;
+  let lastRows: number | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  return {
+    onResize(cols, rows) {
+      // First observation just records the baseline — nothing to redraw yet.
+      if (lastCols === null || lastRows === null) {
+        lastCols = cols;
+        lastRows = rows;
+        return;
+      }
+      if (cols === lastCols && rows === lastRows) return;
+      lastCols = cols;
+      lastRows = rows;
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        timer = null;
+        redraw();
+      }, debounceMs);
+    },
+    dispose() {
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    },
+  };
+}
+
+/**
+ * Redraw the whole TUI when the terminal is resized. Ink's incremental renderer
+ * miscounts wrapped/scrolled lines on resize (leaving stale duplicate frames),
+ * and it can't un-write `<Static>` scrollback, so the only reliable fix is to
+ * wipe the terminal and re-flush. `redraw` should clear the terminal and bump
+ * the `<Static>` epoch key. The debounce guarantees this runs after the size
+ * hooks have committed the new layout, so the reflush uses the new dimensions.
+ */
+export function useResizeRedraw(redraw: () => void): void {
+  const { stdout } = useStdout();
+  const redrawRef = useLatestRef(redraw);
+  useEffect(() => {
+    if (!stdout) return;
+    const controller = createResizeRedrawController(() => redrawRef.current());
+    const onResize = () =>
+      controller.onResize(stdout.columns ?? 80, stdout.rows ?? 24);
+    // Seed the baseline so the first real resize is detected as a change.
+    onResize();
+    stdout.on("resize", onResize);
+    return () => {
+      stdout.off("resize", onResize);
+      controller.dispose();
+    };
+  }, [stdout, redrawRef]);
+}

--- a/src/tui/terminal.ts
+++ b/src/tui/terminal.ts
@@ -1,0 +1,12 @@
+// Full-clear escape sequence: erase screen (2J), erase scrollback (3J), and
+// move the cursor home (H). Used to force a clean redraw of the whole terminal
+// — Ink's incremental renderer can't un-write <Static> scrollback, so we wipe
+// everything and let a <Static> remount re-flush the history at the current
+// width. Shared by /clear and the resize redraw.
+export const CLEAR_TERMINAL = "\x1b[2J\x1b[3J\x1b[H";
+
+export function clearTerminal(
+  stdout: NodeJS.WriteStream = process.stdout,
+): void {
+  if (stdout.isTTY) stdout.write(CLEAR_TERMINAL);
+}

--- a/test/tui/useResizeRedraw.test.ts
+++ b/test/tui/useResizeRedraw.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import { createResizeRedrawController } from "../../src/tui/hooks/useResizeRedraw.ts";
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("createResizeRedrawController", () => {
+  test("first onResize only records the baseline (no redraw)", async () => {
+    let redraws = 0;
+    const c = createResizeRedrawController(() => redraws++, { debounceMs: 20 });
+    c.onResize(80, 24);
+    await wait(40);
+    expect(redraws).toBe(0);
+    c.dispose();
+  });
+
+  test("no redraw when dimensions are unchanged", async () => {
+    let redraws = 0;
+    const c = createResizeRedrawController(() => redraws++, { debounceMs: 20 });
+    c.onResize(80, 24);
+    c.onResize(80, 24);
+    c.onResize(80, 24);
+    await wait(40);
+    expect(redraws).toBe(0);
+    c.dispose();
+  });
+
+  test("fires a single trailing redraw after debounce for a real change", async () => {
+    let redraws = 0;
+    const c = createResizeRedrawController(() => redraws++, { debounceMs: 20 });
+    c.onResize(80, 24); // baseline
+    c.onResize(60, 24); // width shrink
+    expect(redraws).toBe(0); // debounced, not yet fired
+    await wait(40);
+    expect(redraws).toBe(1);
+    c.dispose();
+  });
+
+  test("detects a rows-only change", async () => {
+    let redraws = 0;
+    const c = createResizeRedrawController(() => redraws++, { debounceMs: 20 });
+    c.onResize(80, 24); // baseline
+    c.onResize(80, 12); // rows shrink
+    await wait(40);
+    expect(redraws).toBe(1);
+    c.dispose();
+  });
+
+  test("rapid successive resizes coalesce into one redraw", async () => {
+    let redraws = 0;
+    const c = createResizeRedrawController(() => redraws++, { debounceMs: 20 });
+    c.onResize(80, 24); // baseline
+    c.onResize(70, 24);
+    c.onResize(60, 22);
+    c.onResize(50, 20);
+    await wait(40);
+    expect(redraws).toBe(1);
+    c.dispose();
+  });
+
+  test("dispose cancels a pending redraw", async () => {
+    let redraws = 0;
+    const c = createResizeRedrawController(() => redraws++, { debounceMs: 20 });
+    c.onResize(80, 24); // baseline
+    c.onResize(60, 24); // schedules redraw
+    c.dispose();
+    await wait(40);
+    expect(redraws).toBe(0);
+  });
+});


### PR DESCRIPTION
Resizing the `botholomew chat` window left the layout corrupted — the StatusBar, InputBar, and TabBar rendered multiple times with broken, overlapping borders. The cause is Ink 7's incremental renderer, which erases the previous frame by logical line count (miscounting wrapped/scrolled lines on resize) and can't reflow the completed message history that `<Static>` writes once to scrollback. On resize we now debounce briefly, then clear the terminal and bump the `<Static>` epoch key so the whole history re-flushes at the new width — the same wipe-and-remount pattern `/clear` already uses (extracted into a shared `clearTerminal()` helper). The redraw logic lives in a new `useResizeRedraw` hook with a testable `createResizeRedrawController` core (6 unit tests). Docs (`docs/tui.md`) and the version bump are included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)