### PR TITLE
Fix chat TUI freezing during large LLM streams

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.24.7",
+  "version": "0.24.8",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/chat/agent.ts
+++ b/src/chat/agent.ts
@@ -167,7 +167,10 @@ export interface ToolEndMeta {
 }
 
 export interface ChatTurnCallbacks {
-  onToken: (text: string) => void;
+  // May return a promise; the stream loop awaits it. Consumers that render
+  // (the TUI) use this to yield a macrotask on flush frames so Ink's
+  // timer-throttled paint can run mid-stream instead of only after the burst.
+  onToken: (text: string) => void | Promise<void>;
   onToolPreparing?: (id: string, name: string) => void;
   onToolStart: (id: string, name: string, input: string) => void;
   onToolEnd: (
@@ -323,7 +326,7 @@ async function runChatTurnBody(input: {
         switch (part.type) {
           case "text-delta":
             assistantText += part.text;
-            callbacks.onToken(part.text);
+            await callbacks.onToken(part.text);
             break;
           case "tool-input-start":
             earlyReportedToolIds.add(part.id);

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -299,6 +299,7 @@ function AppInner({
           activeToolCalls={activeToolCalls}
           preparingTool={preparingTool}
           streamStartedAt={streamStartedAt}
+          maxLines={panelHeight}
         />
       </Box>
 

--- a/src/tui/components/MessageList.tsx
+++ b/src/tui/components/MessageList.tsx
@@ -1,7 +1,7 @@
 import { Box, Text, useStdout } from "ink";
 import Spinner from "ink-spinner";
 import { memo, useMemo } from "react";
-import { renderMarkdown } from "../markdown.ts";
+import { renderMarkdown, tailLines } from "../markdown.ts";
 import { theme } from "../theme.ts";
 import { ToolCall, type ToolCallData } from "./ToolCall.tsx";
 
@@ -21,6 +21,9 @@ interface MessageListProps {
   /** Timestamp the current streaming bubble started. Stable across token flushes
    * so the displayed time doesn't flicker on every re-render. */
   streamStartedAt: Date | null;
+  /** Visible height of the chat area (lines). The streaming preview only
+   * renders this many trailing lines, since the box clips the rest. */
+  maxLines: number;
 }
 
 function formatTime(date: Date): string {
@@ -149,10 +152,18 @@ const ActiveToolsBox = memo(function ActiveToolsBox({
 
 const StreamingMarkdown = memo(function StreamingMarkdown({
   text,
+  maxLines,
 }: {
   text: string;
+  maxLines: number;
 }) {
-  const rendered = useMemo(() => renderMarkdown(text), [text]);
+  // Only the last ~viewport lines are visible (the chat box clips the top),
+  // so render just the tail — this keeps per-frame cost flat instead of
+  // growing with the reply length. The finalized bubble renders full markdown.
+  const rendered = useMemo(
+    () => renderMarkdown(tailLines(text, maxLines)),
+    [text, maxLines],
+  );
   return (
     <Box marginLeft={1}>
       <Text>{rendered}</Text>
@@ -166,6 +177,7 @@ export function MessageList({
   activeToolCalls,
   preparingTool,
   streamStartedAt,
+  maxLines,
 }: MessageListProps) {
   return (
     <>
@@ -179,7 +191,9 @@ export function MessageList({
             <Text dimColor> {formatTime(streamStartedAt ?? new Date())}</Text>
           </Box>
           <ActiveToolsBox toolCalls={activeToolCalls} />
-          {streamingText && <StreamingMarkdown text={streamingText} />}
+          {streamingText && (
+            <StreamingMarkdown text={streamingText} maxLines={maxLines} />
+          )}
         </Box>
       )}
 

--- a/src/tui/hooks/useMessageQueue.ts
+++ b/src/tui/hooks/useMessageQueue.ts
@@ -136,6 +136,11 @@ export function useMessageQueue({
               setStreamingText(currentText);
               lastStreamFlush = now;
               markActivityRef.current();
+              // Yield a macrotask so Ink's timer-throttled render can paint
+              // this frame. Without it, a burst of deltas drains as microtasks
+              // and the terminal only repaints once the whole burst ends —
+              // the reply looks frozen, then dumps in all at once.
+              return new Promise<void>((resolve) => setTimeout(resolve, 0));
             }
           },
           onToolPreparing: (id, name) => {

--- a/src/tui/markdown.ts
+++ b/src/tui/markdown.ts
@@ -49,3 +49,19 @@ export function renderMarkdown(text: string, width?: number): string {
 export function isMarkdownPath(path: string): boolean {
   return path.toLowerCase().endsWith(".md");
 }
+
+/**
+ * Return the last `maxLines` source lines of `text` (rejoined with `\n`).
+ * Used to bound the cost of rendering the in-flight streaming reply: the chat
+ * view only shows the last ~viewport lines, so re-parsing the entire growing
+ * buffer every frame is wasted work whose cost grows with the reply length.
+ * A block (code fence, table) that opens above the window may be briefly
+ * mis-styled in the live preview, but the finalized message re-renders the
+ * full, correct markdown. Non-positive `maxLines` returns the text unchanged.
+ */
+export function tailLines(text: string, maxLines: number): string {
+  if (maxLines <= 0) return text;
+  const lines = text.split("\n");
+  if (lines.length <= maxLines) return text;
+  return lines.slice(lines.length - maxLines).join("\n");
+}

--- a/test/chat/agent.test.ts
+++ b/test/chat/agent.test.ts
@@ -1,9 +1,18 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { buildChatSystemPrompt, getChatTools } from "../../src/chat/agent.ts";
+import {
+  buildChatSystemPrompt,
+  getChatTools,
+  runChatTurn,
+} from "../../src/chat/agent.ts";
+import { DEFAULT_CONFIG } from "../../src/config/schemas.ts";
 import { getPromptsDir } from "../../src/constants.ts";
+import { createFakeLanguageModel } from "../../src/llm/fake.ts";
+import { sharedWithMem } from "../../src/mem/client.ts";
+import { createThread } from "../../src/threads/store.ts";
+import { setupTestMembot } from "../helpers.ts";
 
 let projectDir: string;
 
@@ -30,5 +39,71 @@ describe("chat agent tooling", () => {
     expect(prompt).toContain("## Large JSON results");
     expect(prompt).toContain("membot_pipe");
     expect(prompt).toContain("membot_query");
+  });
+});
+
+describe("runChatTurn streaming", () => {
+  let mem: Awaited<ReturnType<typeof setupTestMembot>>["mem"];
+  let dir: string;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ mem, projectDir: dir, cleanup } = await setupTestMembot());
+    await mkdir(getPromptsDir(dir), { recursive: true });
+  });
+
+  afterEach(async () => {
+    delete process.env.BOTHOLOMEW_FAKE_LLM_FIXTURE;
+    await cleanup();
+  });
+
+  test("awaits a promise-returning onToken before processing the next delta", async () => {
+    // Fixture emits three text deltas and stops (no tool calls → single turn).
+    const fixture = join(dir, "fixture.json");
+    await writeFile(
+      fixture,
+      JSON.stringify({ turns: [{ chunks: ["a", "b", "c"], delayMs: 0 }] }),
+    );
+    process.env.BOTHOLOMEW_FAKE_LLM_FIXTURE = fixture;
+
+    const threadId = await createThread(dir, "chat_session", undefined, "t");
+
+    // Each onToken records the token synchronously, then resolves on a
+    // macrotask. If the stream loop awaits the returned promise, tokens and
+    // their resolutions strictly interleave (a, resolved:a, b, ...). If it
+    // does NOT await, all tokens arrive before any resolution.
+    const order: string[] = [];
+    await runChatTurn({
+      messages: [{ role: "user", content: "hi" }],
+      projectDir: dir,
+      config: { ...DEFAULT_CONFIG, max_turns: 1 },
+      threadId,
+      mcpxClient: null,
+      _testModel: createFakeLanguageModel(),
+      _testMaxInputTokens: 100_000,
+      _testWithMem: sharedWithMem(mem),
+      callbacks: {
+        onToken: (token) => {
+          order.push(token);
+          return new Promise<void>((resolve) => {
+            setTimeout(() => {
+              order.push(`resolved:${token}`);
+              resolve();
+            }, 0);
+          });
+        },
+        onToolStart: () => {},
+        onToolEnd: () => {},
+      },
+    });
+
+    expect(order).toEqual([
+      "a",
+      "resolved:a",
+      "b",
+      "resolved:b",
+      "c",
+      "resolved:c",
+    ]);
   });
 });

--- a/test/tui/markdown.test.ts
+++ b/test/tui/markdown.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { isMarkdownPath, renderMarkdown } from "../../src/tui/markdown.ts";
+import {
+  isMarkdownPath,
+  renderMarkdown,
+  tailLines,
+} from "../../src/tui/markdown.ts";
 
 describe("isMarkdownPath", () => {
   test("matches .md path", () => {
@@ -51,5 +55,32 @@ describe("renderMarkdown", () => {
     // natural width with no ellipsis.
     expect(out).not.toContain("…");
     expect(out).toContain("│");
+  });
+});
+
+describe("tailLines", () => {
+  test("returns the last N lines when text exceeds the limit", () => {
+    const text = "a\nb\nc\nd\ne";
+    expect(tailLines(text, 2)).toBe("d\ne");
+  });
+
+  test("returns the full text unchanged when line count <= limit", () => {
+    const text = "a\nb\nc";
+    expect(tailLines(text, 3)).toBe(text);
+    expect(tailLines(text, 10)).toBe(text);
+  });
+
+  test("handles empty string", () => {
+    expect(tailLines("", 5)).toBe("");
+  });
+
+  test("returns the text unchanged for non-positive limits", () => {
+    const text = "a\nb\nc";
+    expect(tailLines(text, 0)).toBe(text);
+    expect(tailLines(text, -3)).toBe(text);
+  });
+
+  test("keeps a single-line string intact", () => {
+    expect(tailLines("just one line", 2)).toBe("just one line");
   });
 });


### PR DESCRIPTION
The chat TUI stopped repainting while a large token stream arrived, then dumped the whole reply at once, because the stream loop called `onToken` synchronously — a burst of deltas drained as microtasks so Ink's timer-throttled paint never fired until the burst ended — and every flush re-rendered markdown over the entire growing buffer. `onToken` may now return a promise the loop awaits, and the TUI returns a next-macrotask yield on its ~50ms flush frames so Ink paints continuously (~20fps) throughout the stream. Additionally, only the visible tail (last `panelHeight` lines, via a new `tailLines` helper) is markdown-rendered during streaming, keeping per-frame cost flat instead of growing with reply length; the finalized message still renders full, correct markdown. Adds unit tests for `tailLines` and for the loop awaiting a promise-returning `onToken`, and bumps the version to 0.24.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)