### PR TITLE
Add offset paging to the list_threads agent tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botholomew",
-  "version": "0.24.8",
+  "version": "0.24.9",
   "description": "An autonomous AI agent for knowledge work — works your task queue while you sleep.",
   "type": "module",
   "bin": {

--- a/src/tools/thread/list.ts
+++ b/src/tools/thread/list.ts
@@ -7,7 +7,22 @@ const inputSchema = z.object({
     .enum(["worker_tick", "chat_session"])
     .optional()
     .describe("Filter by thread type"),
-  limit: z.number().optional().describe("Max number of threads to return"),
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .default(50)
+    .describe(
+      "Max number of threads to return (newest first). Default 50 keeps long histories from flooding the context window.",
+    ),
+  offset: z
+    .number()
+    .int()
+    .nonnegative()
+    .optional()
+    .default(0)
+    .describe("Skip the first N threads; use with `limit` to paginate."),
 });
 
 const outputSchema = z.object({
@@ -22,12 +37,15 @@ const outputSchema = z.object({
     }),
   ),
   count: z.number(),
+  offset: z.number(),
   is_error: z.boolean(),
+  next_action_hint: z.string().optional(),
 });
 
 export const listThreadsTool = {
   name: "list_threads",
-  description: "List conversation threads (worker ticks or chat sessions).",
+  description:
+    "[[ bash equivalent command: ls ]] List conversation threads (worker ticks or chat sessions), newest first. Pass `offset` with `limit` to page through a long history.",
   group: "thread",
   inputSchema,
   outputSchema,
@@ -35,6 +53,7 @@ export const listThreadsTool = {
     const threads = await listThreads(ctx.projectDir, {
       type: input.type,
       limit: input.limit,
+      offset: input.offset,
     });
     return {
       threads: threads.map((t) => ({
@@ -46,7 +65,14 @@ export const listThreadsTool = {
         ended_at: t.ended_at?.toISOString() ?? null,
       })),
       count: threads.length,
+      offset: input.offset,
       is_error: false,
+      // The store returns only the sliced page (no total), so use the
+      // full-page heuristic: a full page means there are possibly more.
+      next_action_hint:
+        threads.length === input.limit
+          ? `Returned a full page; there may be more — call list_threads again with offset=${input.offset + input.limit} to see older threads.`
+          : undefined,
     };
   },
 } satisfies ToolDefinition<typeof inputSchema, typeof outputSchema>;

--- a/test/tools/thread-search-view.test.ts
+++ b/test/tools/thread-search-view.test.ts
@@ -9,6 +9,7 @@ import {
   endThread,
   logInteraction,
 } from "../../src/threads/store.ts";
+import { listThreadsTool } from "../../src/tools/thread/list.ts";
 import { searchThreadsTool } from "../../src/tools/thread/search.ts";
 import { viewThreadTool } from "../../src/tools/thread/view.ts";
 import type { ToolContext } from "../../src/tools/tool.ts";
@@ -95,6 +96,50 @@ describe("view_thread pagination", () => {
     expect(result.is_error).toBe(false);
     expect(result.thread).toBeNull();
     expect(result.interactions).toEqual([]);
+  });
+});
+
+describe("list_threads pagination", () => {
+  test("offset + limit page through threads disjointly and newest-first", async () => {
+    for (let i = 0; i < 3; i++) {
+      await createThread(projectDir, "chat_session", undefined, `thread-${i}`);
+    }
+    // Reference ordering (newest-first) with a wide limit.
+    const all = await listThreadsTool.execute({ limit: 50, offset: 0 }, ctx());
+    expect(all.is_error).toBe(false);
+    expect(all.count).toBe(3);
+    const orderedIds = all.threads.map((t) => t.id);
+
+    const page1 = await listThreadsTool.execute({ limit: 2, offset: 0 }, ctx());
+    const page2 = await listThreadsTool.execute({ limit: 2, offset: 2 }, ctx());
+
+    expect(page1.threads.map((t) => t.id)).toEqual(orderedIds.slice(0, 2));
+    expect(page2.threads.map((t) => t.id)).toEqual(orderedIds.slice(2, 3));
+    expect(page2.count).toBe(1);
+    expect(page2.offset).toBe(2);
+
+    // Pages are disjoint and cover everything.
+    const seen = new Set([
+      ...page1.threads.map((t) => t.id),
+      ...page2.threads.map((t) => t.id),
+    ]);
+    expect(seen.size).toBe(3);
+  });
+
+  test("full page emits a paging hint; a partial page does not", async () => {
+    for (let i = 0; i < 3; i++) {
+      await createThread(projectDir, "chat_session", undefined, `t-${i}`);
+    }
+    const full = await listThreadsTool.execute({ limit: 2, offset: 0 }, ctx());
+    expect(full.threads).toHaveLength(2);
+    expect(full.next_action_hint).toContain("offset=2");
+
+    const partial = await listThreadsTool.execute(
+      { limit: 2, offset: 2 },
+      ctx(),
+    );
+    expect(partial.threads).toHaveLength(1);
+    expect(partial.next_action_hint).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
The `list_threads` agent tool only exposed `type` and `limit`, dropping `offset` even though the underlying `listThreads` store helper and the `botholomew thread list` CLI already support it — so an agent could not page past the first window of threads. This adds an `offset` input, gives `limit` a description and a default of 50 (protecting the LLM context window), and emits a paging `next_action_hint` on full pages, mirroring `view_thread`. Includes tool-level pagination tests and a version bump to 0.24.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)