### PR TITLE
Fix `upgrade` to always check for the latest release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.24.8",
+  "version": "0.24.9",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -4,18 +4,45 @@ import { dim, green, red, yellow } from "ansis";
 import { $ } from "bun";
 import type { Command } from "commander";
 import { pkg } from "../pkg.ts";
-import {
-  clearUpdateCache,
-  loadUpdateCache,
-  saveUpdateCache,
-} from "../update/cache.ts";
-import type { UpdateCache } from "../update/checker.ts";
+import { clearUpdateCache, saveUpdateCache } from "../update/cache.ts";
 import {
   checkForUpdate,
   detectInstallMethod,
   type InstallMethod,
-  needsCheck,
 } from "../update/checker.ts";
+
+export interface UpgradeTarget {
+  latestVersion: string;
+  hasUpdate: boolean;
+  changelog?: string;
+}
+
+/**
+ * Resolve the upgrade target by always performing a fresh update check.
+ *
+ * An explicit `upgrade` must never trust a possibly-stale cache: the startup
+ * background check may have run <24h ago and seen no update, while a new
+ * release shipped since. We always re-check here, then refresh the cache so
+ * the background notice benefits. `check` and `save` are injectable for tests.
+ */
+export async function resolveUpgradeTarget(
+  currentVersion: string,
+  check: typeof checkForUpdate = checkForUpdate,
+  save: typeof saveUpdateCache = saveUpdateCache,
+): Promise<UpgradeTarget> {
+  const info = await check(currentVersion);
+  await save({
+    lastCheckAt: new Date().toISOString(),
+    latestVersion: info.latestVersion,
+    hasUpdate: info.hasUpdate,
+    changelog: info.changelog,
+  });
+  return {
+    latestVersion: info.latestVersion,
+    hasUpdate: info.hasUpdate,
+    changelog: info.changelog,
+  };
+}
 
 const GITHUB_REPO = (pkg.repository.url as string)
   .replace(/^https:\/\/github\.com\//, "")
@@ -96,27 +123,10 @@ export function registerUpgradeCommand(program: Command) {
     .description("Upgrade botholomew to the latest version")
     .action(async () => {
       try {
-        // Check for update (use cache if fresh)
-        const cache = await loadUpdateCache();
-        let latestVersion: string;
-        let hasUpdate: boolean;
-
-        if (!needsCheck(cache) && cache) {
-          latestVersion = cache.latestVersion;
-          hasUpdate = cache.hasUpdate;
-        } else {
-          const info = await checkForUpdate(pkg.version);
-          latestVersion = info.latestVersion;
-          hasUpdate = info.hasUpdate;
-
-          const newCache: UpdateCache = {
-            lastCheckAt: new Date().toISOString(),
-            latestVersion,
-            hasUpdate,
-            changelog: info.changelog,
-          };
-          await saveUpdateCache(newCache);
-        }
+        // Always perform a fresh check — never trust a possibly-stale cache.
+        const { latestVersion, hasUpdate } = await resolveUpgradeTarget(
+          pkg.version,
+        );
 
         if (!hasUpdate) {
           console.log(

--- a/test/commands/upgrade.test.ts
+++ b/test/commands/upgrade.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { resolveUpgradeTarget } from "../../src/commands/upgrade.ts";
+import type { UpdateCache, UpdateInfo } from "../../src/update/checker.ts";
+
+describe("resolveUpgradeTarget", () => {
+  test("always performs a fresh check (never trusts the cache)", async () => {
+    let checkedWith: string | undefined;
+    const check = async (currentVersion: string): Promise<UpdateInfo> => {
+      checkedWith = currentVersion;
+      return {
+        currentVersion,
+        latestVersion: "9.9.9",
+        hasUpdate: true,
+        aheadOfLatest: false,
+        changelog: "## v9.9.9\nshiny",
+      };
+    };
+
+    let saved: UpdateCache | undefined;
+    const save = async (cache: UpdateCache) => {
+      saved = cache;
+    };
+
+    const target = await resolveUpgradeTarget("1.0.0", check, save);
+
+    // The fresh check ran with the current version...
+    expect(checkedWith).toBe("1.0.0");
+    // ...and its result is returned verbatim (not any cached value).
+    expect(target.latestVersion).toBe("9.9.9");
+    expect(target.hasUpdate).toBe(true);
+    expect(target.changelog).toBe("## v9.9.9\nshiny");
+    // ...and the cache is refreshed for the background notice.
+    expect(saved?.latestVersion).toBe("9.9.9");
+    expect(saved?.hasUpdate).toBe(true);
+    expect(typeof saved?.lastCheckAt).toBe("string");
+  });
+
+  test("reports no update when the fresh check finds none", async () => {
+    const check = async (currentVersion: string): Promise<UpdateInfo> => ({
+      currentVersion,
+      latestVersion: currentVersion,
+      hasUpdate: false,
+      aheadOfLatest: false,
+    });
+    const save = async () => {};
+
+    const target = await resolveUpgradeTarget("2.3.4", check, save);
+    expect(target.hasUpdate).toBe(false);
+    expect(target.latestVersion).toBe("2.3.4");
+  });
+});


### PR DESCRIPTION
## Problem

`botholomew upgrade` short-circuited on a fresh (<24h) update cache. If the startup background check had run recently and seen no update, but a new release shipped since, `upgrade` reported **"already up to date"** from stale data — the exact moment a user runs `upgrade` is when they most want a fresh check.

## Fix

Extract the resolution into `resolveUpgradeTarget(currentVersion)`, which **always** performs a fresh `checkForUpdate` and then refreshes the cache (so the background startup notice still benefits). The non-blocking background notice keeps its cache-based behavior — only the explicit `upgrade` command changes.

The helper takes injectable `check`/`save` functions so the always-fresh behavior is unit-tested without touching the network or `~/.botholomew`.

## Test plan
- `bun run lint` ✅
- `bun test test/commands/upgrade.test.ts test/update` ✅ (new regression test asserts a fresh check runs regardless of cache state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)