### PR TITLE
Add founder framing and field notes to README + docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@
 
 ![Botholomew chat TUI](docs/assets/chat-happy-path.gif)
 
-**An AI agent for knowledge work.** Botholomew is an autonomous agent
-that works its way through a task queue — reading email, summarizing
-documents, researching topics, organizing notes, and maintaining context
-over time — while you sleep, work, or chat with it.
+**An AI agent for knowledge work.** Point Botholomew at your docs,
+projects, and inboxes and it reads them, remembers them, and works a
+durable task queue — summarizing, researching, organizing, chasing
+things down — while you sleep, work, or chat with it. It runs locally
+(local LLMs included), and it's built around a large memory store rather
+than a single chat window.
 
 Botholomew has **no shell and no access to your real filesystem**. The
 agent's world is a per-project knowledge store managed by
@@ -26,8 +28,39 @@ through MCP servers wired up via
 
 ---
 
+## Why I built this
+
+I built the agent I wanted for my own manager-style work — the reading,
+summarizing, chasing-down, and _remembering_ that fills a week. Nothing
+on the shelf fit, so Botholomew is opinionated on purpose:
+
+- **Memory is the point, not a feature.** I load it up with every Linear
+  project and hundreds of Google Docs and expect it to search across all
+  of them. The knowledge store isn't bolted on — the whole agent is built
+  around it.
+- **Local, including local LLMs.** It runs on my machine and talks to
+  Ollama just as happily as it talks to Anthropic.
+- **Real tasks, not a swarm.** Durable, schedulable, monitorable tasks
+  with DAGs — not fire-and-forget subagents. (My distributed-systems
+  background wouldn't let me ship anything less.)
+- **Hyper-focused on tool use.** Its reach into the outside world runs
+  through an [Arcade](https://www.arcade.dev/) gateway — one
+  authenticated door to hundreds of services, which is where most of the
+  interesting work actually happens.
+
+It's also nerdy by design: every prompt, task, thread, and belief is a
+plain file I can open, `grep`, and `git diff`. — Evan
+
+---
+
 ## Why Botholomew?
 
+- **Memory-first.** The agent is built to reason over a large corpus, not
+  a single chat. Ingest hundreds of files and URLs (PDF/DOCX/HTML →
+  markdown) into a local [`membot`](https://github.com/evantahler/membot)
+  store with hybrid BM25 + semantic search, append-only versioning, and
+  history you can `diff`. Big tool responses get piped into the same store
+  so the agent can work through megabytes of JSON without burning tokens.
 - **Autonomous.** Background **workers** claim tasks, work them with Claude,
   and log every interaction. You can spawn one-shot workers on demand, a
   long-running `--persist` worker, or point cron at `botholomew worker run`.
@@ -41,13 +74,13 @@ through MCP servers wired up via
   versioned, queryable with the DuckDB CLI if you ever want to. Model
   calls go direct to Anthropic; any further reach is scoped to the MCP
   servers you add.
-- **Extensible.** External tools come from MCP servers via
-  [MCPX](https://github.com/evantahler/mcpx) — run them locally (Gmail,
-  Slack, GitHub) or connect through an MCP gateway like
-  [Arcade.dev](https://www.arcade.dev/) to reach hundreds of
-  authenticated services without managing each server yourself.
-  Reusable workflows are defined as markdown "skills" (slash commands)
-  that the chat agent can also create, edit, and search at runtime.
+- **Tool use, done through a gateway.** External tools come from MCP
+  servers via [MCPX](https://github.com/evantahler/mcpx). Run them locally
+  (Gmail, Slack, GitHub) — but the setup Botholomew is tuned for points a
+  single [Arcade](https://www.arcade.dev/) gateway at hundreds of
+  authenticated services, so you handle auth once instead of babysitting a
+  server per tool. Reusable workflows are markdown "skills" (slash
+  commands) the chat agent can also create, edit, and search at runtime.
 - **Safe by default.** The agent has no shell and no direct filesystem
   access. The knowledge store is keyed by `logical_path` (an opaque DB
   string, not a filesystem path); every external capability is an MCP
@@ -330,6 +363,9 @@ Topics worth understanding in detail:
   and its default.
 - **[Doc captures](docs/captures.md)** — how the screenshots and GIFs in
   these docs are regenerated programmatically via VHS and a fake-LLM mode.
+- **[Field notes](docs/field-notes.md)** — what I learned building this:
+  why tools are named after bash, why big tool responses go into memory,
+  and the one agent trend I think is overrated.
 
 ---
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -36,6 +36,7 @@ For example: \`/architecture.md\`, \`/configuration.md\`
 - Skills: /skills.md
 - Tools: /tools.md
 - MCPX integration: /mcpx.md
+- Field notes: /field-notes.md
 - Doc captures: /captures.md
 - Owl character sheet: /owl-character-sheet.md
 - Changelog: /changelog.md
@@ -204,6 +205,7 @@ export default defineConfig({
       {
         text: "Reference",
         items: [
+          { text: "Field notes", link: "/field-notes" },
           { text: "Doc captures", link: "/captures" },
           { text: "Owl character sheet", link: "/owl-character-sheet" },
           { text: "Changelog", link: "/changelog" },

--- a/docs/field-notes.md
+++ b/docs/field-notes.md
@@ -1,0 +1,66 @@
+# Field notes
+
+Botholomew started as a tool I built for myself, and building it taught
+me a handful of things I didn't expect. Here they are — including the one
+that didn't work.
+
+## Workers and a real task system
+
+I have a distributed-systems background, and I couldn't bring myself to
+build "agents" as a pile of subagents that fan out and vanish. I took
+some inspiration from OpenClaw — keep the agent alive, give it a
+heartbeat — but I wanted a task system I could actually monitor. Durable tasks on disk, a queue, workers that
+register and get reaped when they die, DAGs between tasks. The payoff I
+didn't plan for: watching the agent spin up its own workers when it
+decides it has parallel work to do. That one still delights me.
+
+## Name your tools after bash
+
+Once [`membot`](https://github.com/evantahler/membot) gave the agent an
+address space that looks like a filesystem, I started naming its tools
+after commands it already knows — `cat`, `ls`, `mv`, `grep`. Every such
+tool description is prefixed with a machine-parseable tag,
+`[[ bash equivalent command: <cmd> ]]`, ahead of the real description.
+The effect was bigger than I expected. Correct tool use by Claude jumped
+the moment I did this — the model has seen an enormous amount of bash, so
+meet it where it already lives.
+
+## Big content is the normal case
+
+A lot of what comes back from a tool is huge. One of my test cases pulls
+a few megabytes of JSON out of Huckleberry — baby-tracking data, because
+I have a toddler and apparently now so does my agent. Stuffing that into
+the context window is a great way to light money on fire. So large tool
+responses get piped straight into the membot store, and the agent gets a
+jq-style query tool (JSONata under the hood) to slice it down to just the
+part it needs. It works through megabytes without ever holding them all
+in context at once.
+
+## TUIs are hard, and worth it
+
+I spent way too long making the chat TUI feel responsive and obvious —
+Ink and React in a terminal, redrawing on resize, a message queue,
+streaming output, tool-call visualization. Far more than a "reasonable"
+share of the total effort. I don't regret a minute of it. If something
+feels off, [tell me](https://github.com/evantahler/botholomew/issues).
+
+## Keep the chat history in context
+
+Every chat thread lands in the knowledge store when it's done, which
+means the agent can search its own past conversations later. `thread
+search` turns "what did we decide about that last week?" into a real
+query. Handy, and nearly free to build once the threads are already on
+disk as CSVs.
+
+## Some agent trends are overrated
+
+I implemented "dreaming" — the knowledge-rollup loop where the agent
+reflects on recent threads and consolidates what it learned. Fashionable
+idea. In my implementation, at least, it mostly disappoints: it fixates
+on _themes_ rather than facts, and themes aren't much use when I already
+have the agent's prompts and beliefs sitting right there in plain files I
+can read. I shipped it anyway (`/dream` and `botholomew dream`) because
+it's occasionally useful and trivial to turn off. But I'd be lying if I
+called it the best part.
+
+Facts beat vibes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: Botholomew
   text: An AI agent for knowledge work.
-  tagline: An autonomous agent that works your task queue — reading email, summarizing documents, researching topics, organizing notes, and maintaining context over time — while you sleep, work, or chat with it.
+  tagline: Point it at your docs, projects, and inboxes and it reads them, remembers them, and works a durable task queue — summarizing, researching, organizing — while you sleep, work, or chat with it. Local, including local LLMs, and built around a large memory store rather than a single chat window.
   actions:
     - theme: brand
       text: Get started
@@ -14,14 +14,16 @@ hero:
       link: https://github.com/evantahler/botholomew
 
 features:
+  - title: Memory-first
+    details: Built to reason over a large corpus, not a single chat. Ingest hundreds of files and URLs (PDF/DOCX/HTML → markdown) into a local [membot](https://github.com/evantahler/membot) store with hybrid BM25 + semantic search, append-only versioning, and history you can `diff`. Big tool responses pipe into the same store, so the agent works through megabytes of JSON without burning tokens.
   - title: Autonomous
     details: Background workers claim tasks, work them with Claude, and log every interaction. Spawn one-shot workers, a long-running --persist worker, or point cron at `botholomew worker run`.
   - title: Portable
     details: A project is a directory of files — markdown for prompts, tasks, and schedules; CSVs for conversation history. Copy it, share it, `git diff` it, check it in, or `.gitignore` it.
   - title: Your data, your disk
     details: Tasks, schedules, threads, prompts, and skills are all real files you can `vim`, `grep`, and `git`. The knowledge store is a single local DuckDB file managed by [membot](https://github.com/evantahler/membot) — append-only, versioned, queryable.
-  - title: Extensible
-    details: External tools come from MCP servers via MCPX — run them locally (Gmail, Slack, GitHub) or connect through a gateway like Arcade.dev to reach hundreds of authenticated services.
+  - title: Tool use through a gateway
+    details: External tools come from MCP servers via MCPX. Run them locally (Gmail, Slack, GitHub) — but the setup Botholomew is tuned for points a single [Arcade](https://www.arcade.dev/) gateway at hundreds of authenticated services, so you handle auth once instead of babysitting a server per tool.
   - title: Safe by default
     details: The agent has no shell and no direct filesystem access. The knowledge store is addressed by `logical_path` (a DB key, not a filesystem path); the remaining file-system paths the agent touches (tasks, schedules, prompts, skills) all route through one sandbox helper (NFC normalization + lstat-walk to reject symlinks).
   - title: Concurrent
@@ -35,6 +37,32 @@ features:
 ![Botholomew chat TUI tour](/full-tour.gif)
 
 </div>
+
+## Why I built this
+
+I built the agent I wanted for my own manager-style work — the reading,
+summarizing, chasing-down, and _remembering_ that fills a week. Nothing
+on the shelf fit, so Botholomew is opinionated on purpose:
+
+- **Memory is the point, not a feature.** I load it up with every Linear
+  project and hundreds of Google Docs and expect it to search across all
+  of them. The knowledge store isn't bolted on — the whole agent is built
+  around it.
+- **Local, including local LLMs.** It runs on my machine and talks to
+  Ollama just as happily as it talks to Anthropic.
+- **Real tasks, not a swarm.** Durable, schedulable, monitorable tasks
+  with DAGs — not fire-and-forget subagents. (My distributed-systems
+  background wouldn't let me ship anything less.)
+- **Hyper-focused on tool use.** Its reach into the outside world runs
+  through an [Arcade](https://www.arcade.dev/) gateway — one authenticated
+  door to hundreds of services, which is where most of the interesting
+  work actually happens.
+
+It's also nerdy by design: every prompt, task, thread, and belief is a
+plain file I can open, `grep`, and `git diff`. — Evan
+
+For the honest version — including what I got wrong — see the
+[field notes](/field-notes).
 
 ## Why Botholomew?
 


### PR DESCRIPTION
Reworks the README intro and landing hero to lead with the memory-first, manager-work framing, and adds a first-person "Why I built this" note to both. Adds a Memory-first pillar/card and elevates Arcade as first-class tool-use positioning (renaming the old *Extensible* pillar). Adds a candid `docs/field-notes.md` capturing six build lessons — bash-equivalent tool naming, piping large content into memory, workers/heartbeat, TUIs, chat→knowledge, and an honest take on why "dreaming" is overrated — wired into the VitePress sidebar and the README Deep dives. Docs-only change, so no `package.json` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)